### PR TITLE
P7: Routes and rendering — public landing, /maps, /share, cacheComponents PPR

### DIFF
--- a/app/(auth-pages)/layout.tsx
+++ b/app/(auth-pages)/layout.tsx
@@ -1,19 +1,5 @@
-/*
- * Decorative dot field. It is the same grid the mindmap canvas draws, so the
- * auth pages read as the edge of the product rather than a separate site.
- *
- * The mask is an alpha channel, not a colour: `#000` here means "fully opaque
- * mask" and never paints a pixel, so the visible dots stay on --canvas-dot.
- */
-const DOT_FIELD_MASK =
-  "radial-gradient(ellipse 62% 58% at 50% 46%, #000 0%, transparent 100%)";
-
-const dotFieldStyle = {
-  backgroundImage: "radial-gradient(var(--canvas-dot) 1px, transparent 1px)",
-  backgroundSize: "24px 24px",
-  maskImage: DOT_FIELD_MASK,
-  WebkitMaskImage: DOT_FIELD_MASK,
-};
+import { DotField } from "@/components/dot-field";
+import { Wordmark } from "@/components/wordmark";
 
 /**
  * Frame shared by every unauthenticated route.
@@ -29,23 +15,11 @@ export default async function Layout({
 }) {
   return (
     <main className="relative h-svh w-full overflow-hidden">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0"
-        style={dotFieldStyle}
-      />
+      <DotField />
       <div className="relative flex h-full w-full justify-center overflow-y-auto px-6 py-12">
         <div className="my-auto flex w-full max-w-md flex-col gap-8">
           <div className="flex flex-col items-center gap-1.5">
-            <span className="flex items-center gap-2.5 font-mono text-sm uppercase tracking-[0.28em] text-foreground">
-              <span
-                aria-hidden="true"
-                className="size-1.5 rounded-full bg-primary"
-              />
-              {/* The negative margin eats the trailing letter-space so the
-                  wordmark optically centres against the tagline below it. */}
-              <span className="-mr-[0.28em]">Sprig</span>
-            </span>
+            <Wordmark />
             <p className="text-center text-sm text-muted-foreground">
               Grow and organize ideas.
             </p>

--- a/app/(main-app)/layout.tsx
+++ b/app/(main-app)/layout.tsx
@@ -1,28 +1,42 @@
 import { fetchQuery } from "convex/nextjs";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, Suspense } from "react";
 
-import { ConvexAuthNotice } from "@/components/convex-auth-notice";
 import { FloatingSidebar } from "@/components/sidebar";
 import { api } from "@/convex/_generated/api";
 import { getConvexAuthToken } from "@/lib/convex-server";
+import { ConvexClientProvider } from "@/providers/ConvexClientProvider";
 
-export default async function MainAppLayout({ children }: PropsWithChildren) {
+/** Loads the authenticated navigation list inside the layout's dynamic island. */
+async function MindmapSidebar() {
   const token = await getConvexAuthToken();
-  if (token === null) {
-    return (
-      <>
-        <FloatingSidebar mindmaps={[]} />
-        <ConvexAuthNotice />
-      </>
-    );
-  }
+  const mindmaps =
+    token === null
+      ? []
+      : await fetchQuery(api.mindmaps.listMine, {}, { token });
 
-  const mindmaps = await fetchQuery(api.mindmaps.listMine, {}, { token });
+  return <FloatingSidebar mindmaps={mindmaps} />;
+}
 
+/**
+ * Keeps the protected app frame prerenderable while its sidebar streams in.
+ * ConvexClientProvider mounts here, not in the root layout: constructing the
+ * browser ConvexReactClient during the static prerender of public routes trips
+ * cacheComponents' Math.random guard, and only this group uses client hooks.
+ */
+function MainAppLayout({ children }: PropsWithChildren) {
   return (
-    <>
-      <FloatingSidebar mindmaps={mindmaps} />
-      {children}
-    </>
+    // The boundary sits ABOVE the provider: constructing ConvexReactClient
+    // involves randomness, which cacheComponents only permits inside a
+    // Suspense hole. The whole group is auth-gated and dynamic regardless.
+    <Suspense fallback={null}>
+      <ConvexClientProvider>
+        <Suspense fallback={<FloatingSidebar mindmaps={[]} />}>
+          <MindmapSidebar />
+        </Suspense>
+        {children}
+      </ConvexClientProvider>
+    </Suspense>
   );
 }
+
+export { MainAppLayout as default };

--- a/app/(main-app)/layout.tsx
+++ b/app/(main-app)/layout.tsx
@@ -1,10 +1,11 @@
 import { fetchQuery } from "convex/nextjs";
 import { PropsWithChildren, Suspense } from "react";
 
-import { FloatingSidebar } from "@/components/sidebar";
+import { ActiveFloatingSidebar, FloatingSidebar } from "@/components/sidebar";
+import { SidebarProvider } from "@/components/sidebar/sidebar-provider";
+import { Toaster } from "@/components/ui/sonner";
 import { api } from "@/convex/_generated/api";
 import { getConvexAuthToken } from "@/lib/convex-server";
-import { ConvexClientProvider } from "@/providers/ConvexClientProvider";
 
 /** Loads the authenticated navigation list inside the layout's dynamic island. */
 async function MindmapSidebar() {
@@ -14,28 +15,29 @@ async function MindmapSidebar() {
       ? []
       : await fetchQuery(api.mindmaps.listMine, {}, { token });
 
-  return <FloatingSidebar mindmaps={mindmaps} />;
+  return <ActiveFloatingSidebar mindmaps={mindmaps} />;
 }
 
 /**
- * Keeps the protected app frame prerenderable while its sidebar streams in.
- * ConvexClientProvider mounts here, not in the root layout: constructing the
- * browser ConvexReactClient during the static prerender of public routes trips
- * cacheComponents' Math.random guard, and only this group uses client hooks.
+ * Keeps protected-only chrome out of public and authentication surfaces.
+ *
+ * The sidebar owns its request-time Suspense boundary while children remain
+ * outside it, so route-level static shells such as the dashboard heading and
+ * card skeleton reach the first response. Editable canvases mount their Convex
+ * client inside their existing route boundary, where the random client
+ * construction is safe without swallowing sibling static content.
  */
 function MainAppLayout({ children }: PropsWithChildren) {
   return (
-    // The boundary sits ABOVE the provider: constructing ConvexReactClient
-    // involves randomness, which cacheComponents only permits inside a
-    // Suspense hole. The whole group is auth-gated and dynamic regardless.
-    <Suspense fallback={null}>
-      <ConvexClientProvider>
-        <Suspense fallback={<FloatingSidebar mindmaps={[]} />}>
-          <MindmapSidebar />
-        </Suspense>
-        {children}
-      </ConvexClientProvider>
-    </Suspense>
+    <SidebarProvider>
+      {/* The fallback must stay hook-free: FloatingSidebar reads useParams(),
+          which is request-time data and cannot render in the static shell. */}
+      <Suspense fallback={<FloatingSidebar mindmaps={[]} />}>
+        <MindmapSidebar />
+      </Suspense>
+      {children}
+      <Toaster position="bottom-right" richColors expand />
+    </SidebarProvider>
   );
 }
 

--- a/app/(main-app)/maps/[publicId]/page.tsx
+++ b/app/(main-app)/maps/[publicId]/page.tsx
@@ -1,20 +1,20 @@
 import { fetchQuery } from "convex/nextjs";
 import { ConvexError } from "convex/values";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
 
 import { ConvexAuthNotice } from "@/components/convex-auth-notice";
 import Flow from "@/components/flow/Flow";
 import { Header } from "@/components/header";
-import { MindmapNotFound } from "@/components/mindmap-not-found";
 import { Stack } from "@/components/ui/stack";
 import { api } from "@/convex/_generated/api";
 import { getConvexAuthToken } from "@/lib/convex-server";
 
-export default async function MindmapPage(props: {
-  params: Promise<{ mindmapSlug: string }>;
-}) {
-  const params = await props.params;
-  const { mindmapSlug } = params;
+type MindmapPageParams = Promise<{ publicId: string }>;
 
+/** Loads one authenticated canvas after its request params become available. */
+async function MindmapCanvas({ params }: { params: MindmapPageParams }) {
+  const { publicId } = await params;
   const token = await getConvexAuthToken();
   if (token === null) {
     return <ConvexAuthNotice />;
@@ -22,10 +22,10 @@ export default async function MindmapPage(props: {
 
   const result = await fetchQuery(
     api.mindmaps.getByPublicId,
-    { publicId: mindmapSlug },
+    { publicId },
     { token }
   ).catch((error: unknown) => {
-    // The query uses this exact public error for absent and unreadable maps.
+    // Private and absent IDs intentionally share the same public error.
     if (error instanceof ConvexError && error.data === "Not found") {
       return null;
     }
@@ -33,8 +33,8 @@ export default async function MindmapPage(props: {
     throw error;
   });
 
-  if (!result) {
-    return <MindmapNotFound />;
+  if (result === null) {
+    notFound();
   }
 
   return (
@@ -46,3 +46,22 @@ export default async function MindmapPage(props: {
     </>
   );
 }
+
+/** Static canvas shell that streams request-specific map data. */
+function MindmapPage({ params }: { params: MindmapPageParams }) {
+  return (
+    <Suspense
+      fallback={
+        <main
+          aria-label="Loading mindmap"
+          className="h-full w-full bg-background"
+          role="status"
+        />
+      }
+    >
+      <MindmapCanvas params={params} />
+    </Suspense>
+  );
+}
+
+export { MindmapPage as default };

--- a/app/(main-app)/maps/[publicId]/page.tsx
+++ b/app/(main-app)/maps/[publicId]/page.tsx
@@ -9,6 +9,7 @@ import { Header } from "@/components/header";
 import { Stack } from "@/components/ui/stack";
 import { api } from "@/convex/_generated/api";
 import { getConvexAuthToken } from "@/lib/convex-server";
+import { ConvexClientProvider } from "@/providers/ConvexClientProvider";
 
 type MindmapPageParams = Promise<{ publicId: string }>;
 
@@ -41,7 +42,13 @@ async function MindmapCanvas({ params }: { params: MindmapPageParams }) {
     <>
       <Header mindmap={result.mindmap} />
       <Stack className="flex-1 relative">
-        <Flow mindmap={result.mindmap} nodes={result.nodes} />
+        <ConvexClientProvider>
+          <Flow
+            mindmap={result.mindmap}
+            nodes={result.nodes}
+            readOnly={!result.mindmap.isOwner}
+          />
+        </ConvexClientProvider>
       </Stack>
     </>
   );

--- a/app/(main-app)/maps/page.tsx
+++ b/app/(main-app)/maps/page.tsx
@@ -1,44 +1,84 @@
 import { fetchQuery } from "convex/nextjs";
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { Suspense } from "react";
 
 import { ConvexAuthNotice } from "@/components/convex-auth-notice";
-import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { getConvexAuthToken } from "@/lib/convex-server";
 import { MindmapDB } from "@/types/Mindmap";
 
-/** Formats a persisted update timestamp for the server-rendered card. */
-function formatUpdatedAt(updatedAt: number): string {
+import { formatRelativeUpdatedAt } from "./relative-time";
+
+/** One grid definition shared by the cards, the empty state and the skeleton. */
+const CARD_GRID_CLASS = "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3";
+
+/** Every card is the same block: a hairline, the card surface, one height. */
+const CARD_CLASS =
+  "flex h-full min-h-[8.5rem] flex-col gap-3 rounded-lg p-5 transition-colors duration-200 ease-organic motion-reduce:transition-none";
+
+/** Spells out a timestamp for the hover title, behind the relative phrase. */
+function formatExactUpdatedAt(updatedAt: number): string {
   return new Intl.DateTimeFormat("en", {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(updatedAt));
 }
 
-/** Renders one owned map with its last update and canonical canvas link. */
-function MindmapCard({ mindmap }: { mindmap: MindmapDB }) {
-  const updatedAt = formatUpdatedAt(mindmap.updatedAt);
-
+/**
+ * Renders one owned map as a single link target.
+ *
+ * The whole card is the anchor rather than a "Open map" link inside it, so the
+ * pointer target and the keyboard target are the same object and the focus ring
+ * traces the card the user is actually about to open.
+ */
+function MindmapCard({ mindmap, now }: { mindmap: MindmapDB; now: number }) {
   return (
-    <li className="rounded-lg border border-line-strong bg-card p-5">
-      <article className="flex h-full flex-col items-start gap-3">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-lg font-medium">{mindmap.name}</h2>
-          <p className="text-sm text-muted-foreground">
-            Updated{" "}
-            <time dateTime={new Date(mindmap.updatedAt).toISOString()}>
-              {updatedAt}
-            </time>
-          </p>
-        </div>
-        <Link
-          className="mt-auto font-medium text-primary underline underline-offset-4"
-          href={`/maps/${mindmap.publicId}`}
+    <li>
+      <Link
+        className={`${CARD_CLASS} border border-line-strong bg-card text-card-foreground hover:bg-accent`}
+        href={`/maps/${mindmap.publicId}`}
+      >
+        <h2 className="line-clamp-2 text-base font-medium leading-snug">
+          {mindmap.name}
+        </h2>
+        <p className="mt-auto font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+          <time
+            dateTime={new Date(mindmap.updatedAt).toISOString()}
+            title={formatExactUpdatedAt(mindmap.updatedAt)}
+          >
+            {formatRelativeUpdatedAt(mindmap.updatedAt, now)}
+          </time>
+        </p>
+      </Link>
+    </li>
+  );
+}
+
+/**
+ * The one way to start a map, wherever the grid is shown.
+ *
+ * A dashed hairline marks it as an empty slot rather than an existing map, and
+ * it is deliberately the same size and shape as one so the grid stays even.
+ */
+function NewMapCard() {
+  return (
+    <li>
+      <Link
+        className={`${CARD_CLASS} border border-dashed border-line-strong text-muted-foreground hover:border-primary hover:text-foreground`}
+        href="/new"
+      >
+        <span
+          aria-hidden="true"
+          className="flex size-8 items-center justify-center rounded-sm border border-dashed border-line-strong"
         >
-          Open map
-        </Link>
-      </article>
+          <Plus className="size-4" />
+        </span>
+        <span className="mt-auto text-base font-medium text-foreground">
+          New map
+        </span>
+        <span className="text-sm">Start from a blank canvas.</span>
+      </Link>
     </li>
   );
 }
@@ -51,20 +91,27 @@ async function MindmapList() {
   }
 
   const mindmaps = await fetchQuery(api.mindmaps.listMine, {}, { token });
+  // One clock reading for the whole grid, so every card is relative to the
+  // same instant and the list cannot disagree with itself.
+  const now = Date.now();
 
   if (mindmaps.length === 0) {
     return (
-      <p className="rounded-lg border border-line-strong bg-card p-5 text-muted-foreground">
-        You do not have any maps yet. Start one when you are ready.
-      </p>
+      <div className="flex flex-col gap-5">
+        <p className="text-muted-foreground">No maps yet — grow your first.</p>
+        <ul className={CARD_GRID_CLASS}>
+          <NewMapCard />
+        </ul>
+      </div>
     );
   }
 
   return (
-    <ul className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <ul className={CARD_GRID_CLASS}>
       {mindmaps.map((mindmap) => (
-        <MindmapCard key={mindmap._id} mindmap={mindmap} />
+        <MindmapCard key={mindmap._id} mindmap={mindmap} now={now} />
       ))}
+      <NewMapCard />
     </ul>
   );
 }
@@ -74,13 +121,13 @@ function MindmapListSkeleton() {
   return (
     <div
       aria-label="Loading your maps"
-      className="grid grid-cols-1 gap-4 md:grid-cols-2"
+      className={CARD_GRID_CLASS}
       role="status"
     >
-      {[0, 1].map((card) => (
+      {[0, 1, 2].map((card) => (
         <div
           aria-hidden="true"
-          className="h-32 rounded-lg border border-border bg-card"
+          className="min-h-[8.5rem] rounded-lg border border-border bg-card"
           key={card}
         />
       ))}
@@ -93,16 +140,11 @@ function MapsPage() {
   return (
     <main className="h-full w-full overflow-y-auto">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-8 py-20">
-        <header className="flex flex-wrap items-end justify-between gap-4">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-3xl font-semibold tracking-tight">Your maps</h1>
-            <p className="text-muted-foreground">
-              Open an existing mindmap or start a new one.
-            </p>
-          </div>
-          <Button asChild>
-            <Link href="/new">New map</Link>
-          </Button>
+        <header className="flex flex-col gap-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Your maps</h1>
+          <p className="text-muted-foreground">
+            Open an existing mindmap or start a new one.
+          </p>
         </header>
         <Suspense fallback={<MindmapListSkeleton />}>
           <MindmapList />

--- a/app/(main-app)/maps/page.tsx
+++ b/app/(main-app)/maps/page.tsx
@@ -15,13 +15,18 @@ const CARD_GRID_CLASS = "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3";
 
 /** Every card is the same block: a hairline, the card surface, one height. */
 const CARD_CLASS =
-  "flex h-full min-h-[8.5rem] flex-col gap-3 rounded-lg p-5 transition-colors duration-200 ease-organic motion-reduce:transition-none";
+  "flex h-full min-h-[8.5rem] flex-col gap-3 rounded-lg p-5 transition-colors duration-200 ease-organic focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none";
 
 /** Spells out a timestamp for the hover title, behind the relative phrase. */
 function formatExactUpdatedAt(updatedAt: number): string {
   return new Intl.DateTimeFormat("en", {
-    dateStyle: "medium",
-    timeStyle: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+    year: "numeric",
   }).format(new Date(updatedAt));
 }
 
@@ -39,7 +44,10 @@ function MindmapCard({ mindmap, now }: { mindmap: MindmapDB; now: number }) {
         className={`${CARD_CLASS} border border-line-strong bg-card text-card-foreground hover:bg-accent`}
         href={`/maps/${mindmap.publicId}`}
       >
-        <h2 className="line-clamp-2 text-base font-medium leading-snug">
+        <h2
+          className="line-clamp-2 text-base font-medium leading-snug"
+          title={mindmap.name}
+        >
           {mindmap.name}
         </h2>
         <p className="mt-auto font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
@@ -127,7 +135,7 @@ function MindmapListSkeleton() {
       {[0, 1, 2].map((card) => (
         <div
           aria-hidden="true"
-          className="min-h-[8.5rem] rounded-lg border border-border bg-card"
+          className="min-h-[8.5rem] rounded-lg border border-line-strong bg-card"
           key={card}
         />
       ))}

--- a/app/(main-app)/maps/page.tsx
+++ b/app/(main-app)/maps/page.tsx
@@ -1,0 +1,115 @@
+import { fetchQuery } from "convex/nextjs";
+import Link from "next/link";
+import { Suspense } from "react";
+
+import { ConvexAuthNotice } from "@/components/convex-auth-notice";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import { getConvexAuthToken } from "@/lib/convex-server";
+import { MindmapDB } from "@/types/Mindmap";
+
+/** Formats a persisted update timestamp for the server-rendered card. */
+function formatUpdatedAt(updatedAt: number): string {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(updatedAt));
+}
+
+/** Renders one owned map with its last update and canonical canvas link. */
+function MindmapCard({ mindmap }: { mindmap: MindmapDB }) {
+  const updatedAt = formatUpdatedAt(mindmap.updatedAt);
+
+  return (
+    <li className="rounded-lg border border-line-strong bg-card p-5">
+      <article className="flex h-full flex-col items-start gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-lg font-medium">{mindmap.name}</h2>
+          <p className="text-sm text-muted-foreground">
+            Updated{" "}
+            <time dateTime={new Date(mindmap.updatedAt).toISOString()}>
+              {updatedAt}
+            </time>
+          </p>
+        </div>
+        <Link
+          className="mt-auto font-medium text-primary underline underline-offset-4"
+          href={`/maps/${mindmap.publicId}`}
+        >
+          Open map
+        </Link>
+      </article>
+    </li>
+  );
+}
+
+/** Loads the signed-in user's dashboard cards per request. */
+async function MindmapList() {
+  const token = await getConvexAuthToken();
+  if (token === null) {
+    return <ConvexAuthNotice />;
+  }
+
+  const mindmaps = await fetchQuery(api.mindmaps.listMine, {}, { token });
+
+  if (mindmaps.length === 0) {
+    return (
+      <p className="rounded-lg border border-line-strong bg-card p-5 text-muted-foreground">
+        You do not have any maps yet. Start one when you are ready.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      {mindmaps.map((mindmap) => (
+        <MindmapCard key={mindmap._id} mindmap={mindmap} />
+      ))}
+    </ul>
+  );
+}
+
+/** Static dashboard loading structure shown while the owned list resolves. */
+function MindmapListSkeleton() {
+  return (
+    <div
+      aria-label="Loading your maps"
+      className="grid grid-cols-1 gap-4 md:grid-cols-2"
+      role="status"
+    >
+      {[0, 1].map((card) => (
+        <div
+          aria-hidden="true"
+          className="h-32 rounded-lg border border-border bg-card"
+          key={card}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Authenticated dashboard and canonical hub for a user's maps. */
+function MapsPage() {
+  return (
+    <main className="h-full w-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-8 py-20">
+        <header className="flex flex-wrap items-end justify-between gap-4">
+          <div className="flex flex-col gap-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Your maps</h1>
+            <p className="text-muted-foreground">
+              Open an existing mindmap or start a new one.
+            </p>
+          </div>
+          <Button asChild>
+            <Link href="/new">New map</Link>
+          </Button>
+        </header>
+        <Suspense fallback={<MindmapListSkeleton />}>
+          <MindmapList />
+        </Suspense>
+      </div>
+    </main>
+  );
+}
+
+export { MapsPage as default };

--- a/app/(main-app)/maps/relative-time.test.ts
+++ b/app/(main-app)/maps/relative-time.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRelativeUpdatedAt } from "./relative-time";
+
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** Verifies the dashboard's date-lib-free "updated" phrasing. */
+describe("formatRelativeUpdatedAt", () => {
+  it.each([
+    ["a write from this second", NOW, "just now"],
+    ["59 seconds", NOW - 59_000, "just now"],
+    ["exactly one minute", NOW - MINUTE, "1 minute ago"],
+    ["59 minutes", NOW - 59 * MINUTE, "59 minutes ago"],
+    ["exactly one hour", NOW - HOUR, "1 hour ago"],
+    ["23 hours", NOW - 23 * HOUR, "23 hours ago"],
+    ["exactly one day", NOW - DAY, "1 day ago"],
+    ["6 days", NOW - 6 * DAY, "6 days ago"],
+    ["exactly one week", NOW - 7 * DAY, "1 week ago"],
+    ["four weeks", NOW - 28 * DAY, "4 weeks ago"],
+    ["thirty days", NOW - 30 * DAY, "1 month ago"],
+    ["eleven months", NOW - 330 * DAY, "11 months ago"],
+    ["one year", NOW - 365 * DAY, "1 year ago"],
+    ["three years", NOW - 3 * 365 * DAY, "3 years ago"],
+  ])("renders %s", (_label, updatedAt, expected) => {
+    expect(formatRelativeUpdatedAt(updatedAt, NOW)).toBe(expected);
+  });
+
+  it("collapses future timestamps from a skewed clock to just now", () => {
+    expect(formatRelativeUpdatedAt(NOW + 5 * HOUR, NOW)).toBe("just now");
+  });
+});

--- a/app/(main-app)/maps/relative-time.test.ts
+++ b/app/(main-app)/maps/relative-time.test.ts
@@ -22,6 +22,7 @@ describe("formatRelativeUpdatedAt", () => {
     ["four weeks", NOW - 28 * DAY, "4 weeks ago"],
     ["thirty days", NOW - 30 * DAY, "1 month ago"],
     ["eleven months", NOW - 330 * DAY, "11 months ago"],
+    ["the day before one year", NOW - 364 * DAY, "11 months ago"],
     ["one year", NOW - 365 * DAY, "1 year ago"],
     ["three years", NOW - 3 * 365 * DAY, "3 years ago"],
   ])("renders %s", (_label, updatedAt, expected) => {

--- a/app/(main-app)/maps/relative-time.ts
+++ b/app/(main-app)/maps/relative-time.ts
@@ -40,7 +40,9 @@ function formatRelativeUpdatedAt(updatedAt: number, now: number): string {
     return agoPhrase(Math.floor(elapsed / WEEK_MS), "week");
   }
   if (elapsed < YEAR_MS) {
-    return agoPhrase(Math.floor(elapsed / MONTH_MS), "month");
+    // Thirty-day buckets can reach 12 before a 365-day year. Keep that
+    // unreachable phrase out of the UI and hand over to years at the boundary.
+    return agoPhrase(Math.min(11, Math.floor(elapsed / MONTH_MS)), "month");
   }
 
   return agoPhrase(Math.floor(elapsed / YEAR_MS), "year");

--- a/app/(main-app)/maps/relative-time.ts
+++ b/app/(main-app)/maps/relative-time.ts
@@ -1,0 +1,49 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+/** Calendar-free approximations: the dashboard only needs a sense of age. */
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+/** Builds "1 hour ago" / "4 hours ago" without pulling in a formatting lib. */
+function agoPhrase(count: number, unit: string): string {
+  return count === 1 ? `1 ${unit} ago` : `${count} ${unit}s ago`;
+}
+
+/**
+ * Describes how long ago a map was last written, in a single short phrase.
+ *
+ * Pure by construction: `now` is passed in rather than read from the clock, so
+ * the caller decides which render the timestamp is relative to and the function
+ * stays trivially testable.
+ *
+ * Timestamps in the future (a client clock running ahead of Convex) collapse to
+ * "just now" rather than rendering a negative duration.
+ */
+function formatRelativeUpdatedAt(updatedAt: number, now: number): string {
+  const elapsed = now - updatedAt;
+
+  if (elapsed < MINUTE_MS) {
+    return "just now";
+  }
+  if (elapsed < HOUR_MS) {
+    return agoPhrase(Math.floor(elapsed / MINUTE_MS), "minute");
+  }
+  if (elapsed < DAY_MS) {
+    return agoPhrase(Math.floor(elapsed / HOUR_MS), "hour");
+  }
+  if (elapsed < WEEK_MS) {
+    return agoPhrase(Math.floor(elapsed / DAY_MS), "day");
+  }
+  if (elapsed < MONTH_MS) {
+    return agoPhrase(Math.floor(elapsed / WEEK_MS), "week");
+  }
+  if (elapsed < YEAR_MS) {
+    return agoPhrase(Math.floor(elapsed / MONTH_MS), "month");
+  }
+
+  return agoPhrase(Math.floor(elapsed / YEAR_MS), "year");
+}
+
+export { formatRelativeUpdatedAt };

--- a/app/[slug]/route.ts
+++ b/app/[slug]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-/** Permanently maps a legacy root slug to its canonical canvas route. */
+/** Temporarily maps a legacy root slug to its canonical canvas route. */
 async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> }
@@ -8,7 +8,9 @@ async function GET(
   const { slug } = await params;
   const destination = new URL(`/maps/${encodeURIComponent(slug)}`, request.url);
 
-  return NextResponse.redirect(destination, 308);
+  // Only GET is exported, so method preservation buys nothing. A 307 also
+  // avoids browsers permanently caching a legacy slug mapping.
+  return NextResponse.redirect(destination, 307);
 }
 
 export { GET };

--- a/app/[slug]/route.ts
+++ b/app/[slug]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/** Permanently maps a legacy root slug to its canonical canvas route. */
+async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const destination = new URL(`/maps/${encodeURIComponent(slug)}`, request.url);
+
+  return NextResponse.redirect(destination, 308);
+}
+
+export { GET };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,9 +7,7 @@ import clsx from "clsx";
 import { ThemeProvider } from "next-themes";
 import { Geist, Geist_Mono } from "next/font/google";
 
-import { SidebarProvider } from "@/components/sidebar/sidebar-provider";
 import { ThemeSwitcher } from "@/components/theme-switcher";
-import { Toaster } from "@/components/ui/sonner";
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -58,11 +56,8 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            <Toaster position="bottom-right" richColors expand />
-            <SidebarProvider>
-              {children}
-              <ThemeSwitcher />
-            </SidebarProvider>
+            {children}
+            <ThemeSwitcher />
           </ThemeProvider>
         </ClerkProvider>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,6 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { SidebarProvider } from "@/components/sidebar/sidebar-provider";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import { Toaster } from "@/components/ui/sonner";
-import { ConvexClientProvider } from "@/providers/ConvexClientProvider";
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -50,21 +49,21 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="bg-background text-foreground h-screen w-screen relative overflow-hidden">
-        <ClerkProvider dynamic>
-          <ConvexClientProvider>
-            <ThemeProvider
-              attribute="class"
-              defaultTheme="dark"
-              enableSystem
-              disableTransitionOnChange
-            >
-              <Toaster position="bottom-right" richColors expand />
-              <SidebarProvider>
-                {children}
-                <ThemeSwitcher />
-              </SidebarProvider>
-            </ThemeProvider>
-          </ConvexClientProvider>
+        {/* Request auth is isolated by page-level Suspense boundaries instead
+            of making the root provider consume headers for every route. */}
+        <ClerkProvider>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="dark"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <Toaster position="bottom-right" richColors expand />
+            <SidebarProvider>
+              {children}
+              <ThemeSwitcher />
+            </SidebarProvider>
+          </ThemeProvider>
         </ClerkProvider>
       </body>
     </html>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -13,7 +13,7 @@ import { Wordmark } from "@/components/wordmark";
  */
 function NotFound() {
   return (
-    <main className="relative h-full w-full overflow-hidden">
+    <main className="relative h-svh w-full overflow-hidden">
       <DotField />
       <div className="relative flex h-full w-full justify-center overflow-y-auto px-6 py-12">
         <div className="my-auto flex w-full max-w-md flex-col gap-8">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,21 +1,50 @@
 import Link from "next/link";
 
+import { DotField } from "@/components/dot-field";
 import { Button } from "@/components/ui/button";
+import { Wordmark } from "@/components/wordmark";
 
-/** Global fallback for routes and map identifiers that do not resolve. */
+/**
+ * Global fallback for routes and map identifiers that do not resolve.
+ *
+ * It borrows the auth shell wholesale — dot field, centred column, one card
+ * held by a hairline — because a 404 is still the product talking, and the
+ * visitor most likely arrived here from a shared link they cannot open.
+ */
 function NotFound() {
   return (
-    <main className="flex h-full w-full items-center justify-center px-8">
-      <section className="flex max-w-lg flex-col items-start gap-4">
-        <p className="font-mono text-sm text-muted-foreground">404</p>
-        <h1 className="text-3xl font-semibold">Page not found</h1>
-        <p className="text-muted-foreground">
-          The page may have moved, or the link may no longer be available.
-        </p>
-        <Button asChild>
-          <Link href="/">Return home</Link>
-        </Button>
-      </section>
+    <main className="relative h-full w-full overflow-hidden">
+      <DotField />
+      <div className="relative flex h-full w-full justify-center overflow-y-auto px-6 py-12">
+        <div className="my-auto flex w-full max-w-md flex-col gap-8">
+          <div className="flex flex-col items-center gap-1.5">
+            <Wordmark />
+            <p className="text-center text-sm text-muted-foreground">
+              Grow and organize ideas.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 rounded-lg border border-line-strong bg-card p-8 text-card-foreground">
+            <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+              404
+            </p>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Nothing grows here
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              The page may have moved, or the map behind this link may no longer
+              be shared.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-3">
+              <Button asChild>
+                <Link href="/">Back to home</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/maps">Your maps</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
     </main>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+/** Global fallback for routes and map identifiers that do not resolve. */
+function NotFound() {
+  return (
+    <main className="flex h-full w-full items-center justify-center px-8">
+      <section className="flex max-w-lg flex-col items-start gap-4">
+        <p className="font-mono text-sm text-muted-foreground">404</p>
+        <h1 className="text-3xl font-semibold">Page not found</h1>
+        <p className="text-muted-foreground">
+          The page may have moved, or the link may no longer be available.
+        </p>
+        <Button asChild>
+          <Link href="/">Return home</Link>
+        </Button>
+      </section>
+    </main>
+  );
+}
+
+export { NotFound as default };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,25 +1,50 @@
-import { fetchQuery } from "convex/nextjs";
-import { redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { Suspense } from "react";
 
-import { ConvexAuthNotice } from "@/components/convex-auth-notice";
-import { api } from "@/convex/_generated/api";
-import { getConvexAuthToken } from "@/lib/convex-server";
+import { Button } from "@/components/ui/button";
 
-export default async function Home() {
-  const token = await getConvexAuthToken();
-  if (token === null) {
-    return <ConvexAuthNotice />;
-  }
+/** Resolves the request-specific landing action without blocking the shell. */
+async function LandingAuthCta() {
+  const { userId } = await auth();
 
-  const [latestMindmap] = await fetchQuery(
-    api.mindmaps.listMine,
-    {},
-    { token }
+  return (
+    <Button asChild>
+      <Link href={userId ? "/maps" : "/sign-in"}>
+        {userId ? "Open your maps" : "Sign in"}
+      </Link>
+    </Button>
   );
-
-  if (!latestMindmap) {
-    redirect("/new");
-  }
-
-  redirect(`/${latestMindmap.publicId}`);
 }
+
+/** Public, statically prerenderable introduction to Sprig. */
+function Home() {
+  return (
+    <main className="h-full w-full overflow-y-auto">
+      <section className="mx-auto flex min-h-full w-full max-w-3xl flex-col items-start justify-center gap-6 px-8 py-20">
+        <div className="flex flex-col gap-3">
+          <p className="font-mono text-sm uppercase tracking-wider text-muted-foreground">
+            Sprig
+          </p>
+          <h1 className="text-4xl font-semibold tracking-tight">
+            Grow ideas into clear mindmaps.
+          </h1>
+          <p className="max-w-2xl text-lg text-muted-foreground">
+            Build, connect, and revisit the ideas you want to understand.
+          </p>
+        </div>
+        <Suspense
+          fallback={
+            <Button disabled type="button">
+              Checking account…
+            </Button>
+          }
+        >
+          <LandingAuthCta />
+        </Suspense>
+      </section>
+    </main>
+  );
+}
+
+export { Home as default };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -112,11 +112,19 @@ function MindmapGlyph() {
 /** Public, statically prerenderable introduction to Sprig. */
 function Home() {
   return (
-    <main className="h-full w-full overflow-y-auto">
+    <div className="h-full w-full overflow-y-auto">
       <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-16 px-8 py-12">
-        <Wordmark />
+        <header>
+          <Link
+            aria-label="Sprig home"
+            className="inline-flex rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            href="/"
+          >
+            <Wordmark />
+          </Link>
+        </header>
 
-        <section className="my-auto grid w-full items-center gap-14 md:grid-cols-[minmax(0,1fr)_auto] md:gap-16">
+        <main className="my-auto grid w-full items-center gap-14 md:grid-cols-[minmax(0,1fr)_auto] md:gap-16">
           <div className="flex max-w-xl flex-col items-start gap-5">
             <h1 className="text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl">
               Grow an idea into a map you can see.
@@ -140,7 +148,7 @@ function Home() {
           <div className="flex justify-start md:justify-end">
             <MindmapGlyph />
           </div>
-        </section>
+        </main>
 
         <footer className="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-6">
           <Wordmark className="text-xs" />
@@ -149,7 +157,7 @@ function Home() {
           </p>
         </footer>
       </div>
-    </main>
+    </div>
   );
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Wordmark } from "@/components/wordmark";
 
 /** Resolves the request-specific landing action without blocking the shell. */
 async function LandingAuthCta() {
@@ -17,32 +18,137 @@ async function LandingAuthCta() {
   );
 }
 
+/**
+ * The product, drawn once: a root idea and the two branches it grew.
+ *
+ * Deliberately hand-built geometry rather than an illustration — same hairline
+ * tokens, same 14/10/8 radius family, and the same leaf-dot as the wordmark, so
+ * it reads as a piece of the canvas instead of marketing art. Nothing animates.
+ */
+function MindmapGlyph() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-auto w-full max-w-[19rem] text-line-strong"
+      fill="none"
+      role="presentation"
+      viewBox="0 0 224 140"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Branch connectors leave the root's right edge flat, then settle into
+          each child, matching the curve the canvas draws between nodes. */}
+      <path
+        d="M96 70 C 116 70 120 30 140 30"
+        stroke="currentColor"
+        strokeWidth="1.25"
+      />
+      <path
+        d="M96 70 C 116 70 120 110 140 110"
+        stroke="currentColor"
+        strokeWidth="1.25"
+      />
+
+      <rect
+        className="fill-card"
+        height="36"
+        rx="12"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        width="88"
+        x="8"
+        y="52"
+      />
+      <circle className="fill-primary" cx="24" cy="70" r="3" />
+      <rect
+        className="fill-border"
+        height="3"
+        rx="1.5"
+        width="44"
+        x="34"
+        y="68.5"
+      />
+
+      <rect
+        className="fill-card"
+        height="28"
+        rx="10"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        width="76"
+        x="140"
+        y="16"
+      />
+      <rect
+        className="fill-border"
+        height="3"
+        rx="1.5"
+        width="48"
+        x="152"
+        y="28.5"
+      />
+
+      <rect
+        className="fill-card"
+        height="28"
+        rx="10"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        width="76"
+        x="140"
+        y="96"
+      />
+      <rect
+        className="fill-border"
+        height="3"
+        rx="1.5"
+        width="36"
+        x="152"
+        y="108.5"
+      />
+    </svg>
+  );
+}
+
 /** Public, statically prerenderable introduction to Sprig. */
 function Home() {
   return (
     <main className="h-full w-full overflow-y-auto">
-      <section className="mx-auto flex min-h-full w-full max-w-3xl flex-col items-start justify-center gap-6 px-8 py-20">
-        <div className="flex flex-col gap-3">
-          <p className="font-mono text-sm uppercase tracking-wider text-muted-foreground">
-            Sprig
+      <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-16 px-8 py-12">
+        <Wordmark />
+
+        <section className="my-auto grid w-full items-center gap-14 md:grid-cols-[minmax(0,1fr)_auto] md:gap-16">
+          <div className="flex max-w-xl flex-col items-start gap-5">
+            <h1 className="text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl">
+              Grow an idea into a map you can see.
+            </h1>
+            <p className="text-lg leading-relaxed text-muted-foreground">
+              Start with one thought, branch it as far as it goes, and keep the
+              whole shape of your thinking in view.
+            </p>
+            {/* Dynamic island: the CTA depends on the request's session, so it
+                is the only part of this page that is not prerendered. */}
+            <Suspense
+              fallback={
+                <Button disabled type="button">
+                  Checking account…
+                </Button>
+              }
+            >
+              <LandingAuthCta />
+            </Suspense>
+          </div>
+          <div className="flex justify-start md:justify-end">
+            <MindmapGlyph />
+          </div>
+        </section>
+
+        <footer className="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-6">
+          <Wordmark className="text-xs" />
+          <p className="text-sm text-muted-foreground">
+            Grow and organize ideas.
           </p>
-          <h1 className="text-4xl font-semibold tracking-tight">
-            Grow ideas into clear mindmaps.
-          </h1>
-          <p className="max-w-2xl text-lg text-muted-foreground">
-            Build, connect, and revisit the ideas you want to understand.
-          </p>
-        </div>
-        <Suspense
-          fallback={
-            <Button disabled type="button">
-              Checking account…
-            </Button>
-          }
-        >
-          <LandingAuthCta />
-        </Suspense>
-      </section>
+        </footer>
+      </div>
     </main>
   );
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+
+const defaultUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : "http://localhost:3000";
+
+/** Publishes crawl rules for public discovery and private application routes. */
+function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: ["/", "/share/"],
+      disallow: ["/maps", "/new"],
+    },
+    sitemap: `${defaultUrl}/sitemap.xml`,
+  };
+}
+
+export { robots as default };

--- a/app/share/[publicId]/page.tsx
+++ b/app/share/[publicId]/page.tsx
@@ -1,10 +1,10 @@
 import { fetchQuery } from "convex/nextjs";
 import { ConvexError } from "convex/values";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
 import Flow from "@/components/flow/Flow";
+import { ShareTopBar } from "@/components/share-top-bar";
 import { api } from "@/convex/_generated/api";
 
 type SharedMindmapPageParams = Promise<{ publicId: string }>;
@@ -33,14 +33,7 @@ async function SharedMindmapCanvas({
 
   return (
     <>
-      <header className="flex h-14 shrink-0 items-center gap-4 border-b border-border px-6">
-        <Link className="font-medium" href="/">
-          Sprig
-        </Link>
-        <span aria-hidden="true" className="h-4 w-px bg-border" />
-        <h1 className="truncate text-sm font-medium">{result.mindmap.name}</h1>
-        <p className="ml-auto text-sm text-muted-foreground">Read-only</p>
-      </header>
+      <ShareTopBar mindmapName={result.mindmap.name} />
       <div className="min-h-0 flex-1">
         <Flow mindmap={result.mindmap} nodes={result.nodes} readOnly />
       </div>

--- a/app/share/[publicId]/page.tsx
+++ b/app/share/[publicId]/page.tsx
@@ -9,8 +9,16 @@ import { api } from "@/convex/_generated/api";
 
 type SharedMindmapPageParams = Promise<{ publicId: string }>;
 
-/** Loads a public shared map without consulting Clerk authentication. */
-async function SharedMindmapCanvas({
+/**
+ * Resolves and renders a public shared map without consulting Clerk.
+ *
+ * The lookup lives inside the Suspense hole because cacheComponents rejects
+ * blocking routes outright. The concession: an unknown or revoked share
+ * answers HTTP 200 with 404 content — but Next injects
+ * `<meta name="robots" content="noindex">` when notFound() fires in a
+ * streamed boundary, so crawlers still drop the page.
+ */
+async function SharedMindmapContent({
   params,
 }: {
   params: SharedMindmapPageParams;
@@ -41,20 +49,12 @@ async function SharedMindmapCanvas({
   );
 }
 
-/** Public static shell that streams only maps explicitly marked shared. */
+/** Static shell: the frame prerenders; the map itself streams in. */
 function SharedMindmapPage({ params }: { params: SharedMindmapPageParams }) {
   return (
-    <main className="flex h-full w-full flex-col">
-      <Suspense
-        fallback={
-          <div
-            aria-label="Loading shared mindmap"
-            className="h-full w-full bg-background"
-            role="status"
-          />
-        }
-      >
-        <SharedMindmapCanvas params={params} />
+    <main className="flex h-svh w-full flex-col">
+      <Suspense fallback={null}>
+        <SharedMindmapContent params={params} />
       </Suspense>
     </main>
   );

--- a/app/share/[publicId]/page.tsx
+++ b/app/share/[publicId]/page.tsx
@@ -1,0 +1,70 @@
+import { fetchQuery } from "convex/nextjs";
+import { ConvexError } from "convex/values";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+
+import Flow from "@/components/flow/Flow";
+import { api } from "@/convex/_generated/api";
+
+type SharedMindmapPageParams = Promise<{ publicId: string }>;
+
+/** Loads a public shared map without consulting Clerk authentication. */
+async function SharedMindmapCanvas({
+  params,
+}: {
+  params: SharedMindmapPageParams;
+}) {
+  const { publicId } = await params;
+  const result = await fetchQuery(api.mindmaps.getShared, { publicId }).catch(
+    (error: unknown) => {
+      // Private and absent IDs intentionally resolve to the same global 404.
+      if (error instanceof ConvexError && error.data === "Not found") {
+        return null;
+      }
+
+      throw error;
+    }
+  );
+
+  if (result === null) {
+    notFound();
+  }
+
+  return (
+    <>
+      <header className="flex h-14 shrink-0 items-center gap-4 border-b border-border px-6">
+        <Link className="font-medium" href="/">
+          Sprig
+        </Link>
+        <span aria-hidden="true" className="h-4 w-px bg-border" />
+        <h1 className="truncate text-sm font-medium">{result.mindmap.name}</h1>
+        <p className="ml-auto text-sm text-muted-foreground">Read-only</p>
+      </header>
+      <div className="min-h-0 flex-1">
+        <Flow mindmap={result.mindmap} nodes={result.nodes} readOnly />
+      </div>
+    </>
+  );
+}
+
+/** Public static shell that streams only maps explicitly marked shared. */
+function SharedMindmapPage({ params }: { params: SharedMindmapPageParams }) {
+  return (
+    <main className="flex h-full w-full flex-col">
+      <Suspense
+        fallback={
+          <div
+            aria-label="Loading shared mindmap"
+            className="h-full w-full bg-background"
+            role="status"
+          />
+        }
+      >
+        <SharedMindmapCanvas params={params} />
+      </Suspense>
+    </main>
+  );
+}
+
+export { SharedMindmapPage as default };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+const defaultUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : "http://localhost:3000";
+
+/** Lists intentionally discoverable static pages. */
+function sitemap(): MetadataRoute.Sitemap {
+  // Shared maps are capability links and remain unlisted by design.
+  return [{ url: defaultUrl }];
+}
+
+export { sitemap as default };

--- a/components/convex-auth-notice.tsx
+++ b/components/convex-auth-notice.tsx
@@ -6,20 +6,27 @@ import { Typography } from "@/components/ui/typography";
  */
 function ConvexAuthNotice() {
   return (
-    <main className="flex min-h-full flex-1 items-center justify-center p-8">
+    <section
+      aria-labelledby="convex-auth-notice-title"
+      className="flex min-h-full flex-1 items-center justify-center p-8"
+    >
       <Stack
         className="max-w-xl gap-y-2 rounded-lg border border-destructive bg-card p-6 text-destructive"
         direction="column"
         role="alert"
       >
-        <Typography className="text-xl font-semibold" variant="h2">
+        <Typography
+          className="text-xl font-semibold"
+          id="convex-auth-notice-title"
+          variant="h2"
+        >
           Convex auth is not configured — see docs/ENV.md
         </Typography>
         <Typography className="text-sm" variant="p">
           Configure the Clerk Convex token template, then reload this page.
         </Typography>
       </Stack>
-    </main>
+    </section>
   );
 }
 

--- a/components/dot-field.tsx
+++ b/components/dot-field.tsx
@@ -1,0 +1,35 @@
+/*
+ * Decorative dot field. It is the same grid the mindmap canvas draws, so the
+ * pages outside the app (auth, 404) read as the edge of the product rather
+ * than a separate site.
+ *
+ * The mask is an alpha channel, not a colour: `#000` here means "fully opaque
+ * mask" and never paints a pixel, so the visible dots stay on --canvas-dot.
+ */
+const DOT_FIELD_MASK =
+  "radial-gradient(ellipse 62% 58% at 50% 46%, #000 0%, transparent 100%)";
+
+const dotFieldStyle = {
+  backgroundImage: "radial-gradient(var(--canvas-dot) 1px, transparent 1px)",
+  backgroundSize: "24px 24px",
+  maskImage: DOT_FIELD_MASK,
+  WebkitMaskImage: DOT_FIELD_MASK,
+};
+
+/**
+ * Fills its nearest positioned ancestor with the canvas dot grid.
+ *
+ * Purely decorative and inert: it is hidden from assistive technology and
+ * never intercepts a pointer event.
+ */
+function DotField() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0"
+      style={dotFieldStyle}
+    />
+  );
+}
+
+export { DotField };

--- a/components/flow/Flow.test.tsx
+++ b/components/flow/Flow.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { PropsWithChildren, useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
+
+import Flow from "./Flow";
+
+vi.mock("@/actions/mindmap", () => ({
+  editMindmapWithAI: vi.fn(),
+}));
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+
+  /**
+   * Models XYFlow's default Backspace behavior while exposing the configured
+   * deletion key for the read-only regression.
+   */
+  function ReactFlowHarness({
+    children,
+    deleteKeyCode = "Backspace",
+    nodes,
+    onNodesChange,
+  }: PropsWithChildren<{
+    deleteKeyCode?: string | null;
+    nodes: Array<{ id: string; selected?: boolean }>;
+    onNodesChange?: (changes: Array<{ id: string; type: "remove" }>) => void;
+  }>) {
+    useEffect(() => {
+      /** Applies the library's default selected-node removal shortcut. */
+      const handleKeyDown = (event: KeyboardEvent) => {
+        const selectedNode = nodes.find((node) => node.selected);
+        if (deleteKeyCode === event.key && selectedNode) {
+          onNodesChange?.([{ id: selectedNode.id, type: "remove" }]);
+        }
+      };
+
+      window.addEventListener("keydown", handleKeyDown);
+      return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [deleteKeyCode, nodes, onNodesChange]);
+
+    return (
+      <div
+        data-delete-key={deleteKeyCode === null ? "disabled" : deleteKeyCode}
+      >
+        <output data-testid="node-count">{nodes.length}</output>
+        <output data-testid="selected-count">
+          {nodes.filter((node) => node.selected).length}
+        </output>
+        {children}
+      </div>
+    );
+  }
+
+  /** Keeps the unit harness focused on Flow configuration and store behavior. */
+  function ReactFlowProviderHarness({ children }: PropsWithChildren) {
+    return children;
+  }
+
+  return {
+    ...actual,
+    Background: () => null,
+    ReactFlow: ReactFlowHarness,
+    ReactFlowProvider: ReactFlowProviderHarness,
+    useReactFlow: () => ({
+      fitView: vi.fn(),
+      getZoom: () => 1,
+    }),
+  };
+});
+
+afterEach(cleanup);
+
+describe("Flow", () => {
+  it("keeps a selected node after Backspace in read-only mode", () => {
+    const view = render(<Flow mindmap={MINDMAP} nodes={NODES} readOnly />);
+
+    expect(view.getByTestId("node-count").textContent).toBe("2");
+    expect(view.getByTestId("selected-count").textContent).toBe("1");
+    expect(
+      view
+        .getByTestId("node-count")
+        .parentElement?.getAttribute("data-delete-key")
+    ).toBe("disabled");
+
+    fireEvent.keyDown(window, { key: "Backspace" });
+
+    expect(view.getByTestId("node-count").textContent).toBe("2");
+  });
+});
+
+const MINDMAP: MindmapDB = {
+  _id: "mindmaps:flow-fixture" as MindmapDB["_id"],
+  publicId: "flow-map",
+  name: "Flow fixture",
+  visibility: "shared",
+  updatedAt: 1,
+  isOwner: false,
+};
+
+const NODES: MindmapNodeProjection[] = [
+  {
+    nodeId: "root",
+    parentId: null,
+    type: "root",
+    title: "Root",
+    order: 0,
+  },
+  {
+    nodeId: "left-child",
+    parentId: "root",
+    type: "left",
+    title: "Left child",
+    order: 0,
+  },
+];

--- a/components/flow/Flow.tsx
+++ b/components/flow/Flow.tsx
@@ -174,6 +174,12 @@ export function MindmapFlow() {
       <ReactFlow
         nodesDraggable={false}
         nodesConnectable={false}
+        nodesFocusable={!readOnly}
+        edgesFocusable={false}
+        // Node deletion has no pending-op or backend path yet. Disable the
+        // XYFlow default in every mode so Backspace cannot create local-only
+        // destruction.
+        deleteKeyCode={null}
         minZoom={0.1}
         disableKeyboardA11y
         nodes={nodes}

--- a/components/flow/Flow.tsx
+++ b/components/flow/Flow.tsx
@@ -39,8 +39,14 @@ const nodeTypes: XYNodeTypes = {
   right: RightNode,
 };
 
-export function MindmapFlow() {
+/** Mounts autosave only for an editable canvas. */
+function MindmapAutosave() {
   useMindmapSync();
+  return null;
+}
+
+export function MindmapFlow() {
+  const readOnly = useMindmapFlow((state) => state.readOnly);
   const nodes = useMindmapFlow((state) => state.nodes);
   const edges = useMindmapFlow((state) => state.edges);
   const mindmapNodesMap = useMindmapFlow((state) => state.mindmapNodesMap);
@@ -57,6 +63,7 @@ export function MindmapFlow() {
   const onAddNode = useMindmapFlow((state) => state.actions.onAddNode);
 
   useMindmapNavigation({
+    readOnly,
     mindmapNodesMap,
     leveledNodes,
     activeNode,
@@ -90,9 +97,11 @@ export function MindmapFlow() {
 
   const handleNodeDoubleClick = useCallback(
     (_ev: unknown, _node: Node) => {
-      setSelectedNode(_node.id);
+      if (!readOnly) {
+        setSelectedNode(_node.id);
+      }
     },
-    [setSelectedNode]
+    [readOnly, setSelectedNode]
   );
 
   const handlePaneClick = useCallback(() => {
@@ -156,9 +165,15 @@ export function MindmapFlow() {
 
   return (
     <Stack className="h-full w-full flex-1">
-      <SaveMindmap />
+      {readOnly ? null : (
+        <>
+          <MindmapAutosave />
+          <SaveMindmap />
+        </>
+      )}
       <ReactFlow
         nodesDraggable={false}
+        nodesConnectable={false}
         minZoom={0.1}
         disableKeyboardA11y
         nodes={nodes}
@@ -189,9 +204,11 @@ export function MindmapFlow() {
 export default function Flow({
   mindmap: mindmapDB,
   nodes,
+  readOnly = false,
 }: {
   mindmap: MindmapDB;
   nodes: MindmapNodeProjection[];
+  readOnly?: boolean;
 }) {
   const initialGraph = useMemo(
     () => transformConvexNodesToFlowNodesAndEdges(nodes),
@@ -216,6 +233,7 @@ export default function Flow({
       {/* This key remounts the prop-seeded store when client navigation loads another mindmap. */}
       <MindmapFlowProvider
         key={mindmapDB._id}
+        readOnly={readOnly}
         mindmapDB={mindmapDB}
         initialNodes={initialNodes.length ? initialNodes : INITIAL_NODES}
         initialEdges={initialEdges.length ? initialEdges : INITIAL_EDGES}

--- a/components/flow/hooks/useMindmapNavigation.test.tsx
+++ b/components/flow/hooks/useMindmapNavigation.test.tsx
@@ -147,12 +147,27 @@ describe("useMindmapNavigation", () => {
     expect(fixture.setSelectedNode).toHaveBeenCalledWith(null);
     expect(fixture.setAiEditNode).toHaveBeenCalledWith(null);
   });
+
+  it("keeps navigation but does not bind mutation keys in read-only mode", () => {
+    const fixture = renderNavigationHook("left-a", true);
+
+    dispatchKey({ key: "ArrowRight" });
+    dispatchKey({ key: "Tab" });
+    dispatchKey({ key: "Enter" });
+    dispatchKey({ key: " " });
+    dispatchKey({ key: "k", metaKey: true });
+
+    expect(fixture.setActiveNode).toHaveBeenCalled();
+    expect(fixture.onAddNode).not.toHaveBeenCalled();
+    expect(fixture.setSelectedNode).not.toHaveBeenCalled();
+    expect(fixture.setAiEditNode).not.toHaveBeenCalled();
+  });
 });
 
 /**
  * Renders the navigation hook with a fresh mindmap and independently observable callbacks.
  */
-function renderNavigationHook(activeNode: string | null) {
+function renderNavigationHook(activeNode: string | null, readOnly = false) {
   const { leveledNodes, nodesMap } = buildMindmapFixture();
   const setActiveNode = vi.fn<(nodeId: string | null) => void>();
   const onAddNode =
@@ -162,6 +177,7 @@ function renderNavigationHook(activeNode: string | null) {
 
   renderHook(() =>
     useMindmapNavigation({
+      readOnly,
       activeNode,
       setActiveNode,
       mindmapNodesMap: nodesMap,

--- a/components/flow/hooks/useMindmapNavigation.ts
+++ b/components/flow/hooks/useMindmapNavigation.ts
@@ -8,6 +8,7 @@ import { navigate, Operation } from "../layout/navigate";
 import { MindmapNode, NodeTypes } from "../types";
 
 export function useMindmapNavigation({
+  readOnly,
   activeNode,
   setActiveNode,
   mindmapNodesMap,
@@ -16,6 +17,7 @@ export function useMindmapNavigation({
   setSelectedNode,
   setAiEditNode,
 }: {
+  readOnly: boolean;
   mindmapNodesMap: Record<string, MindmapNode>;
   leveledNodes: MindmapNode[][];
   activeNode: string | null;
@@ -68,9 +70,13 @@ export function useMindmapNavigation({
     );
   }, [activeNode, mindmapNodesMap, onAddNode]);
 
-  useKey("Tab", () => {
-    addNode();
-  });
+  useKey(
+    "Tab",
+    () => {
+      addNode();
+    },
+    { enabled: !readOnly }
+  );
 
   const onEditNode = useCallback(() => {
     if (!activeNode) return;
@@ -83,15 +89,20 @@ export function useMindmapNavigation({
     }
   }, [activeNode, mindmapNodesMap, setSelectedNode]);
 
-  useKey("Enter", onEditNode);
-  useKey(" ", onEditNode); // space is also used to edit nodes
+  useKey("Enter", onEditNode, { enabled: !readOnly });
+  // Space is also used to edit nodes on an editable canvas.
+  useKey(" ", onEditNode, { enabled: !readOnly });
 
   const onStartAiEditing = useEventCallback(() => {
     setAiEditNode(activeNode);
     setSelectedNode(null); // we unset the selected node to prevent user from editing the node
   });
 
-  useKey("k", onStartAiEditing, { isCtrlKey: true, isMetaKey: true });
+  useKey("k", onStartAiEditing, {
+    enabled: !readOnly,
+    isCtrlKey: true,
+    isMetaKey: true,
+  });
 
   useKey(
     "Escape",

--- a/components/flow/nodes/Node/Node.tsx
+++ b/components/flow/nodes/Node/Node.tsx
@@ -106,9 +106,14 @@ const BaseNode = (props: NodeProps & { direction: "left" | "right" }) => {
 
   const selectedNode = useMindmapFlow((state) => state.selectedNode);
   const isAiEditing = useMindmapFlow((state) => state.aiEditNode);
+  const readOnly = useMindmapFlow((state) => state.readOnly);
 
   return (
-    <Popover open={selectedNode === props.id || isAiEditing === props.id}>
+    <Popover
+      open={
+        !readOnly && (selectedNode === props.id || isAiEditing === props.id)
+      }
+    >
       <PopoverTrigger
         className={clsx({ "focus-visible:outline-bloom": isSelected })}
       >
@@ -121,20 +126,24 @@ const BaseNode = (props: NodeProps & { direction: "left" | "right" }) => {
         <Handle type="source" position={sourcePosition} />
         <Handle type="target" position={targetPosition} />
       </PopoverTrigger>
-      <PopoverContent
-        className={!selectedNode ? "hidden" : ""}
-        side="bottom"
-        sideOffset={10}
-      >
-        <NodeDataInput />
-      </PopoverContent>
-      <PopoverContent
-        className={clsx("!p-0 w-[400px]", { hidden: !isAiEditing })}
-        side="right"
-        sideOffset={20}
-      >
-        <NodeAiEdit />
-      </PopoverContent>
+      {readOnly ? null : (
+        <>
+          <PopoverContent
+            className={!selectedNode ? "hidden" : ""}
+            side="bottom"
+            sideOffset={10}
+          >
+            <NodeDataInput />
+          </PopoverContent>
+          <PopoverContent
+            className={clsx("!p-0 w-[400px]", { hidden: !isAiEditing })}
+            side="right"
+            sideOffset={20}
+          >
+            <NodeAiEdit />
+          </PopoverContent>
+        </>
+      )}
     </Popover>
   );
 };

--- a/components/flow/providers/MindmapFlowProvider.test.tsx
+++ b/components/flow/providers/MindmapFlowProvider.test.tsx
@@ -56,6 +56,22 @@ describe("MindmapFlowProvider", () => {
       )
     ).not.toThrow();
   });
+
+  it("mounts an authenticated non-owner in read-only mode", () => {
+    const fixture = createProviderFixture();
+    const nonOwnerMindmap = { ...fixture.mindmapDB, isOwner: false };
+    const view = render(
+      <MindmapFlowProvider
+        {...fixture}
+        mindmapDB={nonOwnerMindmap}
+        readOnly={!nonOwnerMindmap.isOwner}
+      >
+        <ReadOnlyProbe />
+      </MindmapFlowProvider>
+    );
+
+    expect(view.getByTestId("read-only").textContent).toBe("true");
+  });
 });
 
 /** Exposes selected store writes while recording renders of the active slice. */
@@ -82,6 +98,12 @@ function StoreProbe({ onRender }: { onRender: () => void }) {
 function OutsideProviderProbe() {
   useMindmapFlow((state) => state.activeNode);
   return null;
+}
+
+/** Exposes the provider's ownership-derived interaction mode. */
+function ReadOnlyProbe() {
+  const readOnly = useMindmapFlow((state) => state.readOnly);
+  return <output data-testid="read-only">{String(readOnly)}</output>;
 }
 
 /** Creates a minimal rooted mindmap for provider wiring tests. */

--- a/components/flow/providers/MindmapFlowProvider.tsx
+++ b/components/flow/providers/MindmapFlowProvider.tsx
@@ -36,6 +36,7 @@ function useMindmapStoreApi(): StoreApi<MindmapStore> {
 
 type MindmapFlowProviderProps = {
   children: React.ReactNode;
+  readOnly?: boolean;
   mindmapDB: MindmapDB;
   initialNodes: BaseFlowNode[];
   initialEdges: Edge[];
@@ -46,13 +47,14 @@ type MindmapFlowProviderProps = {
  */
 const MindmapFlowProvider = ({
   children,
+  readOnly = false,
   mindmapDB,
   initialNodes,
   initialEdges,
 }: MindmapFlowProviderProps) => {
   // A lazy state initializer guarantees one prop-seeded store per provider.
   const [store] = useState(() =>
-    createMindmapStore({ mindmapDB, initialNodes, initialEdges })
+    createMindmapStore({ readOnly, mindmapDB, initialNodes, initialEdges })
   );
 
   const debugLogger = useCallback(() => {

--- a/components/flow/providers/store.test.ts
+++ b/components/flow/providers/store.test.ts
@@ -267,6 +267,7 @@ describe("createMindmapStore", () => {
     const fixture = createStoreFixture();
     const store = createMindmapStore({ ...fixture, readOnly: true });
     const initialState = store.getState();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const addedNode = initialState.actions.onAddNode(
       NodeTypes.LEFT,
@@ -274,6 +275,7 @@ describe("createMindmapStore", () => {
       "blocked-child"
     );
     initialState.actions.onUpdateNode("l-child", { title: "Blocked edit" });
+    initialState.actions.onNodesChange([{ id: "l-child", type: "remove" }]);
     initialState.setSelectedNode("l-child");
     initialState.setAiEditNode("l-child");
 
@@ -284,6 +286,12 @@ describe("createMindmapStore", () => {
     expect(state.pendingOps).toEqual([]);
     expect(state.selectedNode).toBeNull();
     expect(state.aiEditNode).toBeNull();
+    expect(warning.mock.calls).toEqual([
+      ["[MindmapFlowProvider] ignored onAddNode in read-only mode"],
+      ["[MindmapFlowProvider] ignored onUpdateNode in read-only mode"],
+      ["[MindmapFlowProvider] ignored onNodesChange remove in read-only mode"],
+    ]);
+    warning.mockRestore();
   });
 
   it("keeps derived state synchronized after every node action", () => {

--- a/components/flow/providers/store.test.ts
+++ b/components/flow/providers/store.test.ts
@@ -263,6 +263,29 @@ describe("createMindmapStore", () => {
     expectDerivedStateInvariant(store.getState());
   });
 
+  it("rejects mutation actions when seeded read-only", () => {
+    const fixture = createStoreFixture();
+    const store = createMindmapStore({ ...fixture, readOnly: true });
+    const initialState = store.getState();
+
+    const addedNode = initialState.actions.onAddNode(
+      NodeTypes.LEFT,
+      "l-child",
+      "blocked-child"
+    );
+    initialState.actions.onUpdateNode("l-child", { title: "Blocked edit" });
+    initialState.setSelectedNode("l-child");
+    initialState.setAiEditNode("l-child");
+
+    const state = store.getState();
+    expect(addedNode).toBeNull();
+    expect(state.nodesMap["blocked-child"]).toBeUndefined();
+    expect(state.nodesMap["l-child"].data.title).toBe("Left child");
+    expect(state.pendingOps).toEqual([]);
+    expect(state.selectedNode).toBeNull();
+    expect(state.aiEditNode).toBeNull();
+  });
+
   it("keeps derived state synchronized after every node action", () => {
     const store = createFixtureStore();
 

--- a/components/flow/providers/store.ts
+++ b/components/flow/providers/store.ts
@@ -73,6 +73,14 @@ function createNodeDataPatch(
   return patch;
 }
 
+/** Reports an ignored read-only mutation during local development. */
+function warnReadOnlyMutation(action: string): void {
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console -- read-only violations should be visible during development
+    console.warn(`[MindmapFlowProvider] ignored ${action} in read-only mode`);
+  }
+}
+
 /**
  * Creates an isolated mindmap store seeded from one provider instance.
  *
@@ -98,9 +106,21 @@ function createMindmapStore({
     const onNodesChange: MindmapFlowContext["actions"]["onNodesChange"] = (
       changes
     ) => {
+      const applicableChanges = readOnly
+        ? changes.filter((change) => change.type !== "remove")
+        : changes;
+
+      if (applicableChanges.length !== changes.length) {
+        warnReadOnlyMutation("onNodesChange remove");
+      }
+
+      if (applicableChanges.length === 0) {
+        return;
+      }
+
       set((state) => {
         const updatedNodes = applyNodeChanges(
-          changes,
+          applicableChanges,
           state.nodes
         ) as FlowNode[];
 
@@ -121,6 +141,7 @@ function createMindmapStore({
       options
     ) => {
       if (readOnly) {
+        warnReadOnlyMutation("onAddNode");
         return null;
       }
 
@@ -262,6 +283,7 @@ function createMindmapStore({
       options
     ) => {
       if (readOnly) {
+        warnReadOnlyMutation("onUpdateNode");
         return;
       }
 

--- a/components/flow/providers/store.ts
+++ b/components/flow/providers/store.ts
@@ -30,6 +30,7 @@ import { MindmapFlowContext } from "./types";
 type MindmapStore = MindmapFlowContext;
 
 type MindmapStoreSeed = {
+  readOnly?: boolean;
   mindmapDB: MindmapDB;
   initialNodes: BaseFlowNode[];
   initialEdges: Edge[];
@@ -79,6 +80,7 @@ function createNodeDataPatch(
  * every derived view affected by that write.
  */
 function createMindmapStore({
+  readOnly = false,
   mindmapDB,
   initialNodes,
   initialEdges,
@@ -118,6 +120,10 @@ function createMindmapStore({
       data,
       options
     ) => {
+      if (readOnly) {
+        return null;
+      }
+
       const currentMindmapNodesMap = get().mindmapNodesMap;
 
       if (!currentMindmapNodesMap[parentNodeId]) {
@@ -255,6 +261,10 @@ function createMindmapStore({
       data,
       options
     ) => {
+      if (readOnly) {
+        return;
+      }
+
       set((state) => {
         const currentNode = state.nodesMap[nodeId];
 
@@ -316,6 +326,7 @@ function createMindmapStore({
     };
 
     return {
+      readOnly,
       layout,
       nodes,
       edges,
@@ -325,9 +336,17 @@ function createMindmapStore({
       activeNode: ROOT_NODE_ID,
       setActiveNode: (activeNode) => set({ activeNode }),
       selectedNode: null,
-      setSelectedNode: (selectedNode) => set({ selectedNode }),
+      setSelectedNode: (selectedNode) => {
+        if (!readOnly) {
+          set({ selectedNode });
+        }
+      },
       aiEditNode: null,
-      setAiEditNode: (aiEditNode) => set({ aiEditNode }),
+      setAiEditNode: (aiEditNode) => {
+        if (!readOnly) {
+          set({ aiEditNode });
+        }
+      },
       mindmapDB,
       pendingOps: [],
       flushedWatermark: 0,

--- a/components/flow/providers/types.ts
+++ b/components/flow/providers/types.ts
@@ -10,6 +10,7 @@ type DagreGraph = graphlib.Graph<GraphLabel, NodeLabel, EdgeLabel>;
 
 // todo: add documentation for the context
 type MindmapFlowContext = {
+  readOnly: boolean;
   layout: {
     leftGraph: DagreGraph;
     rightGraph: DagreGraph;

--- a/components/mindmap-not-found.tsx
+++ b/components/mindmap-not-found.tsx
@@ -10,8 +10,8 @@ import { Typography } from "./ui/typography";
 export function MindmapNotFound() {
   const router = useRouter();
 
-  const handleGoToHome = () => {
-    router.push("/new");
+  const handleGoToMaps = () => {
+    router.push("/maps");
   };
 
   return (
@@ -27,8 +27,8 @@ export function MindmapNotFound() {
           It may have been deleted, or the link may point at a map on another
           account. Your other maps are still in the sidebar.
         </Typography>
-        <Button className="mt-3" onClick={handleGoToHome}>
-          Start a new map
+        <Button className="mt-3" onClick={handleGoToMaps}>
+          View your maps
         </Button>
       </Stack>
     </Stack>

--- a/components/new-ai-mindmap.test.tsx
+++ b/components/new-ai-mindmap.test.tsx
@@ -78,7 +78,7 @@ describe("AIMindmapInput", () => {
     await user.click(screen.getByRole("button", { name: "Grow the map" }));
 
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith("/generated1");
+      expect(pushMock).toHaveBeenCalledWith("/maps/generated1");
       expect(refreshMock).toHaveBeenCalledOnce();
     });
     expect(pushMock.mock.invocationCallOrder[0]).toBeLessThan(

--- a/components/new-ai-mindmap.tsx
+++ b/components/new-ai-mindmap.tsx
@@ -45,7 +45,7 @@ function AIMindmapInput() {
       try {
         const aiMindmap = await createMindmapFromAI(userPrompt);
         const publicId = aiMindmap.data.publicId;
-        router.push(`/${publicId}`);
+        router.push(`/maps/${publicId}`);
         // Refresh the shared server layout so listMine includes the new map.
         router.refresh();
       } catch (error) {

--- a/components/share-top-bar.test.tsx
+++ b/components/share-top-bar.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ShareTopBar } from "./share-top-bar";
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Verifies the public chrome that frames a read-only shared canvas. */
+describe("ShareTopBar", () => {
+  it("names the product, the map, and the read-only state", () => {
+    render(<ShareTopBar mindmapName="Photosynthesis" />);
+
+    const home = screen.getByRole("link", { name: "Sprig home" });
+    expect(home).toHaveProperty("href", expect.stringMatching(/\/$/));
+    expect(home.textContent).toContain("Sprig");
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Photosynthesis" })
+    ).toBeTruthy();
+    expect(screen.getByText("Read-only")).toBeTruthy();
+  });
+});

--- a/components/share-top-bar.tsx
+++ b/components/share-top-bar.tsx
@@ -12,10 +12,10 @@ import { Wordmark } from "@/components/wordmark";
  */
 function ShareTopBar({ mindmapName }: { mindmapName: string }) {
   return (
-    <header className="flex h-13 shrink-0 items-center gap-3 border-b border-border px-5 sm:gap-4 sm:px-6">
+    <header className="flex h-13 shrink-0 items-center gap-3 border-b border-border pl-5 pr-18 sm:gap-4 sm:pl-6 sm:pr-20">
       <Link
         aria-label="Sprig home"
-        className="shrink-0 rounded-sm transition-opacity duration-200 ease-organic hover:opacity-70 motion-reduce:transition-none"
+        className="shrink-0 rounded-sm transition-opacity duration-200 ease-organic hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none"
         href="/"
       >
         <Wordmark className="text-xs" />

--- a/components/share-top-bar.tsx
+++ b/components/share-top-bar.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+import { Wordmark } from "@/components/wordmark";
+
+/**
+ * Public frame above a shared, read-only canvas.
+ *
+ * A visitor arrives here from a link with no other context, so the bar has to
+ * answer three questions at a glance: whose product this is, which map they are
+ * looking at, and why the canvas below will not accept their edits. It is chrome
+ * only — it never touches the flow beneath it.
+ */
+function ShareTopBar({ mindmapName }: { mindmapName: string }) {
+  return (
+    <header className="flex h-13 shrink-0 items-center gap-3 border-b border-border px-5 sm:gap-4 sm:px-6">
+      <Link
+        aria-label="Sprig home"
+        className="shrink-0 rounded-sm transition-opacity duration-200 ease-organic hover:opacity-70 motion-reduce:transition-none"
+        href="/"
+      >
+        <Wordmark className="text-xs" />
+      </Link>
+      <span aria-hidden="true" className="h-4 w-px shrink-0 bg-border" />
+      <h1 className="min-w-0 flex-1 truncate text-sm font-medium">
+        {mindmapName}
+      </h1>
+      <span className="shrink-0 rounded-sm border border-border px-2 py-0.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+        Read-only
+      </span>
+    </header>
+  );
+}
+
+export { ShareTopBar };

--- a/components/sidebar/floating-sidebar.tsx
+++ b/components/sidebar/floating-sidebar.tsx
@@ -30,12 +30,32 @@ import { NewMindmapButton } from "./new-mindmap-btn";
  * elevation. Identity is carried by the wordmark and the moss rail on the
  * active row, not by an icon.
  */
-export function FloatingSidebar({
+/**
+ * Live wrapper: reads the route param to highlight the active map. Kept apart
+ * from FloatingSidebar so the Suspense fallback can render the same shell
+ * without touching request-time data (useParams breaks static prerender).
+ */
+function ActiveFloatingSidebar({
   mindmaps,
   ...props
 }: React.ComponentProps<typeof Sidebar> & { mindmaps: MindmapDB[] }) {
   const params = useParams();
   const publicId = params.publicId as string | undefined;
+  return (
+    <FloatingSidebar activePublicId={publicId} mindmaps={mindmaps} {...props} />
+  );
+}
+
+export function FloatingSidebar({
+  mindmaps,
+  activePublicId,
+  ...props
+}: React.ComponentProps<typeof Sidebar> & {
+  mindmaps: MindmapDB[];
+  /** publicId of the currently open map; undefined in the static fallback. */
+  activePublicId?: string;
+}) {
+  const publicId = activePublicId;
 
   return (
     <Sidebar variant="floating" {...props}>
@@ -102,3 +122,5 @@ export function FloatingSidebar({
     </Sidebar>
   );
 }
+
+export { ActiveFloatingSidebar };

--- a/components/sidebar/floating-sidebar.tsx
+++ b/components/sidebar/floating-sidebar.tsx
@@ -35,7 +35,7 @@ export function FloatingSidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar> & { mindmaps: MindmapDB[] }) {
   const params = useParams();
-  const mindmapSlug = params.mindmapSlug as string;
+  const publicId = params.publicId as string | undefined;
 
   return (
     <Sidebar variant="floating" {...props}>
@@ -73,9 +73,9 @@ export function FloatingSidebar({
                     <SidebarMenuSubItem key={mindmap._id}>
                       <SidebarMenuSubButton
                         asChild
-                        isActive={mindmap.publicId === mindmapSlug}
+                        isActive={mindmap.publicId === publicId}
                       >
-                        <a href={`/${mindmap.publicId}`}>
+                        <a href={`/maps/${mindmap.publicId}`}>
                           <TypographyWithTooltip
                             className="text-sm"
                             variant="p"

--- a/components/wordmark.tsx
+++ b/components/wordmark.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * The Sprig lockup: a leaf-dot in --primary followed by the mono wordmark.
+ *
+ * Every public surface (landing, 404, shared canvas) draws its identity from
+ * here so the leaf-dot spacing and the letter-spacing stay in one place.
+ *
+ * The trailing negative margin eats the last letter-space that `tracking`
+ * appends after the "g", so the lockup optically centres inside its box and
+ * sits flush against whatever follows it in a row.
+ */
+function Wordmark({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2.5 font-mono text-sm uppercase tracking-[0.28em] text-foreground",
+        className
+      )}
+    >
+      <span aria-hidden="true" className="size-1.5 rounded-full bg-primary" />
+      <span className="-mr-[0.28em]">Sprig</span>
+    </span>
+  );
+}
+
+export { Wordmark };

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Generated `api` utility.
  *

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * Generated `api` utility.
  *

--- a/convex/mindmaps.test.ts
+++ b/convex/mindmaps.test.ts
@@ -20,6 +20,24 @@ function createHarness() {
   };
 }
 
+/** Requires the complete application error message, avoiding substring oracles. */
+async function expectErrorMessage(
+  promise: Promise<unknown>,
+  expectedMessage: string
+): Promise<void> {
+  const error = await promise.then(
+    () => null,
+    (caught: unknown) => caught
+  );
+
+  expect(error).toBeInstanceOf(Error);
+  if (!(error instanceof Error)) {
+    return;
+  }
+
+  expect(error.message).toBe(expectedMessage);
+}
+
 describe("mindmaps", () => {
   it("creates a private mindmap with a URL-safe public id and root node", async () => {
     const { asAlice } = createHarness();
@@ -130,7 +148,7 @@ describe("mindmaps", () => {
         nodes,
       })
     ).resolves.toBeDefined();
-    await expect(
+    await expectErrorMessage(
       asAlice.mutation(api.mindmaps.createWithNodes, {
         name: "Above the limit",
         nodes: [
@@ -143,14 +161,15 @@ describe("mindmaps", () => {
             order: 199,
           },
         ],
-      })
-    ).rejects.toThrow("Invalid op: too many nodes");
+      }),
+      "Invalid op: too many nodes"
+    );
   });
 
   it("rolls back the mindmap when generated nodes are rejected", async () => {
     const { t, asAlice } = createHarness();
 
-    await expect(
+    await expectErrorMessage(
       asAlice.mutation(api.mindmaps.createWithNodes, {
         name: "Invalid generated plan",
         nodes: [
@@ -169,8 +188,9 @@ describe("mindmaps", () => {
             order: 0,
           },
         ],
-      })
-    ).rejects.toThrow("parent is on another side");
+      }),
+      "Invalid op: parent is on another side"
+    );
 
     const rows = await t.run(async (ctx) => ({
       mindmaps: await ctx.db.query("mindmaps").collect(),
@@ -222,12 +242,17 @@ describe("mindmaps", () => {
     });
     expect(result.mindmap).not.toHaveProperty("ownerId");
     expect(result.nodes.map((node) => node.nodeId)).toEqual(["root"]);
-    await expect(
-      t.query(api.mindmaps.getShared, { publicId: privateMap.publicId })
-    ).rejects.toThrow("Not found");
-    await expect(
-      t.query(api.mindmaps.getShared, { publicId: "unknown000" })
-    ).rejects.toThrow("Not found");
+    expect(result.nodes[0]).not.toHaveProperty("_id");
+    expect(result.nodes[0]).not.toHaveProperty("_creationTime");
+    expect(result.nodes[0]).not.toHaveProperty("mindmapId");
+    await expectErrorMessage(
+      t.query(api.mindmaps.getShared, { publicId: privateMap.publicId }),
+      "Not found"
+    );
+    await expectErrorMessage(
+      t.query(api.mindmaps.getShared, { publicId: "unknown000" }),
+      "Not found"
+    );
   });
 
   it("allows only the owner to change visibility", async () => {
@@ -245,22 +270,24 @@ describe("mindmaps", () => {
     });
 
     expect(shared.mindmap.visibility).toBe("shared");
-    await expect(
+    await expectErrorMessage(
       asBob.mutation(api.mindmaps.setVisibility, {
         mindmapId: created.mindmapId,
         visibility: "private",
-      })
-    ).rejects.toThrow("Forbidden");
+      }),
+      "Forbidden"
+    );
 
     await asAlice.mutation(api.mindmaps.setVisibility, {
       mindmapId: created.mindmapId,
       visibility: "private",
     });
-    await expect(
+    await expectErrorMessage(
       asBob.query(api.mindmaps.getByPublicId, {
         publicId: created.publicId,
-      })
-    ).rejects.toThrow("Not found");
+      }),
+      "Not found"
+    );
   });
 
   it("lists only the owner's mindmaps newest-updated first", async () => {
@@ -346,15 +373,18 @@ describe("mindmaps", () => {
       name: "Private",
     });
 
-    await expect(
-      t.query(api.mindmaps.get, { mindmapId: created.mindmapId })
-    ).rejects.toThrow("Unauthenticated");
-    await expect(t.query(api.mindmaps.listMine, {})).rejects.toThrow(
+    await expectErrorMessage(
+      t.query(api.mindmaps.get, { mindmapId: created.mindmapId }),
       "Unauthenticated"
     );
-    await expect(
-      t.mutation(api.mindmaps.create, { name: "Anonymous" })
-    ).rejects.toThrow("Unauthenticated");
+    await expectErrorMessage(
+      t.query(api.mindmaps.listMine, {}),
+      "Unauthenticated"
+    );
+    await expectErrorMessage(
+      t.mutation(api.mindmaps.create, { name: "Anonymous" }),
+      "Unauthenticated"
+    );
   });
 
   it("forbids a non-owner from reading or mutating a private mindmap", async () => {
@@ -363,20 +393,23 @@ describe("mindmaps", () => {
       name: "Private",
     });
 
-    await expect(
-      asBob.query(api.mindmaps.get, { mindmapId: created.mindmapId })
-    ).rejects.toThrow("Forbidden");
-    await expect(
+    await expectErrorMessage(
+      asBob.query(api.mindmaps.get, { mindmapId: created.mindmapId }),
+      "Forbidden"
+    );
+    await expectErrorMessage(
       asBob.mutation(api.mindmaps.rename, {
         mindmapId: created.mindmapId,
         name: "Hijacked",
-      })
-    ).rejects.toThrow("Forbidden");
-    await expect(
+      }),
+      "Forbidden"
+    );
+    await expectErrorMessage(
       asBob.mutation(api.mindmaps.remove, {
         mindmapId: created.mindmapId,
-      })
-    ).rejects.toThrow("Forbidden");
+      }),
+      "Forbidden"
+    );
   });
 
   it("allows authenticated shared reads but still forbids non-owner writes", async () => {
@@ -403,12 +436,13 @@ describe("mindmaps", () => {
     expect(byPublicId.mindmap.isOwner).toBe(false);
     expect(byId.mindmap).not.toHaveProperty("ownerId");
     expect(byPublicId.mindmap).not.toHaveProperty("ownerId");
-    await expect(
+    await expectErrorMessage(
       asBob.mutation(api.mindmaps.rename, {
         mindmapId: created.mindmapId,
         name: "Not allowed",
-      })
-    ).rejects.toThrow("Forbidden");
+      }),
+      "Forbidden"
+    );
   });
 
   it("hides private public-id existence from non-owners", async () => {
@@ -417,16 +451,18 @@ describe("mindmaps", () => {
       name: "Private route",
     });
 
-    await expect(
+    await expectErrorMessage(
       asBob.query(api.mindmaps.getByPublicId, {
         publicId: created.publicId,
-      })
-    ).rejects.toThrow("Not found");
-    await expect(
+      }),
+      "Not found"
+    );
+    await expectErrorMessage(
       asBob.query(api.mindmaps.getByPublicId, {
         publicId: "unknown000",
-      })
-    ).rejects.toThrow("Not found");
+      }),
+      "Not found"
+    );
   });
 
   it("sorts sibling nodes by order for both canvas read paths", async () => {
@@ -547,11 +583,12 @@ describe("mindmaps", () => {
       mindmapId: created.mindmapId,
     });
 
-    await expect(
+    await expectErrorMessage(
       asAlice.query(api.mindmaps.get, {
         mindmapId: created.mindmapId,
-      })
-    ).rejects.toThrow("Not found");
+      }),
+      "Not found"
+    );
 
     const beforePurge = await t.run(async (ctx) => ({
       node: await ctx.db.get("nodes", nodeIds[0]),

--- a/convex/mindmaps.test.ts
+++ b/convex/mindmaps.test.ts
@@ -197,6 +197,72 @@ describe("mindmaps", () => {
     expect(result.nodes.map((node) => node.nodeId)).toEqual(["root"]);
   });
 
+  it("exposes only shared maps through the unauthenticated public query", async () => {
+    const { t, asAlice } = createHarness();
+    const shared = await asAlice.mutation(api.mindmaps.create, {
+      name: "Shared route",
+    });
+    const privateMap = await asAlice.mutation(api.mindmaps.create, {
+      name: "Private route",
+    });
+    await asAlice.mutation(api.mindmaps.setVisibility, {
+      mindmapId: shared.mindmapId,
+      visibility: "shared",
+    });
+
+    const result = await t.query(api.mindmaps.getShared, {
+      publicId: shared.publicId,
+    });
+
+    expect(result.mindmap).toMatchObject({
+      _id: shared.mindmapId,
+      publicId: shared.publicId,
+      visibility: "shared",
+      isOwner: false,
+    });
+    expect(result.mindmap).not.toHaveProperty("ownerId");
+    expect(result.nodes.map((node) => node.nodeId)).toEqual(["root"]);
+    await expect(
+      t.query(api.mindmaps.getShared, { publicId: privateMap.publicId })
+    ).rejects.toThrow("Not found");
+    await expect(
+      t.query(api.mindmaps.getShared, { publicId: "unknown000" })
+    ).rejects.toThrow("Not found");
+  });
+
+  it("allows only the owner to change visibility", async () => {
+    const { asAlice, asBob } = createHarness();
+    const created = await asAlice.mutation(api.mindmaps.create, {
+      name: "Visibility control",
+    });
+
+    await asAlice.mutation(api.mindmaps.setVisibility, {
+      mindmapId: created.mindmapId,
+      visibility: "shared",
+    });
+    const shared = await asAlice.query(api.mindmaps.get, {
+      mindmapId: created.mindmapId,
+    });
+
+    expect(shared.mindmap.visibility).toBe("shared");
+    await expect(
+      asBob.mutation(api.mindmaps.setVisibility, {
+        mindmapId: created.mindmapId,
+        visibility: "private",
+      })
+    ).rejects.toThrow("Forbidden");
+
+    await asAlice.mutation(api.mindmaps.setVisibility, {
+      mindmapId: created.mindmapId,
+      visibility: "private",
+    });
+    await expect(
+      asBob.query(api.mindmaps.getByPublicId, {
+        publicId: created.publicId,
+      })
+    ).rejects.toThrow("Not found");
+  });
+
   it("lists only the owner's mindmaps newest-updated first", async () => {
     const { t, asAlice, asBob } = createHarness();
     const older = await asAlice.mutation(api.mindmaps.create, {

--- a/convex/mindmaps.ts
+++ b/convex/mindmaps.ts
@@ -13,6 +13,7 @@ const PUBLIC_ID_LENGTH = 10;
 const PURGE_BATCH_SIZE = 200;
 /** Bounds generated trees so one atomic apply operation remains predictable. */
 const MAX_GENERATED_NODE_COUNT = 200;
+const visibilityValidator = v.union(v.literal("private"), v.literal("shared"));
 const nodeSnapshotValidator = v.object({
   nodeId: v.string(),
   parentId: v.union(v.string(), v.null()),
@@ -78,7 +79,7 @@ function projectMindmap(
     visibility: "private" | "shared";
     updatedAt: number;
   },
-  subject: string
+  subject: string | null
 ) {
   return {
     _id: mindmap._id,
@@ -258,6 +259,34 @@ export const getByPublicId = query({
 });
 
 /**
+ * Resolves a shared public route without reading authentication state.
+ */
+export const getShared = query({
+  args: { publicId: v.string() },
+  handler: async (ctx, args) => {
+    const resolvedMindmap = await ctx.db
+      .query("mindmaps")
+      .withIndex("by_publicId", (q) => q.eq("publicId", args.publicId))
+      .unique();
+
+    // Shared and absent IDs deliberately have one indistinguishable failure.
+    if (resolvedMindmap === null || resolvedMindmap.visibility !== "shared") {
+      throw new ConvexError("Not found");
+    }
+
+    const nodes = await ctx.db
+      .query("nodes")
+      .withIndex("by_mindmap", (q) => q.eq("mindmapId", resolvedMindmap._id))
+      .collect();
+
+    return {
+      mindmap: projectMindmap(resolvedMindmap, null),
+      nodes: sortNodesByParentAndOrder(nodes),
+    };
+  },
+});
+
+/**
  * Lists the current user's mindmaps with the most recently changed first.
  */
 export const listMine = query({
@@ -293,6 +322,21 @@ export const rename = mutation({
     });
     await ctx.db.patch("mindmaps", args.mindmapId, {
       name: args.name,
+    });
+  },
+});
+
+/** Changes sharing visibility for an owned mindmap. */
+export const setVisibility = mutation({
+  args: {
+    mindmapId: v.id("mindmaps"),
+    visibility: visibilityValidator,
+  },
+  handler: async (ctx, args) => {
+    await requireOwner(ctx, args.mindmapId);
+    await ctx.db.patch("mindmaps", args.mindmapId, {
+      visibility: args.visibility,
+      updatedAt: Date.now(),
     });
   },
 });

--- a/convex/mindmaps.ts
+++ b/convex/mindmaps.ts
@@ -1,7 +1,7 @@
 import { ConvexError, v } from "convex/values";
 
 import { internal } from "./_generated/api";
-import type { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
 import { requireOwner, requireReadable, requireUser } from "./lib/access";
@@ -90,6 +90,26 @@ function projectMindmap(
     isOwner: subject === mindmap.ownerId,
   };
 }
+
+/** Keeps public node reads limited to fields the canvas can render. */
+function projectRenderableNode(node: Doc<"nodes">): NodeSnapshot {
+  return {
+    nodeId: node.nodeId,
+    parentId: node.parentId,
+    type: node.type,
+    title: node.title,
+    ...(node.description === undefined
+      ? {}
+      : { description: node.description }),
+    ...(node.link === undefined ? {} : { link: node.link }),
+    order: node.order,
+  };
+}
+
+type SharedMindmapResult = {
+  mindmap: ReturnType<typeof projectMindmap>;
+  nodes: NodeSnapshot[];
+};
 
 /**
  * Inserts one private mindmap and its canonical root for an authenticated owner.
@@ -263,7 +283,7 @@ export const getByPublicId = query({
  */
 export const getShared = query({
   args: { publicId: v.string() },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<SharedMindmapResult> => {
     const resolvedMindmap = await ctx.db
       .query("mindmaps")
       .withIndex("by_publicId", (q) => q.eq("publicId", args.publicId))
@@ -281,7 +301,7 @@ export const getShared = query({
 
     return {
       mindmap: projectMindmap(resolvedMindmap, null),
-      nodes: sortNodesByParentAndOrder(nodes),
+      nodes: sortNodesByParentAndOrder(nodes.map(projectRenderableNode)),
     };
   },
 });

--- a/hooks/use-key.ts
+++ b/hooks/use-key.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 type UseKeyOptions = {
+  enabled?: boolean;
   isMetaKey?: boolean;
   isCtrlKey?: boolean;
   isShiftKey?: boolean;
@@ -15,6 +16,7 @@ export function useKey(
   opts?: UseKeyOptions
 ) {
   const {
+    enabled = true,
     isMetaKey = false,
     isCtrlKey = false,
     isShiftKey = false,
@@ -23,6 +25,10 @@ export function useKey(
   } = opts ?? {};
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const handleKey = (event: KeyboardEvent) => {
       const target = event.target;
       const isEditableTarget =
@@ -56,6 +62,7 @@ export function useKey(
   }, [
     key,
     callback,
+    enabled,
     isMetaKey,
     isCtrlKey,
     isShiftKey,

--- a/lib/auth-routing.test.ts
+++ b/lib/auth-routing.test.ts
@@ -13,8 +13,14 @@ describe("auth routing", () => {
     ["/sign-in/sso-callback", true],
     ["/sign-up", true],
     ["/sign-up/verify", true],
-    ["/", false],
+    ["/", true],
+    ["/share", true],
+    ["/share/public-map", true],
+    ["/maps", false],
+    ["/maps/private-map", false],
+    ["/new", false],
     ["/sign-invitation", false],
+    ["/shared", false],
     ["/api/chat", false],
   ])("matches public path %s as %s", (pathname, expected) => {
     expect(isPublicPath(pathname)).toBe(expected);

--- a/lib/auth-routing.test.ts
+++ b/lib/auth-routing.test.ts
@@ -16,11 +16,18 @@ describe("auth routing", () => {
     ["/", true],
     ["/share", true],
     ["/share/public-map", true],
+    ["/robots.txt", true],
+    ["/sitemap.xml", true],
+    ["/favicon.ico", true],
+    ["/opengraph-image", true],
+    ["/opengraph-image-abc123", true],
     ["/maps", false],
     ["/maps/private-map", false],
     ["/new", false],
     ["/sign-invitation", false],
     ["/shared", false],
+    ["/robots.txt/private", false],
+    ["/sitemap.xml/private", false],
     ["/api/chat", false],
   ])("matches public path %s as %s", (pathname, expected) => {
     expect(isPublicPath(pathname)).toBe(expected);

--- a/lib/auth-routing.ts
+++ b/lib/auth-routing.ts
@@ -1,4 +1,5 @@
 const PUBLIC_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
+const PUBLIC_PATH_PREFIXES = [...PUBLIC_AUTH_PATHS, "/share"] as const;
 
 /**
  * Accepts only same-origin, root-relative destinations.
@@ -36,9 +37,13 @@ function buildAuthPageUrl(
   return `${pathname}?${searchParams.toString()}`;
 }
 
-/** Matches the auth pages and their optional Clerk catch-all path segments. */
+/** Matches public pages and their optional catch-all path segments. */
 function isPublicPath(pathname: string): boolean {
-  return PUBLIC_AUTH_PATHS.some(
+  if (pathname === "/") {
+    return true;
+  }
+
+  return PUBLIC_PATH_PREFIXES.some(
     (publicPath) =>
       pathname === publicPath || pathname.startsWith(`${publicPath}/`)
   );

--- a/lib/auth-routing.ts
+++ b/lib/auth-routing.ts
@@ -1,5 +1,10 @@
 const PUBLIC_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
 const PUBLIC_PATH_PREFIXES = [...PUBLIC_AUTH_PATHS, "/share"] as const;
+const PUBLIC_METADATA_PATHS = [
+  "/robots.txt",
+  "/sitemap.xml",
+  "/favicon.ico",
+] as const;
 
 /**
  * Accepts only same-origin, root-relative destinations.
@@ -39,7 +44,11 @@ function buildAuthPageUrl(
 
 /** Matches public pages and their optional catch-all path segments. */
 function isPublicPath(pathname: string): boolean {
-  if (pathname === "/") {
+  if (
+    pathname === "/" ||
+    PUBLIC_METADATA_PATHS.some((publicPath) => pathname === publicPath) ||
+    pathname.startsWith("/opengraph-image")
+  ) {
     return true;
   }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   reactCompiler: true,
 };
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,8 +4,7 @@ import { NextResponse } from "next/server";
 import { acceptsJsonOverHtml, isPublicPath } from "@/lib/auth-routing";
 
 const proxy = clerkMiddleware(async (auth, request) => {
-  // "/" stays protected until P7 ships a real landing page — its current
-  // content is the authenticated dashboard, which fetches user data.
+  // Public landing, auth, and shared-map routes bypass Clerk protection.
   if (isPublicPath(request.nextUrl.pathname)) {
     return;
   }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,11 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-import { acceptsJsonOverHtml, isPublicPath } from "@/lib/auth-routing";
+import {
+  acceptsJsonOverHtml,
+  isPublicPath,
+  sanitizeRedirectUrl,
+} from "@/lib/auth-routing";
 
 const proxy = clerkMiddleware(async (auth, request) => {
   // Public landing, auth, and shared-map routes bypass Clerk protection.
@@ -23,7 +27,10 @@ const proxy = clerkMiddleware(async (auth, request) => {
 
   const destination = `${request.nextUrl.pathname}${request.nextUrl.search}`;
   const unauthenticatedUrl = new URL("/sign-in", request.url);
-  unauthenticatedUrl.searchParams.set("redirect_url", destination);
+  unauthenticatedUrl.searchParams.set(
+    "redirect_url",
+    sanitizeRedirectUrl(destination)
+  );
 
   return NextResponse.redirect(unauthenticatedUrl);
 });
@@ -37,7 +44,7 @@ export const config = {
      * - Next.js internals
      * - common static files, unless they are explicitly requested via search params
      */
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/((?!_next|robots\\.txt|sitemap\\.xml|favicon\\.ico|opengraph-image.*|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
Phase 7 of the [Sprig overhaul plan](https://hatim-s.github.io/planloft-plans/p/Ad43uXfOzC/). Two commits: `3af8731` architecture (Codex + orchestrator), `decd3f4` design pass (Opus).

**Routes**: public `/` landing; `/maps` dashboard (list, not auto-latest); `/maps/[publicId]` canvas; `/new`; public read-only `/share/[publicId]`; global `app/not-found.tsx`; legacy `/[slug]` 308→`/maps/[slug]` via route handler.

**Rendering**: `cacheComponents: true`. Every page is a static shell + Suspense islands — build table: `◐ /`, `◐ /maps`, `◐ /maps/[publicId]`, `◐ /new`, `◐ /share/[publicId]`, `○` sign-in/up/404. The build initially failed because `ConvexReactClient` construction (randomness) sat in the root layout above every boundary — the provider now mounts inside a Suspense hole in the authenticated group only.

**Share**: new `mindmaps.getShared` (public query, shared-visibility only, uniform "Not found") + `mindmaps.setVisibility` (owner). Read-only mode threads one `readOnly` prop: no autosave, no save pill, no edit/AI popovers, no mutation keybindings; arrow navigation stays. Share toggle UI is deliberately not built yet (P9).

**Design**: landing hero with a token-built SVG mindmap glyph, dashboard card grid with dependency-free relative timestamps, 404 on the auth-shell aesthetic, share top bar with read-only badge. Wordmark/dot-field extracted to shared components; auth pages visually unchanged.

Reviewer notes:
- Unknown single-segment paths (`/whatever`) hit the legacy redirect → `/maps/whatever` → authenticated not-found, rather than 404ing directly. Known trade-off; opinions welcome.
- `/maps` and the share success branch aren't headlessly verifiable here (auth wall / Convex backend down); covered by jsdom tests + build instead.
- 232 tests; build needs zero env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01446fKN7Xz6f47x9ui5eBGB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maps dashboard with loading states, empty states, relative update times, and quick access to create new maps.
  * Added public, read-only shared mindmap pages with clear branding and navigation.
  * Added a global not-found page and permanent redirects for legacy map links.
  * Added read-only viewing support that prevents editing and saving.
  * Added visibility controls for sharing or keeping mindmaps private.

* **Bug Fixes**
  * Improved missing or inaccessible mindmap handling with consistent 404 responses.
  * Updated navigation to use the new `/maps/...` routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->