### PR TITLE
P9: Live canvas sync, thread switcher, share toggle, production runbook

### DIFF
--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -254,7 +254,7 @@ function LoginForm() {
               </div>
             ) : null}
             <Button className="w-full" disabled={isSubmitting} type="submit">
-              {isSubmitting ? "Sending code..." : "Send reset code"}
+              {isSubmitting ? "Sending code…" : "Send reset code"}
             </Button>
           </form>
         ) : null}
@@ -281,7 +281,7 @@ function LoginForm() {
               </div>
             ) : null}
             <Button className="w-full" disabled={isSubmitting} type="submit">
-              {isSubmitting ? "Verifying..." : "Verify code"}
+              {isSubmitting ? "Verifying…" : "Verify code"}
             </Button>
           </form>
         ) : null}
@@ -316,7 +316,7 @@ function LoginForm() {
               </div>
             ) : null}
             <Button className="w-full" disabled={isSubmitting} type="submit">
-              {isSubmitting ? "Saving password..." : "Save new password"}
+              {isSubmitting ? "Saving password…" : "Save new password"}
             </Button>
           </form>
         ) : null}
@@ -395,7 +395,7 @@ function LoginForm() {
           </div>
         ) : null}
         <Button className="w-full" disabled={isSubmitting} type="submit">
-          {isSubmitting ? "Signing in..." : "Sign in"}
+          {isSubmitting ? "Signing in…" : "Sign in"}
         </Button>
       </form>
     </div>

--- a/app/(auth-pages)/sign-up/page.tsx
+++ b/app/(auth-pages)/sign-up/page.tsx
@@ -242,7 +242,7 @@ function SignupForm() {
           onClick={finalizeSignUp}
           type="button"
         >
-          {isSubmitting ? "Finishing..." : "Retry finishing sign up"}
+          {isSubmitting ? "Finishing…" : "Retry finishing sign up"}
         </Button>
       </div>
     );
@@ -296,7 +296,7 @@ function SignupForm() {
             </div>
           ) : null}
           <Button className="w-full" disabled={isSubmitting} type="submit">
-            {isSubmitting ? "Verifying..." : "Verify email"}
+            {isSubmitting ? "Verifying…" : "Verify email"}
           </Button>
         </form>
 
@@ -378,7 +378,7 @@ function SignupForm() {
           </div>
         ) : null}
         <Button className="w-full" disabled={isSubmitting} type="submit">
-          {isSubmitting ? "Signing up..." : "Sign up"}
+          {isSubmitting ? "Signing up…" : "Sign up"}
         </Button>
       </form>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,3 @@
-// import { ThemeSwitcher } from "@/components/theme-switcher";
 // eslint-disable-next-line simple-import-sort/imports
 import "./globals.css";
 

--- a/components/ai-panel/AiPanel.test.tsx
+++ b/components/ai-panel/AiPanel.test.tsx
@@ -68,16 +68,19 @@ vi.mock("./useSprigChat", () => ({
 /** Builds the chat surface state the panel renders against. */
 function createChat(overrides: Partial<UseSprigChat> = {}): UseSprigChat {
   return {
+    activeThreadId: null,
     clearError: vi.fn(),
     error: undefined,
     isHistoryLoading: false,
     isStreaming: false,
     messages: [],
     regenerate: vi.fn(async () => true),
+    selectThread: vi.fn(() => true),
     sendPrompt: vi.fn(async () => true),
     startNewConversation: vi.fn(),
     status: "ready",
     stop: vi.fn(),
+    threads: [],
     ...overrides,
   };
 }

--- a/components/ai-panel/AiPanel.test.tsx
+++ b/components/ai-panel/AiPanel.test.tsx
@@ -30,6 +30,9 @@ import type { UseSprigChat } from "./useSprigChat";
 
 const mocks = vi.hoisted(() => ({
   chat: { current: null as unknown as UseSprigChat },
+  onTurnFinished: {
+    current: null as null | ((message: SprigUIMessage) => Promise<void>),
+  },
   refresh: vi.fn(),
   undoTo: vi.fn(),
 }));
@@ -52,7 +55,14 @@ vi.mock("streamdown", () => ({
 }));
 
 vi.mock("./useSprigChat", () => ({
-  useSprigChat: () => mocks.chat.current,
+  useSprigChat: ({
+    onTurnFinished,
+  }: {
+    onTurnFinished: (message: SprigUIMessage) => Promise<void>;
+  }) => {
+    mocks.onTurnFinished.current = onTurnFinished;
+    return mocks.chat.current;
+  },
 }));
 
 /** Builds the chat surface state the panel renders against. */
@@ -89,6 +99,23 @@ function createTurnWithOperation(): SprigUIMessage {
   };
 }
 
+/** An assistant turn that changed only the RSC-rendered mindmap name. */
+function createRenameTurn(): SprigUIMessage {
+  return {
+    id: "assistant-rename",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-renameMindmap",
+        toolCallId: "tool:rename",
+        state: "output-available",
+        input: { name: "Renamed" },
+        output: { operationId: "operations:rename" },
+      },
+    ] as SprigUIMessage["parts"],
+  };
+}
+
 beforeAll(() => {
   globalThis.ResizeObserver ??= class {
     observe() {}
@@ -100,6 +127,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   mocks.chat.current = createChat();
+  mocks.onTurnFinished.current = null;
   mocks.refresh.mockReset();
   mocks.undoTo.mockReset().mockResolvedValue({ undoneCount: 1, seq: 4 });
 });
@@ -196,6 +224,8 @@ describe("AiPanel", () => {
       expect(screen.getByText("Undone back to this change.")).toBeDefined()
     );
     expect(mocks.refresh).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Reload" })).toBeNull();
+    expect(screen.queryByText(/Reload to see it/)).toBeNull();
   });
 
   it("explains a rejected undo inline instead of failing silently", async () => {
@@ -271,36 +301,66 @@ describe("AiPanel", () => {
     expect(clearError).toHaveBeenCalled();
   });
 
-  it("reloads immediately when the canvas queue is clean", async () => {
-    const user = userEvent.setup();
-    const reload = vi.fn();
-    mocks.chat.current = createChat({ messages: [createTurnWithOperation()] });
-    renderPanel(reload);
+  it("queues an AI-created id to bloom after the next server reseed", async () => {
+    renderPanel();
 
-    await user.click(screen.getByRole("button", { name: "Undo to message 1" }));
-    await user.click(screen.getByRole("button", { name: "Reload" }));
+    await act(async () => {
+      await mocks.onTurnFinished.current?.(createTurnWithOperation());
+    });
 
-    expect(reload).toHaveBeenCalledOnce();
+    expect(panelStore.getState().aiTouchedNodeIds).toEqual([]);
+    expect(panelStore.getState().pendingAiTouchedNodeIds).toEqual(["l-1"]);
+    expect(screen.queryByText(/Reload to see it/)).toBeNull();
   });
 
-  it("attempts a flush and refuses reload when dirty edits cannot save", async () => {
-    const user = userEvent.setup();
-    const reload = vi.fn();
-    const flushNow = vi.fn(async () => false);
-    mocks.chat.current = createChat({ messages: [createTurnWithOperation()] });
-    renderPanel(reload);
+  it("blooms immediately when the AI reseed beat the turn-finished callback", async () => {
+    renderPanel();
 
-    await user.click(screen.getByRole("button", { name: "Undo to message 1" }));
+    act(() => {
+      panelStore.getState().actions.reseedFromServer({
+        updatedAt: 2,
+        nodes: [
+          {
+            nodeId: ROOT_NODE_ID,
+            parentId: null,
+            type: "root",
+            title: "Root",
+            order: 0,
+          },
+          {
+            nodeId: "l-1",
+            parentId: ROOT_NODE_ID,
+            type: "left",
+            title: "Created early",
+            order: 0,
+          },
+        ],
+      });
+    });
+    await act(async () => {
+      await mocks.onTurnFinished.current?.(createTurnWithOperation());
+    });
+
+    expect(panelStore.getState().aiTouchedNodeIds).toEqual(["l-1"]);
+    expect(panelStore.getState().pendingAiTouchedNodeIds).toEqual([]);
+  });
+
+  it("keeps the flush guard before refreshing renamed RSC chrome", async () => {
+    const flushNow = vi.fn(async () => false);
+    renderPanel();
+
     act(() => {
       panelStore
         .getState()
         .actions.onUpdateNode("right-child", { title: "Unsaved" });
       panelStore.getState().actions.registerFlushNow(flushNow);
     });
-    await user.click(screen.getByRole("button", { name: "Reload" }));
+    await act(async () => {
+      await mocks.onTurnFinished.current?.(createRenameTurn());
+    });
 
     expect(flushNow).toHaveBeenCalledOnce();
-    expect(reload).not.toHaveBeenCalled();
+    expect(mocks.refresh).not.toHaveBeenCalled();
     expect(screen.getByRole("alert").textContent).toContain(
       "Couldn't save your latest canvas edits"
     );
@@ -308,11 +368,11 @@ describe("AiPanel", () => {
 });
 
 /** Mounts the panel over a real mindmap store, as the canvas does. */
-function renderPanel(onReload?: () => void): void {
+function renderPanel(): void {
   render(
     <MindmapFlowProvider {...createPanelFixture()}>
       <PanelStoreProbe />
-      <AiPanel onCollapse={vi.fn()} onReload={onReload} />
+      <AiPanel onCollapse={vi.fn()} />
     </MindmapFlowProvider>
   );
 }

--- a/components/ai-panel/AiPanel.test.tsx
+++ b/components/ai-panel/AiPanel.test.tsx
@@ -304,6 +304,21 @@ describe("AiPanel", () => {
     expect(clearError).toHaveBeenCalled();
   });
 
+  it("surfaces the AI configuration failure without offering retry", () => {
+    mocks.chat.current = createChat({
+      error: new Error('{"error":"AI is not configured"}'),
+      status: "error",
+    });
+
+    renderPanel();
+
+    expect(screen.getAllByText("AI is not configured")).toHaveLength(2);
+    expect(screen.getByText("ANTHROPIC_OAUTH_TOKEN")).toBeDefined();
+    expect(screen.getByText("docs/ENV.md")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("queues an AI-created id to bloom after the next server reseed", async () => {
     renderPanel();
 
@@ -321,7 +336,9 @@ describe("AiPanel", () => {
 
     act(() => {
       panelStore.getState().actions.reseedFromServer({
+        name: "Panel fixture",
         updatedAt: 2,
+        visibility: "private",
         nodes: [
           {
             nodeId: ROOT_NODE_ID,

--- a/components/ai-panel/AiPanel.tsx
+++ b/components/ai-panel/AiPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation } from "convex/react";
-import { PanelRightClose, RotateCw, Sprout } from "lucide-react";
+import { PanelRightClose, Sprout } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -17,14 +17,13 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useEventCallback } from "@/hooks/use-event-callback";
 
-import { useMindmapFlow } from "../flow/providers/MindmapFlowProvider";
+import {
+  useMindmapFlow,
+  useMindmapStoreApi,
+} from "../flow/providers/MindmapFlowProvider";
 import { AiChatInput } from "./AiChatInput";
 import { AiMessage } from "./AiMessage";
-import {
-  collectTouchedNodeIds,
-  getToolParts,
-  getUndoOperationId,
-} from "./messages";
+import { collectTouchedNodeIds, getToolParts } from "./messages";
 import { SelectedNodeChip } from "./SelectedNodeChip";
 import { useSprigChat } from "./useSprigChat";
 
@@ -35,48 +34,38 @@ import { useSprigChat } from "./useSprigChat";
  * on the left, mono for anything the machine says about itself, and the bloom
  * accent reserved for the single moment the model is actually working.
  */
-function AiPanel({
-  onCollapse,
-  onReload = () => window.location.reload(),
-}: {
-  onCollapse: () => void;
-  onReload?: () => void;
-}) {
+function AiPanel({ onCollapse }: { onCollapse: () => void }) {
   const router = useRouter();
+  const store = useMindmapStoreApi();
   const mindmapId = useMindmapFlow((state) => state.mindmapDB._id);
   const activeNode = useMindmapFlow((state) => state.activeNode);
   const mindmapNodesMap = useMindmapFlow((state) => state.mindmapNodesMap);
-  const setAiTouchedNodeIds = useMindmapFlow(
-    (state) => state.setAiTouchedNodeIds
-  );
   const pendingOpsLength = useMindmapFlow((state) => state.pendingOps.length);
   const syncState = useMindmapFlow((state) => state.syncState);
   const flushNow = useMindmapFlow((state) => state.actions.flushNow);
   const undoTo = useMutation(api.ops.undoTo);
 
-  // The canvas store is seeded from server props at mount and has no live
-  // subscription, so a server-side edit is announced rather than applied.
-  const [isCanvasStale, setIsCanvasStale] = useState(false);
   const [dismissedNodeId, setDismissedNodeId] = useState<string | null>(null);
-  const [reloadError, setReloadError] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
   const [announcement, setAnnouncement] = useState("");
   const wasStreamingRef = useRef(false);
+  const aiTurnSeededUpdatedAtRef = useRef(store.getState().seededUpdatedAt);
 
   const ensureCanvasEditsSaved = useEventCallback(async () => {
     if (pendingOpsLength === 0 && syncState === "idle") {
-      setReloadError(null);
+      setRefreshError(null);
       return true;
     }
 
     const saved = await flushNow();
     if (saved) {
-      setReloadError(null);
+      setRefreshError(null);
       return true;
     }
 
     const message =
-      "Couldn't save your latest canvas edits — resolve saving before reloading.";
-    setReloadError(message);
+      "Couldn't save your latest canvas edits — resolve saving before refreshing.";
+    setRefreshError(message);
     setAnnouncement(message);
     return false;
   });
@@ -86,11 +75,12 @@ function AiPanel({
       const touchedNodeIds = collectTouchedNodeIds(message);
 
       if (touchedNodeIds.length > 0) {
-        setAiTouchedNodeIds(touchedNodeIds);
-      }
-
-      if (getUndoOperationId(message) !== null) {
-        setIsCanvasStale(true);
+        store
+          .getState()
+          .actions.setAiTouchedNodeIdsAfterReseed(
+            touchedNodeIds,
+            aiTurnSeededUpdatedAtRef.current
+          );
       }
 
       const renamedMindmap = getToolParts(message).some(
@@ -146,7 +136,6 @@ function AiPanel({
       }
 
       await undoTo({ operationId: operationId as Id<"operations"> });
-      setIsCanvasStale(true);
       setAnnouncement("Change undone");
 
       if (shouldRefresh && (await ensureCanvasEditsSaved())) {
@@ -156,14 +145,14 @@ function AiPanel({
     [ensureCanvasEditsSaved, router, undoTo]
   );
 
-  const handleSubmit = useEventCallback((text: string) =>
-    chat.sendPrompt(text, selectedNodeId)
-  );
+  const handleSubmit = useEventCallback((text: string) => {
+    aiTurnSeededUpdatedAtRef.current = store.getState().seededUpdatedAt;
+    return chat.sendPrompt(text, selectedNodeId);
+  });
 
-  const handleReload = useEventCallback(async () => {
-    if (await ensureCanvasEditsSaved()) {
-      onReload();
-    }
+  const handleRegenerate = useEventCallback(() => {
+    aiTurnSeededUpdatedAtRef.current = store.getState().seededUpdatedAt;
+    return chat.regenerate();
   });
 
   return (
@@ -243,7 +232,7 @@ function AiPanel({
             </span>
             <button
               className="font-medium underline underline-offset-2"
-              onClick={() => void chat.regenerate()}
+              onClick={() => void handleRegenerate()}
               type="button"
             >
               Try again
@@ -257,29 +246,12 @@ function AiPanel({
             </button>
           </div>
         )}
-        {reloadError ? (
+        {refreshError ? (
           <div
             className="rounded-md border border-destructive px-2.5 py-2 text-sm font-medium text-destructive"
             role="alert"
           >
-            {reloadError}
-          </div>
-        ) : null}
-        {isCanvasStale ? (
-          <div className="flex items-start gap-2 rounded-md border border-line-strong bg-secondary px-2.5 py-2 text-xs text-muted-foreground">
-            <span className="flex-1">
-              The map changed on the server. Reload to see it on the canvas.
-            </span>
-            <Button
-              className="h-6 gap-1 px-2 text-[11px]"
-              onClick={() => void handleReload()}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              <RotateCw aria-hidden="true" className="!size-3" />
-              Reload
-            </Button>
+            {refreshError}
           </div>
         ) : null}
         {isChipVisible ? (

--- a/components/ai-panel/AiPanel.tsx
+++ b/components/ai-panel/AiPanel.tsx
@@ -25,7 +25,8 @@ import { AiChatInput } from "./AiChatInput";
 import { AiMessage } from "./AiMessage";
 import { collectTouchedNodeIds, getToolParts } from "./messages";
 import { SelectedNodeChip } from "./SelectedNodeChip";
-import { useSprigChat } from "./useSprigChat";
+import { ThreadSwitcher } from "./ThreadSwitcher";
+import { type SprigThreadSummary, useSprigChat } from "./useSprigChat";
 
 /**
  * The Sprig conversation surface.
@@ -155,6 +156,14 @@ function AiPanel({ onCollapse }: { onCollapse: () => void }) {
     return chat.regenerate();
   });
 
+  const handleSelectThread = useEventCallback((thread: SprigThreadSummary) => {
+    // The transcript is replaced without moving focus, so the switch has to be
+    // announced or a screen reader user gets no confirmation it happened.
+    if (chat.selectThread(thread._id)) {
+      setAnnouncement(`Opened conversation: ${thread.title}`);
+    }
+  });
+
   return (
     <section
       aria-label="Sprig assistant"
@@ -172,26 +181,34 @@ function AiPanel({ onCollapse }: { onCollapse: () => void }) {
         {chat.isStreaming ? (
           <span aria-hidden="true" className="sprig-bloom-dot" />
         ) : null}
-        <Button
-          className="ml-auto h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
-          disabled={chat.isStreaming || chat.messages.length === 0}
-          onClick={chat.startNewConversation}
-          size="sm"
-          type="button"
-          variant="ghost"
-        >
-          New conversation
-        </Button>
-        <Button
-          aria-label="Collapse Sprig panel"
-          className="size-7 rounded-md text-muted-foreground hover:text-foreground"
-          onClick={onCollapse}
-          size="icon"
-          type="button"
-          variant="ghost"
-        >
-          <PanelRightClose aria-hidden="true" className="!size-4" />
-        </Button>
+        <div className="ml-auto flex items-center gap-1">
+          <ThreadSwitcher
+            activeThreadId={chat.activeThreadId}
+            isStreaming={chat.isStreaming}
+            onSelect={handleSelectThread}
+            threads={chat.threads}
+          />
+          <Button
+            className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+            disabled={chat.isStreaming || chat.messages.length === 0}
+            onClick={chat.startNewConversation}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            New conversation
+          </Button>
+          <Button
+            aria-label="Collapse Sprig panel"
+            className="size-7 rounded-md text-muted-foreground hover:text-foreground"
+            onClick={onCollapse}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <PanelRightClose aria-hidden="true" className="!size-4" />
+          </Button>
+        </div>
       </div>
 
       <Conversation className="min-h-0 flex-1" aria-label="Conversation">

--- a/components/ai-panel/AiPanel.tsx
+++ b/components/ai-panel/AiPanel.tsx
@@ -28,6 +28,15 @@ import { SelectedNodeChip } from "./SelectedNodeChip";
 import { ThreadSwitcher } from "./ThreadSwitcher";
 import { type SprigThreadSummary, useSprigChat } from "./useSprigChat";
 
+const AI_NOT_CONFIGURED_MESSAGE = "AI is not configured";
+
+/**
+ * Detects the route's known 503 body in the error text exposed by the AI SDK.
+ */
+function isAIConfigurationError(error: Error | undefined): boolean {
+  return error?.message.includes(AI_NOT_CONFIGURED_MESSAGE) ?? false;
+}
+
 /**
  * The Sprig conversation surface.
  *
@@ -99,6 +108,7 @@ function AiPanel({ onCollapse }: { onCollapse: () => void }) {
   );
 
   const chat = useSprigChat({ mindmapId, onTurnFinished: handleTurnFinished });
+  const hasAIConfigurationError = isAIConfigurationError(chat.error);
 
   const activeNodeTitle =
     activeNode === null
@@ -126,7 +136,11 @@ function AiPanel({ onCollapse }: { onCollapse: () => void }) {
 
   useEffect(() => {
     if (chat.error !== undefined) {
-      setAnnouncement("Sprig could not finish that. Try again.");
+      setAnnouncement(
+        isAIConfigurationError(chat.error)
+          ? "AI is not configured"
+          : "Sprig could not finish that. Try again."
+      );
     }
   }, [chat.error]);
 
@@ -239,7 +253,18 @@ function AiPanel({ onCollapse }: { onCollapse: () => void }) {
       </Conversation>
 
       <div className="flex flex-col gap-2 border-t border-border p-3">
-        {chat.error === undefined ? null : (
+        {chat.error === undefined ? null : hasAIConfigurationError ? (
+          <div
+            className="rounded-md border border-line-strong bg-secondary px-2.5 py-2 text-sm text-muted-foreground"
+            role="status"
+          >
+            <p className="font-medium text-foreground">AI is not configured</p>
+            <p className="mt-1 text-xs leading-relaxed">
+              Set <code>ANTHROPIC_OAUTH_TOKEN</code> as described in{" "}
+              <code>docs/ENV.md</code>, then reload.
+            </p>
+          </div>
+        ) : (
           <div
             className="flex items-start gap-2 rounded-md border border-destructive px-2.5 py-2 text-sm font-medium text-destructive"
             role="alert"
@@ -288,4 +313,4 @@ function AiPanel({ onCollapse }: { onCollapse: () => void }) {
   );
 }
 
-export { AiPanel };
+export { AiPanel, isAIConfigurationError };

--- a/components/ai-panel/ThreadSwitcher.test.tsx
+++ b/components/ai-panel/ThreadSwitcher.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -97,17 +97,20 @@ describe("ThreadSwitcher", () => {
     await user.click(screen.getByRole("button", { name: "Conversations" }));
 
     const items = screen.getAllByRole("menuitemradio");
-    items[0].focus();
+    await waitFor(() => expect(document.activeElement).toBe(items[0]));
+    expect(items.map((item) => item.tabIndex)).toEqual([0, -1]);
     await user.keyboard("{ArrowDown}");
 
     expect(document.activeElement).toBe(items[1]);
+    expect(items.map((item) => item.tabIndex)).toEqual([-1, 0]);
 
     await user.keyboard("{Home}");
 
     expect(document.activeElement).toBe(items[0]);
   });
 
-  it("refuses to open while a turn is streaming", () => {
+  it("keeps the paused trigger focusable and refuses to open", async () => {
+    const user = userEvent.setup();
     render(
       <ThreadSwitcher
         activeThreadId="threads:new"
@@ -121,8 +124,52 @@ describe("ThreadSwitcher", () => {
       name: "Conversations — paused while Sprig is working",
     });
 
-    expect(trigger).toHaveProperty("disabled", true);
+    expect(trigger).toHaveProperty("disabled", false);
+    expect(trigger.getAttribute("aria-disabled")).toBe("true");
+    trigger.focus();
+    await user.click(trigger);
+    expect(document.activeElement).toBe(trigger);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes an open menu and returns focus when streaming starts", async () => {
+    const user = userEvent.setup();
+    const view = render(
+      <ThreadSwitcher
+        activeThreadId="threads:old"
+        isStreaming={false}
+        onSelect={vi.fn()}
+        threads={THREADS}
+      />
+    );
+
+    const trigger = screen.getByRole("button", { name: "Conversations" });
+    await user.click(trigger);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("menuitemradio", {
+          name: "First pass at the outline",
+        })
+      )
+    );
+
+    view.rerender(
+      <ThreadSwitcher
+        activeThreadId="threads:old"
+        isStreaming
+        onSelect={vi.fn()}
+        threads={THREADS}
+      />
+    );
+
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", {
+          name: "Conversations — paused while Sprig is working",
+        })
+      )
+    );
   });
 
   it("invites a first message when nothing has been saved yet", async () => {

--- a/components/ai-panel/ThreadSwitcher.test.tsx
+++ b/components/ai-panel/ThreadSwitcher.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ThreadSwitcher } from "./ThreadSwitcher";
+import type { SprigThreadSummary } from "./useSprigChat";
+
+/** Two persisted threads, already ordered the way the hook hands them over. */
+const THREADS: SprigThreadSummary[] = [
+  {
+    _id: "threads:new" as SprigThreadSummary["_id"],
+    _creationTime: 2,
+    title: "Reshuffle the launch branch",
+  },
+  {
+    _id: "threads:old" as SprigThreadSummary["_id"],
+    _creationTime: 1,
+    title: "First pass at the outline",
+  },
+];
+
+beforeAll(() => {
+  // Radix positions the popover with floating-ui, which jsdom cannot observe.
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+afterEach(cleanup);
+
+describe("ThreadSwitcher", () => {
+  it("lists every conversation and marks the open one", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThreadSwitcher
+        activeThreadId="threads:new"
+        isStreaming={false}
+        onSelect={vi.fn()}
+        threads={THREADS}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Conversations" }));
+
+    const items = screen.getAllByRole("menuitemradio");
+
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Reshuffle the launch branch",
+      "First pass at the outline",
+    ]);
+    expect(items[0].getAttribute("aria-checked")).toBe("true");
+    expect(items[1].getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("hands the chosen conversation back and closes", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <ThreadSwitcher
+        activeThreadId="threads:new"
+        isStreaming={false}
+        onSelect={onSelect}
+        threads={THREADS}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Conversations" }));
+    await user.click(
+      screen.getByRole("menuitemradio", { name: "First pass at the outline" })
+    );
+
+    expect(onSelect).toHaveBeenCalledWith(THREADS[1]);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("moves focus between rows with the arrow keys", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThreadSwitcher
+        activeThreadId="threads:new"
+        isStreaming={false}
+        onSelect={vi.fn()}
+        threads={THREADS}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Conversations" }));
+
+    const items = screen.getAllByRole("menuitemradio");
+    items[0].focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(document.activeElement).toBe(items[1]);
+
+    await user.keyboard("{Home}");
+
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it("refuses to open while a turn is streaming", () => {
+    render(
+      <ThreadSwitcher
+        activeThreadId="threads:new"
+        isStreaming
+        onSelect={vi.fn()}
+        threads={THREADS}
+      />
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Conversations — paused while Sprig is working",
+    });
+
+    expect(trigger).toHaveProperty("disabled", true);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("invites a first message when nothing has been saved yet", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThreadSwitcher
+        activeThreadId={null}
+        isStreaming={false}
+        onSelect={vi.fn()}
+        threads={[]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Conversations" }));
+
+    expect(
+      screen.getByText("No conversations yet. Send a message to start one.")
+    ).toBeDefined();
+  });
+});

--- a/components/ai-panel/ThreadSwitcher.test.tsx
+++ b/components/ai-panel/ThreadSwitcher.test.tsx
@@ -109,6 +109,37 @@ describe("ThreadSwitcher", () => {
     expect(document.activeElement).toBe(items[0]);
   });
 
+  it("does not reclaim focus when the live thread list updates while open", async () => {
+    const user = userEvent.setup();
+    const view = render(
+      <ThreadSwitcher
+        activeThreadId="threads:new"
+        isStreaming={false}
+        onSelect={vi.fn()}
+        threads={THREADS}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Conversations" }));
+    await user.keyboard("{ArrowDown}");
+
+    const oldThread = screen.getByRole("menuitemradio", {
+      name: "First pass at the outline",
+    });
+    expect(document.activeElement).toBe(oldThread);
+
+    view.rerender(
+      <ThreadSwitcher
+        activeThreadId="threads:new"
+        isStreaming={false}
+        onSelect={vi.fn()}
+        threads={[...THREADS]}
+      />
+    );
+
+    expect(document.activeElement).toBe(oldThread);
+  });
+
   it("keeps the paused trigger focusable and refuses to open", async () => {
     const user = userEvent.setup();
     render(

--- a/components/ai-panel/ThreadSwitcher.tsx
+++ b/components/ai-panel/ThreadSwitcher.tsx
@@ -44,6 +44,14 @@ function ThreadSwitcher({
   );
   const listRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const previousIsOpenRef = useRef(isOpen);
+  const threadsRef = useRef(threads);
+  const activeThreadIdRef = useRef(activeThreadId);
+
+  // Keep the initial-focus effect tied only to opening, not to live-query
+  // list updates that can arrive while someone is moving through the menu.
+  threadsRef.current = threads;
+  activeThreadIdRef.current = activeThreadId;
 
   const triggerLabel = isStreaming
     ? "Conversations — paused while Sprig is working"
@@ -59,19 +67,29 @@ function ThreadSwitcher({
   }, [isOpen, isStreaming]);
 
   useEffect(() => {
-    if (!isOpen || threads === undefined || threads.length === 0) {
+    const wasOpen = previousIsOpenRef.current;
+    previousIsOpenRef.current = isOpen;
+
+    if (!isOpen || wasOpen) {
+      return;
+    }
+
+    const currentThreads = threadsRef.current;
+    if (currentThreads === undefined || currentThreads.length === 0) {
       return;
     }
 
     const initialThread =
-      threads.find((thread) => thread._id === activeThreadId) ?? threads[0];
+      currentThreads.find(
+        (thread) => thread._id === activeThreadIdRef.current
+      ) ?? currentThreads[0];
     setRovingThreadId(initialThread._id);
     listRef.current
       ?.querySelector<HTMLButtonElement>(
         `[data-thread-id="${initialThread._id}"]`
       )
       ?.focus();
-  }, [activeThreadId, isOpen, threads]);
+  }, [isOpen]);
 
   /** Moves focus between rows without letting the popover scroll under it. */
   function handleListKeyDown(event: KeyboardEvent<HTMLDivElement>) {

--- a/components/ai-panel/ThreadSwitcher.tsx
+++ b/components/ai-panel/ThreadSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, MessagesSquare } from "lucide-react";
-import { type KeyboardEvent, useRef, useState } from "react";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -39,11 +39,39 @@ function ThreadSwitcher({
   threads,
 }: ThreadSwitcherProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [rovingThreadId, setRovingThreadId] = useState<string | null>(
+    activeThreadId
+  );
   const listRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
 
   const triggerLabel = isStreaming
     ? "Conversations — paused while Sprig is working"
     : "Conversations";
+
+  useEffect(() => {
+    if (!isStreaming || !isOpen) {
+      return;
+    }
+
+    setIsOpen(false);
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, [isOpen, isStreaming]);
+
+  useEffect(() => {
+    if (!isOpen || threads === undefined || threads.length === 0) {
+      return;
+    }
+
+    const initialThread =
+      threads.find((thread) => thread._id === activeThreadId) ?? threads[0];
+    setRovingThreadId(initialThread._id);
+    listRef.current
+      ?.querySelector<HTMLButtonElement>(
+        `[data-thread-id="${initialThread._id}"]`
+      )
+      ?.focus();
+  }, [activeThreadId, isOpen, threads]);
 
   /** Moves focus between rows without letting the popover scroll under it. */
   function handleListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
@@ -76,22 +104,45 @@ function ThreadSwitcher({
             ? (currentIndex + 1) % items.length
             : (currentIndex - 1 + items.length) % items.length;
 
+    setRovingThreadId(items[nextIndex]?.dataset.threadId ?? null);
     items[nextIndex]?.focus();
   }
 
   /** Closes first so focus returns to the trigger, then hands off the choice. */
   function handleSelect(thread: SprigThreadSummary) {
+    if (isStreaming) {
+      return;
+    }
+
     setIsOpen(false);
     onSelect(thread);
   }
 
+  /** Keeps the controlled popover closed while the active turn owns the panel. */
+  function handleOpenChange(nextIsOpen: boolean): void {
+    if (nextIsOpen && isStreaming) {
+      return;
+    }
+
+    setIsOpen(nextIsOpen);
+  }
+
   return (
-    <Popover onOpenChange={setIsOpen} open={isOpen}>
+    <Popover onOpenChange={handleOpenChange} open={isOpen}>
       <PopoverTrigger asChild>
         <Button
+          aria-disabled={isStreaming}
           aria-label={triggerLabel}
-          className="size-7 rounded-md text-muted-foreground hover:text-foreground"
-          disabled={isStreaming}
+          className={cn(
+            "size-7 rounded-md text-muted-foreground hover:text-foreground",
+            isStreaming && "cursor-not-allowed opacity-60"
+          )}
+          onClick={(event) => {
+            if (isStreaming) {
+              event.preventDefault();
+            }
+          }}
+          ref={triggerRef}
           size="icon"
           title={triggerLabel}
           type="button"
@@ -133,9 +184,11 @@ function ThreadSwitcher({
                     "hover:bg-accent hover:text-accent-foreground",
                     isActive ? "text-foreground" : "text-muted-foreground"
                   )}
+                  data-thread-id={thread._id}
                   key={thread._id}
                   onClick={() => handleSelect(thread)}
                   role="menuitemradio"
+                  tabIndex={thread._id === rovingThreadId ? 0 : -1}
                   title={thread.title}
                   type="button"
                 >

--- a/components/ai-panel/ThreadSwitcher.tsx
+++ b/components/ai-panel/ThreadSwitcher.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Check, MessagesSquare } from "lucide-react";
+import { type KeyboardEvent, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import type { SprigThreadSummary } from "./useSprigChat";
+
+/** Keys the menu handles itself so arrow navigation matches a real menu. */
+const ROVING_KEYS = new Set(["ArrowDown", "ArrowUp", "Home", "End"]);
+
+type ThreadSwitcherProps = {
+  activeThreadId: string | null;
+  /** Switching mid-stream is refused by the hook, so the trigger says so. */
+  isStreaming: boolean;
+  onSelect: (thread: SprigThreadSummary) => void;
+  threads: SprigThreadSummary[] | undefined;
+};
+
+/**
+ * The past conversations on this map, one click from the panel header.
+ *
+ * A menu rather than a listbox: choosing a row is an action that replaces what
+ * the panel is showing, not a form value being edited. The rows are
+ * `menuitemradio` so the reader hears which conversation is already open, and
+ * the list owns arrow/Home/End roving because a `role="menu"` promises it.
+ */
+function ThreadSwitcher({
+  activeThreadId,
+  isStreaming,
+  onSelect,
+  threads,
+}: ThreadSwitcherProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const triggerLabel = isStreaming
+    ? "Conversations — paused while Sprig is working"
+    : "Conversations";
+
+  /** Moves focus between rows without letting the popover scroll under it. */
+  function handleListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (!ROVING_KEYS.has(event.key)) {
+      return;
+    }
+
+    const items = Array.from(
+      listRef.current?.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitemradio"]'
+      ) ?? []
+    );
+
+    if (items.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const currentIndex = items.indexOf(
+      document.activeElement as HTMLButtonElement
+    );
+    const lastIndex = items.length - 1;
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? lastIndex
+          : event.key === "ArrowDown"
+            ? (currentIndex + 1) % items.length
+            : (currentIndex - 1 + items.length) % items.length;
+
+    items[nextIndex]?.focus();
+  }
+
+  /** Closes first so focus returns to the trigger, then hands off the choice. */
+  function handleSelect(thread: SprigThreadSummary) {
+    setIsOpen(false);
+    onSelect(thread);
+  }
+
+  return (
+    <Popover onOpenChange={setIsOpen} open={isOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          aria-label={triggerLabel}
+          className="size-7 rounded-md text-muted-foreground hover:text-foreground"
+          disabled={isStreaming}
+          size="icon"
+          title={triggerLabel}
+          type="button"
+          variant="ghost"
+        >
+          <MessagesSquare aria-hidden="true" className="!size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72 p-0" sideOffset={8}>
+        <p className="border-b border-border px-3 py-2 font-mono text-[11px] uppercase tracking-[0.09em] text-muted-foreground">
+          Conversations
+        </p>
+        {threads === undefined ? (
+          <p className="px-3 py-3 text-sm text-muted-foreground" role="status">
+            Loading conversations…
+          </p>
+        ) : threads.length === 0 ? (
+          <p className="px-3 py-3 text-sm text-muted-foreground">
+            No conversations yet. Send a message to start one.
+          </p>
+        ) : (
+          <div
+            aria-label="Conversations"
+            className="scrollbar-styles max-h-64 overflow-y-auto p-1"
+            onKeyDown={handleListKeyDown}
+            ref={listRef}
+            role="menu"
+            tabIndex={-1}
+          >
+            {threads.map((thread) => {
+              const isActive = thread._id === activeThreadId;
+
+              return (
+                <button
+                  aria-checked={isActive}
+                  className={cn(
+                    "flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                    "transition-colors duration-200 ease-organic motion-reduce:transition-none",
+                    "hover:bg-accent hover:text-accent-foreground",
+                    isActive ? "text-foreground" : "text-muted-foreground"
+                  )}
+                  key={thread._id}
+                  onClick={() => handleSelect(thread)}
+                  role="menuitemradio"
+                  title={thread.title}
+                  type="button"
+                >
+                  <Check
+                    aria-hidden="true"
+                    className={cn(
+                      "mt-0.5 size-3.5 shrink-0",
+                      isActive ? "text-primary" : "opacity-0"
+                    )}
+                  />
+                  <span className="min-w-0 flex-1 truncate">
+                    {thread.title}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export { ThreadSwitcher };

--- a/components/ai-panel/useSprigChat.test.tsx
+++ b/components/ai-panel/useSprigChat.test.tsx
@@ -124,6 +124,90 @@ describe("useSprigChat", () => {
     await expect(sendResult).resolves.toBe(true);
   });
 
+  it("replays a chosen thread and refuses to switch mid-stream", async () => {
+    mocks.threads = [
+      { _id: "threads:old", mindmapId: "mindmaps:1", title: "Old" },
+      { _id: "threads:new", mindmapId: "mindmaps:1", title: "New" },
+    ];
+    mocks.history = [
+      {
+        _id: "messages:new",
+        role: "assistant",
+        content: [{ type: "text", text: "Newest reply" }],
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useSprigChat({
+        mindmapId: "mindmaps:1" as Id<"mindmaps">,
+        onTurnFinished: vi.fn(),
+      })
+    );
+
+    await waitFor(() => expect(result.current.isHistoryLoading).toBe(false));
+
+    // Convex lists oldest-first; the switcher reads the reverse.
+    expect(result.current.threads?.map((thread) => thread.title)).toEqual([
+      "New",
+      "Old",
+    ]);
+    expect(result.current.activeThreadId).toBe("threads:new");
+
+    let didSwitch: boolean | undefined;
+    let sendResult!: Promise<boolean>;
+    act(() => {
+      sendResult = result.current.sendPrompt("Keep going", null);
+    });
+    act(() => {
+      didSwitch = result.current.selectThread("threads:old" as Id<"threads">);
+    });
+
+    expect(didSwitch).toBe(false);
+    expect(result.current.activeThreadId).toBe("threads:new");
+
+    act(() => {
+      mocks.finish?.({
+        message: {
+          id: "assistant:new",
+          role: "assistant",
+          parts: [{ type: "text", text: "Fresh reply" }],
+        },
+        isAbort: false,
+        isError: false,
+      });
+    });
+    await expect(sendResult).resolves.toBe(true);
+
+    mocks.chat.setMessages.mockClear();
+    mocks.history = [
+      {
+        _id: "messages:old",
+        role: "assistant",
+        content: [{ type: "text", text: "Older reply" }],
+      },
+    ];
+    act(() => {
+      didSwitch = result.current.selectThread("threads:old" as Id<"threads">);
+    });
+
+    expect(didSwitch).toBe(true);
+    expect(result.current.activeThreadId).toBe("threads:old");
+    // The transcript is emptied at once so the previous thread never lingers
+    // under the new one's loading state.
+    expect(mocks.chat.setMessages).toHaveBeenNthCalledWith(1, []);
+    await waitFor(() =>
+      expect(mocks.chat.setMessages.mock.lastCall?.[0]).toMatchObject([
+        { parts: [{ text: "Older reply" }] },
+      ])
+    );
+
+    // Re-selecting the open thread is a no-op rather than a wasted replay.
+    act(() => {
+      didSwitch = result.current.selectThread("threads:old" as Id<"threads">);
+    });
+    expect(didSwitch).toBe(false);
+  });
+
   it("truncates older messages in the client transport body", () => {
     renderHook(() =>
       useSprigChat({

--- a/components/ai-panel/useSprigChat.ts
+++ b/components/ai-panel/useSprigChat.ts
@@ -3,7 +3,7 @@
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useQuery } from "convex/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -22,14 +22,27 @@ type UseSprigChatOptions = {
   onTurnFinished: (message: SprigUIMessage) => void;
 };
 
+/** The fields of a persisted thread the switcher needs to list it. */
+type SprigThreadSummary = {
+  _id: Id<"threads">;
+  _creationTime: number;
+  title: string;
+};
+
 type UseSprigChat = {
   messages: SprigUIMessage[];
   status: ReturnType<typeof useChat<SprigUIMessage>>["status"];
   error: Error | undefined;
   isStreaming: boolean;
   isHistoryLoading: boolean;
+  /** Every thread on this map, newest first; `undefined` until Convex answers. */
+  threads: SprigThreadSummary[] | undefined;
+  /** The thread the panel is addressing, or `null` for an unsent fresh one. */
+  activeThreadId: Id<"threads"> | null;
   clearError: () => void;
   regenerate: () => Promise<boolean>;
+  /** Returns `false` when the switch was refused (mid-stream, or a no-op). */
+  selectThread: (threadId: Id<"threads">) => boolean;
   sendPrompt: (text: string, selectedNodeId: string | null) => Promise<boolean>;
   startNewConversation: () => void;
   stop: () => void;
@@ -54,6 +67,13 @@ function useSprigChat({
   const pendingResultRef = useRef<((succeeded: boolean) => void) | null>(null);
   const lastRequestBodyRef = useRef<Record<string, string>>({ mindmapId });
 
+  // `undefined` means "not resolved yet"; `null` means "no thread is addressed".
+  // Declared above the transport because the fetch seam below adopts the id the
+  // route minted for a brand-new conversation.
+  const [historyThreadId, setHistoryThreadId] = useState<
+    Id<"threads"> | null | undefined
+  >(undefined);
+
   const [transport] = useState(
     () =>
       new DefaultChatTransport<SprigUIMessage>({
@@ -69,6 +89,12 @@ function useSprigChat({
           if (threadId !== null && threadId.length > 0) {
             threadIdRef.current = threadId;
             freshThreadIntentRef.current = false;
+            // A fresh conversation only learns its thread id here, so adopt it
+            // as the active one — without ever overwriting a thread the reader
+            // has explicitly opened.
+            setHistoryThreadId(
+              (current) => current ?? (threadId as Id<"threads">)
+            );
           }
 
           return response;
@@ -112,10 +138,6 @@ function useSprigChat({
   });
   const { setMessages } = chat;
 
-  // `undefined` means "not resolved yet"; `null` means "this map has no thread".
-  const [historyThreadId, setHistoryThreadId] = useState<
-    Id<"threads"> | null | undefined
-  >(undefined);
   const threads = useQuery(api.threads.listThreads, { mindmapId });
   const historyMessages = useQuery(
     api.threads.listMessages,
@@ -164,6 +186,15 @@ function useSprigChat({
   const isHistoryLoading =
     !hasReplayedHistoryRef.current &&
     (historyThreadId === undefined || historyMessages === undefined);
+
+  // Convex lists threads oldest-first; the switcher reads most-recent-first.
+  const orderedThreads = useMemo(
+    () =>
+      threads === undefined
+        ? undefined
+        : [...(threads as SprigThreadSummary[])].reverse(),
+    [threads]
+  );
 
   const sendPrompt = useEventCallback(
     async (text: string, selectedNodeId: string | null) => {
@@ -235,6 +266,31 @@ function useSprigChat({
     return result;
   });
 
+  /**
+   * Points the panel at another persisted thread and replays it.
+   *
+   * Switching mid-stream is refused rather than queued: the in-flight turn is
+   * still addressed to the previous thread and would land in the wrong
+   * conversation, so the caller is told the switch did not happen.
+   */
+  const selectThread = useEventCallback((threadId: Id<"threads">) => {
+    if (isActiveStreamRef.current || threadId === historyThreadId) {
+      return false;
+    }
+
+    // Replay is allowed once per conversation, so re-arming it is what makes
+    // the next `listMessages` result land in the transcript.
+    hasReplayedHistoryRef.current = false;
+    freshThreadIntentRef.current = false;
+    threadIdRef.current = threadId;
+    lastRequestBodyRef.current = { mindmapId };
+    chat.clearError();
+    setMessages([]);
+    setHistoryThreadId(threadId);
+
+    return true;
+  });
+
   const startNewConversation = useEventCallback(() => {
     // Nothing is deleted: the previous thread stays in Convex, this panel just
     // stops addressing it. P9 owns the thread switcher that can return to it.
@@ -260,12 +316,15 @@ function useSprigChat({
     error: chat.error,
     isStreaming,
     isHistoryLoading,
+    threads: orderedThreads,
+    activeThreadId: historyThreadId ?? null,
     clearError: chat.clearError,
     regenerate,
+    selectThread,
     sendPrompt,
     startNewConversation,
     stop,
   };
 }
 
-export { type UseSprigChat, useSprigChat };
+export { type SprigThreadSummary, type UseSprigChat, useSprigChat };

--- a/components/flow/Flow.test.tsx
+++ b/components/flow/Flow.test.tsx
@@ -184,7 +184,9 @@ describe("Flow", () => {
         .getState()
         .actions.setAiTouchedNodeIdsAfterReseed(["l-ai-created"], 1);
       store.getState().actions.reseedFromServer({
+        name: MINDMAP.name,
         updatedAt: 2,
+        visibility: MINDMAP.visibility,
         nodes: [
           ...NODES,
           {
@@ -199,6 +201,34 @@ describe("Flow", () => {
     });
 
     expect(view.getByTestId("bloomed-nodes").textContent).toBe("l-ai-created");
+  });
+
+  it("re-dispatches the active selection after a server reseed", () => {
+    const view = render(
+      <Flow
+        mindmap={{ ...MINDMAP, isOwner: true }}
+        nodes={NODES}
+        readOnly={false}
+      />
+    );
+
+    act(() => store.getState().setActiveNode("left-child"));
+    expect(view.getByTestId("selected-count").textContent).toBe("1");
+
+    act(() => {
+      store.getState().actions.reseedFromServer({
+        name: MINDMAP.name,
+        nodes: NODES.map((node) =>
+          node.nodeId === "left-child"
+            ? { ...node, title: "Server title" }
+            : node
+        ),
+        updatedAt: 2,
+        visibility: MINDMAP.visibility,
+      });
+    });
+
+    expect(view.getByTestId("selected-count").textContent).toBe("1");
   });
 });
 

--- a/components/flow/Flow.test.tsx
+++ b/components/flow/Flow.test.tsx
@@ -37,7 +37,12 @@ vi.mock("@/components/ai-panel/AiPanelLayout", () => ({
   ),
 }));
 
-// Autosave owns a Convex mutation that this suite has no client for.
+// Autosave and the share control own Convex mutations that this suite has no
+// client for; the canvas behaviour under test does not depend on either.
+vi.mock("convex/react", () => ({
+  useMutation: () => vi.fn(),
+}));
+
 vi.mock("./hooks/useMindmapSync", () => ({
   useMindmapSync: () => {},
 }));

--- a/components/flow/Flow.test.tsx
+++ b/components/flow/Flow.test.tsx
@@ -42,6 +42,10 @@ vi.mock("./hooks/useMindmapSync", () => ({
   useMindmapSync: () => {},
 }));
 
+vi.mock("./hooks/useMindmapLiveSync", () => ({
+  useMindmapLiveSync: () => {},
+}));
+
 vi.mock("@xyflow/react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@xyflow/react")>();
 
@@ -159,6 +163,37 @@ describe("Flow", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("blooms an AI-created node after the server reseed mounts it", () => {
+    const view = render(
+      <Flow
+        mindmap={{ ...MINDMAP, isOwner: true }}
+        nodes={NODES}
+        readOnly={false}
+      />
+    );
+
+    act(() => {
+      store
+        .getState()
+        .actions.setAiTouchedNodeIdsAfterReseed(["l-ai-created"], 1);
+      store.getState().actions.reseedFromServer({
+        updatedAt: 2,
+        nodes: [
+          ...NODES,
+          {
+            nodeId: "l-ai-created",
+            parentId: "root",
+            type: "left",
+            title: "AI created",
+            order: 0,
+          },
+        ],
+      });
+    });
+
+    expect(view.getByTestId("bloomed-nodes").textContent).toBe("l-ai-created");
   });
 });
 

--- a/components/flow/Flow.tsx
+++ b/components/flow/Flow.tsx
@@ -20,6 +20,7 @@ import { cn } from "@/lib/utils";
 import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 import { Stack } from "../ui/stack";
 import { SaveMindmap } from "./components/SaveMindmap";
+import { ShareMindmap } from "./components/ShareMindmap";
 import { useMindmapLiveSync } from "./hooks/useMindmapLiveSync";
 import { useMindmapNavigation } from "./hooks/useMindmapNavigation";
 import { useMindmapSync } from "./hooks/useMindmapSync";
@@ -204,7 +205,13 @@ export function MindmapFlow() {
       {readOnly ? null : (
         <>
           <MindmapSynchronization />
-          <SaveMindmap />
+          {/* One right rail below the floating header: sharing is an action,
+              the save pill is ambient status, and they share a row so neither
+              can drift as the pill's copy changes length. */}
+          <div className="absolute top-16 right-[var(--theme-switcher-inset)] z-10 flex items-center gap-2">
+            <ShareMindmap />
+            <SaveMindmap />
+          </div>
         </>
       )}
       <ReactFlow

--- a/components/flow/Flow.tsx
+++ b/components/flow/Flow.tsx
@@ -60,6 +60,7 @@ export function MindmapFlow() {
   const mindmapNodesMap = useMindmapFlow((state) => state.mindmapNodesMap);
   const leveledNodes = useMindmapFlow((state) => state.leveledNodes);
   const activeNode = useMindmapFlow((state) => state.activeNode);
+  const reseedCount = useMindmapFlow((state) => state.reseedCount);
   const setActiveNode = useMindmapFlow((state) => state.setActiveNode);
   const selectedNode = useMindmapFlow((state) => state.selectedNode);
   const aiEditNode = useMindmapFlow((state) => state.aiEditNode);
@@ -151,6 +152,12 @@ export function MindmapFlow() {
 
   const reactflowInstance = useReactFlow();
 
+  // Server reseeds replace every XYFlow node object, including its transient
+  // selected flag. Forget the prior dispatch so the active node is reselected.
+  useEffect(() => {
+    prevActiveNode.current = null;
+  }, [reseedCount]);
+
   // sync active node with the flow
   useEffect(() => {
     if (activeNode) {
@@ -198,7 +205,7 @@ export function MindmapFlow() {
           selected: false,
         },
       ]);
-  }, [activeNode, handleNodeChange, reactflowInstance]);
+  }, [activeNode, handleNodeChange, reactflowInstance, reseedCount]);
 
   return (
     <Stack className="h-full w-full flex-1">

--- a/components/flow/Flow.tsx
+++ b/components/flow/Flow.tsx
@@ -20,16 +20,9 @@ import { cn } from "@/lib/utils";
 import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 import { Stack } from "../ui/stack";
 import { SaveMindmap } from "./components/SaveMindmap";
+import { useMindmapLiveSync } from "./hooks/useMindmapLiveSync";
 import { useMindmapNavigation } from "./hooks/useMindmapNavigation";
 import { useMindmapSync } from "./hooks/useMindmapSync";
-import { INITIAL_EDGES, INITIAL_NODES } from "./initialNodesAndEdges";
-import { createFlowEdgeFromPartialBaseFlowEdge } from "./mindmap/createEdge";
-import { createBaseFlowNodeFromPartialBaseFlowNode } from "./mindmap/createNode";
-import {
-  PartialBaseFlowEdge,
-  PartialBaseFlowNode,
-  transformConvexNodesToFlowNodesAndEdges,
-} from "./mindmap/mindmapNodesToFlowNodes";
 import { LeftNode, RightNode, RootNode } from "./nodes";
 import {
   MindmapFlowProvider,
@@ -52,9 +45,10 @@ const nodeTypes: XYNodeTypes = {
   right: RightNode,
 };
 
-/** Mounts autosave only for an editable canvas. */
-function MindmapAutosave() {
+/** Mounts outbound autosave and inbound live reconciliation for an owner. */
+function MindmapSynchronization() {
   useMindmapSync();
+  useMindmapLiveSync();
   return null;
 }
 
@@ -209,7 +203,7 @@ export function MindmapFlow() {
     <Stack className="h-full w-full flex-1">
       {readOnly ? null : (
         <>
-          <MindmapAutosave />
+          <MindmapSynchronization />
           <SaveMindmap />
         </>
       )}
@@ -258,24 +252,6 @@ export default function Flow({
   nodes: MindmapNodeProjection[];
   readOnly?: boolean;
 }) {
-  const initialGraph = useMemo(
-    () => transformConvexNodesToFlowNodesAndEdges(nodes),
-    [nodes]
-  );
-  const initialNodes = useMemo(
-    () =>
-      initialGraph.nodes.map((node) =>
-        createBaseFlowNodeFromPartialBaseFlowNode(node as PartialBaseFlowNode)
-      ),
-    [initialGraph.nodes]
-  );
-
-  const initialEdges = useMemo(() => {
-    return initialGraph.edges.map((edge) =>
-      createFlowEdgeFromPartialBaseFlowEdge(edge as PartialBaseFlowEdge)
-    );
-  }, [initialGraph.edges]);
-
   return (
     <ReactFlowProvider>
       {/* This key remounts the prop-seeded store when client navigation loads another mindmap. */}
@@ -283,8 +259,7 @@ export default function Flow({
         key={mindmapDB._id}
         readOnly={readOnly}
         mindmapDB={mindmapDB}
-        initialNodes={initialNodes.length ? initialNodes : INITIAL_NODES}
-        initialEdges={initialEdges.length ? initialEdges : INITIAL_EDGES}
+        serverNodes={nodes}
       >
         {/* Only an owner can edit, so only an owner gets the AI panel; a
             read-only canvas keeps the full width it had before P8. */}

--- a/components/flow/components/SaveMindmap.tsx
+++ b/components/flow/components/SaveMindmap.tsx
@@ -41,6 +41,8 @@ const PILL_CLASS_NAME = [
 /**
  * Ambient autosave status with an explicit retry control only after failure.
  *
+ * Positioning belongs to the canvas right rail, not to this pill, so the share
+ * control and the status stay on one row however long the error copy runs.
  * The live-region wrapper announces the concise state copy. The error button
  * remains focusable so Radix exposes the server detail to keyboard users too,
  * without making that described trigger a second status live region.
@@ -58,11 +60,7 @@ const SaveMindmap = () => {
     : TRANSIENT_ERROR_COPY;
 
   return (
-    <div
-      className="absolute top-16 right-[var(--theme-switcher-inset)] z-10"
-      data-sync-state={isError ? "error" : syncState}
-      role="status"
-    >
+    <div data-sync-state={isError ? "error" : syncState} role="status">
       {isError ? (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/components/flow/components/ShareMindmap.test.tsx
+++ b/components/flow/components/ShareMindmap.test.tsx
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Edge } from "@xyflow/react";
 import {
@@ -101,8 +108,16 @@ describe("ShareMindmap", () => {
     expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
       "false"
     );
+    expect(screen.getByRole("switch").getAttribute("aria-disabled")).toBe(
+      "true"
+    );
     reseedVisibility("shared");
 
+    await waitFor(() =>
+      expect(screen.getByRole("switch").getAttribute("aria-disabled")).toBe(
+        "false"
+      )
+    );
     expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
       "true"
     );
@@ -158,6 +173,23 @@ describe("ShareMindmap", () => {
     expect(screen.queryByLabelText("Public link to this map")).toBeNull();
   });
 
+  it("clears a failed toggle error when a later attempt succeeds", async () => {
+    const user = userEvent.setup();
+    mocks.setVisibility.mockRejectedValueOnce(new Error("offline"));
+    renderShareControl("private");
+
+    await user.click(screen.getByRole("button", { name: "Sharing: private" }));
+    await user.click(screen.getByRole("switch"));
+    await waitFor(() => expect(screen.getByRole("alert")).toBeDefined());
+
+    await user.click(screen.getByRole("switch"));
+
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+    expect(screen.getByRole("switch").getAttribute("aria-disabled")).toBe(
+      "true"
+    );
+  });
+
   it("keeps the pending switch focusable and ignores a second activation", async () => {
     const user = userEvent.setup();
     let resolve!: () => void;
@@ -182,6 +214,25 @@ describe("ShareMindmap", () => {
     expect(mocks.setVisibility).toHaveBeenCalledOnce();
 
     await act(async () => resolve());
+  });
+
+  it("releases a successful write if the live visibility reseed never arrives", () => {
+    vi.useFakeTimers();
+    renderShareControl("private");
+
+    try {
+      fireEvent.click(screen.getByRole("button", { name: "Sharing: private" }));
+      const shareSwitch = screen.getByRole("switch");
+      fireEvent.click(shareSwitch);
+
+      expect(shareSwitch.getAttribute("aria-disabled")).toBe("true");
+      act(() => vi.advanceTimersByTime(5_000));
+
+      expect(shareSwitch.getAttribute("aria-disabled")).toBe("false");
+      expect(shareSwitch.getAttribute("aria-checked")).toBe("false");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reflects an external visibility reseed and announces revocation", () => {

--- a/components/flow/components/ShareMindmap.test.tsx
+++ b/components/flow/components/ShareMindmap.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Edge } from "@xyflow/react";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { MindmapDB } from "@/types/Mindmap";
+
+import { ROOT_NODE_ID } from "../const";
+import { createEdge } from "../mindmap/createEdge";
+import { createBaseFlowNodeFromPartialBaseFlowNode } from "../mindmap/createNode";
+import { MindmapFlowProvider } from "../providers/MindmapFlowProvider";
+import { BaseFlowNode, NodeTypes } from "../types";
+import { ShareMindmap } from "./ShareMindmap";
+
+const mocks = vi.hoisted(() => ({
+  setVisibility: vi.fn(),
+  writeText: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => mocks.setVisibility,
+}));
+
+beforeAll(() => {
+  // Radix positions the popover with floating-ui, which jsdom cannot observe.
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+/**
+ * Takes ownership of the clipboard after user-event has installed its own.
+ *
+ * jsdom ships none, and `userEvent.setup()` substitutes a stub of its own, so
+ * the override has to be applied once the session exists or the component
+ * would write into user-event's buffer instead of the spy.
+ */
+function stubClipboard(): void {
+  Object.defineProperty(globalThis.navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: mocks.writeText },
+  });
+}
+
+beforeEach(() => {
+  mocks.setVisibility.mockReset().mockResolvedValue(undefined);
+  mocks.writeText.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(cleanup);
+
+describe("ShareMindmap", () => {
+  it("reads as private until the owner turns sharing on", async () => {
+    const user = userEvent.setup();
+    renderShareControl("private");
+
+    await user.click(screen.getByRole("button", { name: "Sharing: private" }));
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "false"
+    );
+    expect(
+      screen.getByText(
+        "Anyone with the link can view, without the conversation."
+      )
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Public link to this map")).toBeNull();
+  });
+
+  it("writes the new visibility and then reveals the public link", async () => {
+    const user = userEvent.setup();
+    renderShareControl("private");
+
+    await user.click(screen.getByRole("button", { name: "Sharing: private" }));
+    await user.click(screen.getByRole("switch"));
+
+    expect(mocks.setVisibility).toHaveBeenCalledWith({
+      mindmapId: "mindmaps:share-fixture",
+      visibility: "shared",
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+        "true"
+      )
+    );
+
+    const link = screen.getByLabelText("Public link to this map");
+
+    expect(link).toHaveProperty(
+      "value",
+      `${window.location.origin}/share/share-map`
+    );
+    expect(link).toHaveProperty("readOnly", true);
+  });
+
+  it("copies the public link to the clipboard and confirms it", async () => {
+    const user = userEvent.setup();
+    stubClipboard();
+    renderShareControl("shared");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Sharing: anyone with the link can view",
+      })
+    );
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
+
+    expect(mocks.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/share/share-map`
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Link copied" })).toBeDefined()
+    );
+  });
+
+  it("keeps the old state and explains a failed write", async () => {
+    const user = userEvent.setup();
+    mocks.setVisibility.mockImplementation(() =>
+      Promise.reject(new Error("offline"))
+    );
+    renderShareControl("private");
+
+    await user.click(screen.getByRole("button", { name: "Sharing: private" }));
+    await user.click(screen.getByRole("switch"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toBe(
+        "Couldn't change sharing just now. Try again."
+      )
+    );
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "false"
+    );
+    expect(screen.queryByLabelText("Public link to this map")).toBeNull();
+  });
+
+  it("explains a clipboard the browser refused", async () => {
+    const user = userEvent.setup();
+    stubClipboard();
+    mocks.writeText.mockImplementation(() =>
+      Promise.reject(new Error("denied"))
+    );
+    renderShareControl("shared");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Sharing: anyone with the link can view",
+      })
+    );
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toBe(
+        "Couldn't copy the link — select it instead."
+      )
+    );
+  });
+});
+
+/** Mounts the control over a real store, the way the canvas rail does. */
+function renderShareControl(visibility: MindmapDB["visibility"]): void {
+  render(
+    <MindmapFlowProvider {...createShareFixture(visibility)}>
+      <ShareMindmap />
+    </MindmapFlowProvider>
+  );
+}
+
+/** Creates the smallest rooted graph the provider will accept. */
+function createShareFixture(visibility: MindmapDB["visibility"]): {
+  mindmapDB: MindmapDB;
+  initialNodes: BaseFlowNode[];
+  initialEdges: Edge[];
+} {
+  return {
+    mindmapDB: {
+      _id: "mindmaps:share-fixture" as MindmapDB["_id"],
+      publicId: "share-map",
+      name: "Share fixture",
+      visibility,
+      updatedAt: 1,
+      isOwner: true,
+    },
+    initialNodes: [
+      createBaseFlowNodeFromPartialBaseFlowNode({
+        id: ROOT_NODE_ID,
+        type: NodeTypes.ROOT,
+        data: { title: "Root" },
+      }),
+      createBaseFlowNodeFromPartialBaseFlowNode({
+        id: "right-child",
+        type: NodeTypes.RIGHT,
+        data: { title: "Right child" },
+      }),
+    ],
+    initialEdges: [createEdge(ROOT_NODE_ID, "right-child")],
+  };
+}

--- a/components/flow/components/ShareMindmap.test.tsx
+++ b/components/flow/components/ShareMindmap.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Edge } from "@xyflow/react";
 import {
@@ -18,7 +18,10 @@ import { MindmapDB } from "@/types/Mindmap";
 import { ROOT_NODE_ID } from "../const";
 import { createEdge } from "../mindmap/createEdge";
 import { createBaseFlowNodeFromPartialBaseFlowNode } from "../mindmap/createNode";
-import { MindmapFlowProvider } from "../providers/MindmapFlowProvider";
+import {
+  MindmapFlowProvider,
+  useMindmapStoreApi,
+} from "../providers/MindmapFlowProvider";
 import { BaseFlowNode, NodeTypes } from "../types";
 import { ShareMindmap } from "./ShareMindmap";
 
@@ -26,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   setVisibility: vi.fn(),
   writeText: vi.fn(),
 }));
+let store: ReturnType<typeof useMindmapStoreApi>;
 
 vi.mock("convex/react", () => ({
   useMutation: () => mocks.setVisibility,
@@ -94,11 +98,15 @@ describe("ShareMindmap", () => {
       visibility: "shared",
     });
 
-    await waitFor(() =>
-      expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
-        "true"
-      )
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "false"
     );
+    reseedVisibility("shared");
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "true"
+    );
+    expect(screen.getByRole("status").textContent).toBe("Map is now shared");
 
     const link = screen.getByLabelText("Public link to this map");
 
@@ -150,6 +158,43 @@ describe("ShareMindmap", () => {
     expect(screen.queryByLabelText("Public link to this map")).toBeNull();
   });
 
+  it("keeps the pending switch focusable and ignores a second activation", async () => {
+    const user = userEvent.setup();
+    let resolve!: () => void;
+    mocks.setVisibility.mockReturnValue(
+      new Promise<void>((promiseResolve) => {
+        resolve = promiseResolve;
+      })
+    );
+    renderShareControl("private");
+
+    await user.click(screen.getByRole("button", { name: "Sharing: private" }));
+    const shareSwitch = screen.getByRole("switch");
+    shareSwitch.focus();
+    void user.click(shareSwitch);
+
+    await waitFor(() =>
+      expect(shareSwitch.getAttribute("aria-disabled")).toBe("true")
+    );
+    expect(shareSwitch).toHaveProperty("disabled", false);
+    expect(document.activeElement).toBe(shareSwitch);
+    await user.click(shareSwitch);
+    expect(mocks.setVisibility).toHaveBeenCalledOnce();
+
+    await act(async () => resolve());
+  });
+
+  it("reflects an external visibility reseed and announces revocation", () => {
+    renderShareControl("shared");
+
+    reseedVisibility("private");
+
+    expect(
+      screen.getByRole("button", { name: "Sharing: private" })
+    ).toBeDefined();
+    expect(screen.getByRole("status").textContent).toBe("Map is now private");
+  });
+
   it("explains a clipboard the browser refused", async () => {
     const user = userEvent.setup();
     stubClipboard();
@@ -177,9 +222,44 @@ describe("ShareMindmap", () => {
 function renderShareControl(visibility: MindmapDB["visibility"]): void {
   render(
     <MindmapFlowProvider {...createShareFixture(visibility)}>
+      <StoreProbe />
       <ShareMindmap />
     </MindmapFlowProvider>
   );
+}
+
+/** Captures the real canvas store used as the sharing source of truth. */
+function StoreProbe() {
+  store = useMindmapStoreApi();
+  return null;
+}
+
+/** Delivers the live server visibility update that follows a mutation. */
+function reseedVisibility(visibility: MindmapDB["visibility"]): void {
+  act(() => {
+    const state = store.getState();
+    state.actions.reseedFromServer({
+      name: state.mindmapDB.name,
+      nodes: [
+        {
+          nodeId: ROOT_NODE_ID,
+          order: 0,
+          parentId: null,
+          title: "Root",
+          type: "root",
+        },
+        {
+          nodeId: "right-child",
+          order: 0,
+          parentId: ROOT_NODE_ID,
+          title: "Right child",
+          type: "right",
+        },
+      ],
+      updatedAt: state.seededUpdatedAt + 1,
+      visibility,
+    });
+  });
 }
 
 /** Creates the smallest rooted graph the provider will accept. */

--- a/components/flow/components/ShareMindmap.tsx
+++ b/components/flow/components/ShareMindmap.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { Check, Copy, Link2, Lock } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { api } from "@/convex/_generated/api";
+import { useEventCallback } from "@/hooks/use-event-callback";
+import { cn } from "@/lib/utils";
+
+import { useMindmapFlow } from "../providers/MindmapFlowProvider";
+
+/** How long the copy button stays in its confirmed state. */
+const COPIED_RESET_MS = 2000;
+
+type Visibility = "private" | "shared";
+
+/**
+ * Link sharing for the map's owner, from the canvas.
+ *
+ * Visibility is a server fact, so the control never pretends: the switch stays
+ * in a visible pending state until Convex has actually written the change, and
+ * a failure is reported next to the switch rather than swallowed. The trigger
+ * carries the current state so the answer to "is this map out there?" is
+ * readable without opening anything.
+ */
+const ShareMindmap = () => {
+  const mindmapId = useMindmapFlow((state) => state.mindmapDB._id);
+  const publicId = useMindmapFlow((state) => state.mindmapDB.publicId);
+  const seededVisibility = useMindmapFlow(
+    (state) => state.mindmapDB.visibility
+  );
+  const setVisibility = useMutation(api.mindmaps.setVisibility);
+
+  const switchLabelId = useId();
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // The canvas store is seeded from the server render and is not re-seeded by
+  // this mutation, so the confirmed write becomes the local source of truth.
+  const [visibility, setLocalVisibility] =
+    useState<Visibility>(seededVisibility);
+  const [isPending, setIsPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasCopied, setHasCopied] = useState(false);
+  // The origin is only knowable on the client; reading it during render would
+  // make the prerendered markup and the first client render disagree.
+  const [origin, setOrigin] = useState("");
+
+  const isShared = visibility === "shared";
+  const shareUrl = `${origin}/share/${publicId}`;
+
+  useEffect(() => setOrigin(window.location.origin), []);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) {
+        clearTimeout(copyTimerRef.current);
+      }
+    },
+    []
+  );
+
+  const handleToggle = useEventCallback(async () => {
+    if (isPending) {
+      return;
+    }
+
+    const nextVisibility: Visibility = isShared ? "private" : "shared";
+
+    setIsPending(true);
+    setErrorMessage(null);
+
+    try {
+      await setVisibility({ mindmapId, visibility: nextVisibility });
+      setLocalVisibility(nextVisibility);
+      setHasCopied(false);
+    } catch {
+      setErrorMessage("Couldn't change sharing just now. Try again.");
+    } finally {
+      setIsPending(false);
+    }
+  });
+
+  const handleCopy = useEventCallback(async () => {
+    const clipboard = globalThis.navigator?.clipboard;
+
+    if (clipboard === undefined) {
+      setErrorMessage(
+        "Copying isn't available here — select the link instead."
+      );
+      return;
+    }
+
+    try {
+      await clipboard.writeText(shareUrl);
+      setErrorMessage(null);
+      setHasCopied(true);
+
+      if (copyTimerRef.current !== null) {
+        clearTimeout(copyTimerRef.current);
+      }
+      copyTimerRef.current = setTimeout(
+        () => setHasCopied(false),
+        COPIED_RESET_MS
+      );
+    } catch {
+      setErrorMessage("Couldn't copy the link — select it instead.");
+    }
+  });
+
+  const triggerLabel = isShared
+    ? "Sharing: anyone with the link can view"
+    : "Sharing: private";
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          aria-label={triggerLabel}
+          className={cn(
+            "flex items-center gap-1.5 rounded-full border border-line-strong bg-card px-2.5 py-1",
+            "font-mono text-[11px] leading-none select-none",
+            "transition-colors duration-200 ease-organic motion-reduce:transition-none",
+            isShared
+              ? "text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+          title={triggerLabel}
+          type="button"
+        >
+          {isShared ? (
+            <Link2 aria-hidden="true" className="size-3" />
+          ) : (
+            <Lock aria-hidden="true" className="size-3" />
+          )}
+          {isShared ? "Shared" : "Share"}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80" sideOffset={8}>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex min-w-0 flex-col gap-1">
+              <p
+                className="text-sm font-medium text-foreground"
+                id={switchLabelId}
+              >
+                Share this map
+              </p>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Anyone with the link can view, without the conversation.
+              </p>
+            </div>
+            <button
+              aria-checked={isShared}
+              aria-labelledby={switchLabelId}
+              className={cn(
+                "mt-0.5 flex h-5 w-9 shrink-0 items-center rounded-full border border-line-strong p-0.5",
+                "transition-colors duration-200 ease-organic motion-reduce:transition-none",
+                "disabled:cursor-not-allowed disabled:opacity-60",
+                isShared ? "bg-primary" : "bg-secondary"
+              )}
+              disabled={isPending}
+              onClick={() => void handleToggle()}
+              role="switch"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "size-3.5 rounded-full bg-card",
+                  "transition-transform duration-200 ease-organic motion-reduce:transition-none",
+                  isShared ? "translate-x-4" : "translate-x-0"
+                )}
+              />
+            </button>
+          </div>
+
+          <p aria-live="polite" className="sr-only" role="status">
+            {isPending ? "Updating sharing" : hasCopied ? "Link copied" : ""}
+          </p>
+
+          {isPending ? (
+            <p className="font-mono text-[11px] uppercase tracking-[0.09em] text-muted-foreground">
+              Updating…
+            </p>
+          ) : null}
+
+          {isShared && !isPending ? (
+            <div className="flex items-center gap-2">
+              <input
+                aria-label="Public link to this map"
+                className="min-w-0 flex-1 rounded-md border border-line-strong bg-background px-2 py-1.5 font-mono text-[11px] text-muted-foreground"
+                readOnly
+                value={shareUrl}
+              />
+              <button
+                aria-label={hasCopied ? "Link copied" : "Copy link"}
+                className={cn(
+                  "flex size-8 shrink-0 items-center justify-center rounded-md border border-line-strong",
+                  "text-muted-foreground hover:text-foreground",
+                  "transition-colors duration-200 ease-organic motion-reduce:transition-none"
+                )}
+                onClick={() => void handleCopy()}
+                title={hasCopied ? "Link copied" : "Copy link"}
+                type="button"
+              >
+                {hasCopied ? (
+                  <Check aria-hidden="true" className="size-3.5 text-primary" />
+                ) : (
+                  <Copy aria-hidden="true" className="size-3.5" />
+                )}
+              </button>
+            </div>
+          ) : null}
+
+          {errorMessage ? (
+            <p
+              className="rounded-md border border-destructive px-2.5 py-2 text-xs font-medium text-destructive"
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export { ShareMindmap };

--- a/components/flow/components/ShareMindmap.tsx
+++ b/components/flow/components/ShareMindmap.tsx
@@ -17,6 +17,8 @@ import { useMindmapFlow } from "../providers/MindmapFlowProvider";
 
 /** How long the copy button stays in its confirmed state. */
 const COPIED_RESET_MS = 2000;
+/** Gives the live store a bounded window to acknowledge a visibility write. */
+const VISIBILITY_ACK_TIMEOUT_MS = 5000;
 
 type Visibility = "private" | "shared";
 
@@ -37,7 +39,9 @@ const ShareMindmap = () => {
 
   const switchLabelId = useId();
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const visibilityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previousVisibilityRef = useRef(visibility);
+  const pendingVisibilityRef = useRef<Visibility | null>(null);
 
   const [isPending, setIsPending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -64,10 +68,26 @@ const ShareMindmap = () => {
     );
   }, [visibility]);
 
+  useEffect(() => {
+    if (pendingVisibilityRef.current !== visibility) {
+      return;
+    }
+
+    pendingVisibilityRef.current = null;
+    if (visibilityTimerRef.current !== null) {
+      clearTimeout(visibilityTimerRef.current);
+      visibilityTimerRef.current = null;
+    }
+    setIsPending(false);
+  }, [visibility]);
+
   useEffect(
     () => () => {
       if (copyTimerRef.current !== null) {
         clearTimeout(copyTimerRef.current);
+      }
+      if (visibilityTimerRef.current !== null) {
+        clearTimeout(visibilityTimerRef.current);
       }
     },
     []
@@ -83,14 +103,27 @@ const ShareMindmap = () => {
     setIsPending(true);
     setErrorMessage(null);
     setAnnouncement("Updating sharing");
+    pendingVisibilityRef.current = nextVisibility;
+    visibilityTimerRef.current = setTimeout(() => {
+      // The mutation may have succeeded without its live-query reseed arriving.
+      // Release the switch and render the store's still-authoritative value.
+      pendingVisibilityRef.current = null;
+      visibilityTimerRef.current = null;
+      setIsPending(false);
+    }, VISIBILITY_ACK_TIMEOUT_MS);
 
     try {
       await setVisibility({ mindmapId, visibility: nextVisibility });
+      setErrorMessage(null);
     } catch {
+      pendingVisibilityRef.current = null;
+      if (visibilityTimerRef.current !== null) {
+        clearTimeout(visibilityTimerRef.current);
+        visibilityTimerRef.current = null;
+      }
+      setIsPending(false);
       setErrorMessage("Couldn't change sharing just now. Try again.");
       setAnnouncement("Sharing was not changed");
-    } finally {
-      setIsPending(false);
     }
   });
 

--- a/components/flow/components/ShareMindmap.tsx
+++ b/components/flow/components/ShareMindmap.tsx
@@ -32,21 +32,17 @@ type Visibility = "private" | "shared";
 const ShareMindmap = () => {
   const mindmapId = useMindmapFlow((state) => state.mindmapDB._id);
   const publicId = useMindmapFlow((state) => state.mindmapDB.publicId);
-  const seededVisibility = useMindmapFlow(
-    (state) => state.mindmapDB.visibility
-  );
+  const visibility = useMindmapFlow((state) => state.mindmapDB.visibility);
   const setVisibility = useMutation(api.mindmaps.setVisibility);
 
   const switchLabelId = useId();
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previousVisibilityRef = useRef(visibility);
 
-  // The canvas store is seeded from the server render and is not re-seeded by
-  // this mutation, so the confirmed write becomes the local source of truth.
-  const [visibility, setLocalVisibility] =
-    useState<Visibility>(seededVisibility);
   const [isPending, setIsPending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [hasCopied, setHasCopied] = useState(false);
+  const [announcement, setAnnouncement] = useState("");
   // The origin is only knowable on the client; reading it during render would
   // make the prerendered markup and the first client render disagree.
   const [origin, setOrigin] = useState("");
@@ -55,6 +51,18 @@ const ShareMindmap = () => {
   const shareUrl = `${origin}/share/${publicId}`;
 
   useEffect(() => setOrigin(window.location.origin), []);
+
+  useEffect(() => {
+    if (visibility === previousVisibilityRef.current) {
+      return;
+    }
+
+    previousVisibilityRef.current = visibility;
+    setHasCopied(false);
+    setAnnouncement(
+      visibility === "shared" ? "Map is now shared" : "Map is now private"
+    );
+  }, [visibility]);
 
   useEffect(
     () => () => {
@@ -74,13 +82,13 @@ const ShareMindmap = () => {
 
     setIsPending(true);
     setErrorMessage(null);
+    setAnnouncement("Updating sharing");
 
     try {
       await setVisibility({ mindmapId, visibility: nextVisibility });
-      setLocalVisibility(nextVisibility);
-      setHasCopied(false);
     } catch {
       setErrorMessage("Couldn't change sharing just now. Try again.");
+      setAnnouncement("Sharing was not changed");
     } finally {
       setIsPending(false);
     }
@@ -118,117 +126,121 @@ const ShareMindmap = () => {
     : "Sharing: private";
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          aria-label={triggerLabel}
-          className={cn(
-            "flex items-center gap-1.5 rounded-full border border-line-strong bg-card px-2.5 py-1",
-            "font-mono text-[11px] leading-none select-none",
-            "transition-colors duration-200 ease-organic motion-reduce:transition-none",
-            isShared
-              ? "text-foreground"
-              : "text-muted-foreground hover:text-foreground"
-          )}
-          title={triggerLabel}
-          type="button"
-        >
-          {isShared ? (
-            <Link2 aria-hidden="true" className="size-3" />
-          ) : (
-            <Lock aria-hidden="true" className="size-3" />
-          )}
-          {isShared ? "Shared" : "Share"}
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-80" sideOffset={8}>
-        <div className="flex flex-col gap-3">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex min-w-0 flex-col gap-1">
-              <p
-                className="text-sm font-medium text-foreground"
-                id={switchLabelId}
-              >
-                Share this map
-              </p>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                Anyone with the link can view, without the conversation.
-              </p>
-            </div>
-            <button
-              aria-checked={isShared}
-              aria-labelledby={switchLabelId}
-              className={cn(
-                "mt-0.5 flex h-5 w-9 shrink-0 items-center rounded-full border border-line-strong p-0.5",
-                "transition-colors duration-200 ease-organic motion-reduce:transition-none",
-                "disabled:cursor-not-allowed disabled:opacity-60",
-                isShared ? "bg-primary" : "bg-secondary"
-              )}
-              disabled={isPending}
-              onClick={() => void handleToggle()}
-              role="switch"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "size-3.5 rounded-full bg-card",
-                  "transition-transform duration-200 ease-organic motion-reduce:transition-none",
-                  isShared ? "translate-x-4" : "translate-x-0"
-                )}
-              />
-            </button>
-          </div>
-
-          <p aria-live="polite" className="sr-only" role="status">
-            {isPending ? "Updating sharing" : hasCopied ? "Link copied" : ""}
-          </p>
-
-          {isPending ? (
-            <p className="font-mono text-[11px] uppercase tracking-[0.09em] text-muted-foreground">
-              Updating…
-            </p>
-          ) : null}
-
-          {isShared && !isPending ? (
-            <div className="flex items-center gap-2">
-              <input
-                aria-label="Public link to this map"
-                className="min-w-0 flex-1 rounded-md border border-line-strong bg-background px-2 py-1.5 font-mono text-[11px] text-muted-foreground"
-                readOnly
-                value={shareUrl}
-              />
+    <>
+      <p aria-live="polite" className="sr-only" role="status">
+        {hasCopied ? "Link copied" : announcement}
+      </p>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            aria-label={triggerLabel}
+            className={cn(
+              "flex items-center gap-1.5 rounded-full border border-line-strong bg-card px-2.5 py-1",
+              "font-mono text-[11px] leading-none select-none",
+              "transition-colors duration-200 ease-organic motion-reduce:transition-none",
+              isShared
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+            title={triggerLabel}
+            type="button"
+          >
+            {isShared ? (
+              <Link2 aria-hidden="true" className="size-3" />
+            ) : (
+              <Lock aria-hidden="true" className="size-3" />
+            )}
+            {isShared ? "Shared" : "Share"}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-80" sideOffset={8}>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex min-w-0 flex-col gap-1">
+                <p
+                  className="text-sm font-medium text-foreground"
+                  id={switchLabelId}
+                >
+                  Share this map
+                </p>
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Anyone with the link can view, without the conversation.
+                </p>
+              </div>
               <button
-                aria-label={hasCopied ? "Link copied" : "Copy link"}
+                aria-checked={isShared}
+                aria-disabled={isPending}
+                aria-labelledby={switchLabelId}
                 className={cn(
-                  "flex size-8 shrink-0 items-center justify-center rounded-md border border-line-strong",
-                  "text-muted-foreground hover:text-foreground",
-                  "transition-colors duration-200 ease-organic motion-reduce:transition-none"
+                  "mt-0.5 flex h-5 w-9 shrink-0 items-center rounded-full border border-line-strong p-0.5",
+                  "transition-colors duration-200 ease-organic motion-reduce:transition-none",
+                  isPending && "cursor-not-allowed opacity-60",
+                  isShared ? "bg-primary" : "bg-secondary"
                 )}
-                onClick={() => void handleCopy()}
-                title={hasCopied ? "Link copied" : "Copy link"}
+                onClick={() => void handleToggle()}
+                role="switch"
                 type="button"
               >
-                {hasCopied ? (
-                  <Check aria-hidden="true" className="size-3.5 text-primary" />
-                ) : (
-                  <Copy aria-hidden="true" className="size-3.5" />
-                )}
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "size-3.5 rounded-full bg-card",
+                    "transition-transform duration-200 ease-organic motion-reduce:transition-none",
+                    isShared ? "translate-x-4" : "translate-x-0"
+                  )}
+                />
               </button>
             </div>
-          ) : null}
 
-          {errorMessage ? (
-            <p
-              className="rounded-md border border-destructive px-2.5 py-2 text-xs font-medium text-destructive"
-              role="alert"
-            >
-              {errorMessage}
-            </p>
-          ) : null}
-        </div>
-      </PopoverContent>
-    </Popover>
+            {isPending ? (
+              <p className="font-mono text-[11px] uppercase tracking-[0.09em] text-muted-foreground">
+                Updating…
+              </p>
+            ) : null}
+
+            {isShared && !isPending ? (
+              <div className="flex items-center gap-2">
+                <input
+                  aria-label="Public link to this map"
+                  className="min-w-0 flex-1 rounded-md border border-line-strong bg-background px-2 py-1.5 font-mono text-[11px] text-muted-foreground"
+                  readOnly
+                  value={shareUrl}
+                />
+                <button
+                  aria-label={hasCopied ? "Link copied" : "Copy link"}
+                  className={cn(
+                    "flex size-8 shrink-0 items-center justify-center rounded-md border border-line-strong",
+                    "text-muted-foreground hover:text-foreground",
+                    "transition-colors duration-200 ease-organic motion-reduce:transition-none"
+                  )}
+                  onClick={() => void handleCopy()}
+                  title={hasCopied ? "Link copied" : "Copy link"}
+                  type="button"
+                >
+                  {hasCopied ? (
+                    <Check
+                      aria-hidden="true"
+                      className="size-3.5 text-primary"
+                    />
+                  ) : (
+                    <Copy aria-hidden="true" className="size-3.5" />
+                  )}
+                </button>
+              </div>
+            ) : null}
+
+            {errorMessage ? (
+              <p
+                className="rounded-md border border-destructive px-2.5 py-2 text-xs font-medium text-destructive"
+                role="alert"
+              >
+                {errorMessage}
+              </p>
+            ) : null}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </>
   );
 };
 

--- a/components/flow/hooks/useMindmapLiveSync.test.tsx
+++ b/components/flow/hooks/useMindmapLiveSync.test.tsx
@@ -1,0 +1,263 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { Edge } from "@xyflow/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
+
+import { ROOT_NODE_ID } from "../const";
+import { createEdge } from "../mindmap/createEdge";
+import { createBaseFlowNodeFromPartialBaseFlowNode } from "../mindmap/createNode";
+import {
+  MindmapFlowProvider,
+  useMindmapStoreApi,
+} from "../providers/MindmapFlowProvider";
+import { BaseFlowNode, NodeTypes } from "../types";
+import { useMindmapLiveSync } from "./useMindmapLiveSync";
+import { useMindmapSync } from "./useMindmapSync";
+
+const mocks = vi.hoisted(() => ({
+  mutation: vi.fn(),
+  query: {
+    current: undefined as
+      | {
+          mindmap: MindmapDB;
+          nodes: MindmapNodeProjection[];
+        }
+      | undefined,
+  },
+  useQuery: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => mocks.mutation,
+  useQuery: (...args: unknown[]) => {
+    mocks.useQuery(...args);
+    return mocks.query.current;
+  },
+}));
+
+let store: ReturnType<typeof useMindmapStoreApi>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.mutation.mockReset();
+  mocks.query.current = undefined;
+  mocks.useQuery.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useMindmapLiveSync", () => {
+  it("no-ops the initial self-echo at the seeded version", () => {
+    mocks.query.current = createServerState(1);
+    const view = renderLiveHarness();
+    const initialNodes = store.getState().nodes;
+    const initialLayout = store.getState().layout;
+
+    view.rerender(createLiveHarness());
+
+    expect(store.getState().nodes).toBe(initialNodes);
+    expect(store.getState().layout).toBe(initialLayout);
+    expect(store.getState().pendingServerState).toBeNull();
+  });
+
+  it("defers a live result during a flush and applies it when the queue drains", async () => {
+    const mutation = createDeferred<{ operationId: string; seq: number }>();
+    mocks.mutation.mockReturnValue(mutation.promise);
+    const view = renderLiveHarness({ withAutosave: true });
+
+    act(() => {
+      store
+        .getState()
+        .actions.onUpdateNode("right-child", { title: "Local edit" });
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+
+    expect(store.getState().syncState).toBe("saving");
+    expect(store.getState().pendingOps).toHaveLength(1);
+
+    mocks.query.current = createServerState(2, true);
+    view.rerender(createLiveHarness({ withAutosave: true }));
+
+    expect(store.getState().seededUpdatedAt).toBe(1);
+    expect(store.getState().nodesMap["l-ai-created"]).toBeUndefined();
+    expect(store.getState().pendingServerState?.updatedAt).toBe(2);
+
+    await act(async () => {
+      mutation.resolve({ operationId: "operations:1", seq: 1 });
+      await mutation.promise;
+    });
+
+    expect(store.getState().pendingOps).toEqual([]);
+    expect(store.getState().syncState).toBe("idle");
+    expect(store.getState().pendingServerState).toBeNull();
+    expect(store.getState().seededUpdatedAt).toBe(2);
+    expect(store.getState().nodesMap["l-ai-created"]).toBeDefined();
+  });
+
+  it("sets AI touched ids only after a created node is reseeded", () => {
+    const view = renderLiveHarness();
+    const commits: Array<{ hasNode: boolean; isTouched: boolean }> = [];
+
+    act(() => {
+      store
+        .getState()
+        .actions.setAiTouchedNodeIdsAfterReseed(["l-ai-created"], 1);
+    });
+    const unsubscribe = store.subscribe((state) => {
+      commits.push({
+        hasNode: state.nodesMap["l-ai-created"] !== undefined,
+        isTouched: state.aiTouchedNodeIds.includes("l-ai-created"),
+      });
+    });
+
+    mocks.query.current = createServerState(2, true);
+    view.rerender(createLiveHarness());
+
+    expect(commits).toContainEqual({ hasNode: true, isTouched: false });
+    expect(commits.at(-1)).toEqual({ hasNode: true, isTouched: true });
+    unsubscribe();
+  });
+
+  it("uses the Convex skip sentinel for a read-only store", () => {
+    renderLiveHarness({ readOnly: true });
+
+    expect(mocks.useQuery.mock.calls.at(-1)?.[1]).toBe("skip");
+  });
+});
+
+/** Renders a provider whose query result can be replaced between rerenders. */
+function renderLiveHarness(options?: {
+  readOnly?: boolean;
+  withAutosave?: boolean;
+}) {
+  return render(createLiveHarness(options));
+}
+
+/** Creates the live-sync element tree used for initial render and rerender. */
+function createLiveHarness(options?: {
+  readOnly?: boolean;
+  withAutosave?: boolean;
+}) {
+  return (
+    <MindmapFlowProvider
+      {...createFixture()}
+      readOnly={options?.readOnly ?? false}
+    >
+      <StoreProbe />
+      <LiveSyncHarness />
+      {options?.withAutosave ? <AutosaveHarness /> : null}
+    </MindmapFlowProvider>
+  );
+}
+
+/** Captures the real provider store for reconciliation assertions. */
+function StoreProbe() {
+  store = useMindmapStoreApi();
+  return null;
+}
+
+/** Mounts the inbound Convex live-query effect. */
+function LiveSyncHarness() {
+  useMindmapLiveSync();
+  return null;
+}
+
+/** Mounts outbound autosave so flush-success reconciliation is exercised. */
+function AutosaveHarness() {
+  useMindmapSync();
+  return null;
+}
+
+/** Creates a manually controlled promise for an in-flight autosave. */
+function createDeferred<Value>(): {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+} {
+  let resolve!: (value: Value) => void;
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+/** Returns the initial graph accepted by the provider. */
+function createFixture(): {
+  mindmapDB: MindmapDB;
+  initialNodes: BaseFlowNode[];
+  initialEdges: Edge[];
+} {
+  return {
+    mindmapDB: createMindmap(1),
+    initialNodes: [
+      createBaseFlowNodeFromPartialBaseFlowNode({
+        id: ROOT_NODE_ID,
+        type: NodeTypes.ROOT,
+        data: { title: "Root" },
+      }),
+      createBaseFlowNodeFromPartialBaseFlowNode({
+        id: "right-child",
+        type: NodeTypes.RIGHT,
+        data: { title: "Right child" },
+      }),
+    ],
+    initialEdges: [createEdge(ROOT_NODE_ID, "right-child")],
+  };
+}
+
+/** Creates a versioned live-query payload, optionally with a new AI node. */
+function createServerState(
+  updatedAt: number,
+  includeAiNode = false
+): {
+  mindmap: MindmapDB;
+  nodes: MindmapNodeProjection[];
+} {
+  return {
+    mindmap: createMindmap(updatedAt),
+    nodes: [
+      {
+        nodeId: ROOT_NODE_ID,
+        parentId: null,
+        type: "root",
+        title: "Root",
+        order: 0,
+      },
+      {
+        nodeId: "right-child",
+        parentId: ROOT_NODE_ID,
+        type: "right",
+        title: "Local edit",
+        order: 0,
+      },
+      ...(includeAiNode
+        ? [
+            {
+              nodeId: "l-ai-created",
+              parentId: ROOT_NODE_ID,
+              type: "left" as const,
+              title: "AI created",
+              order: 0,
+            },
+          ]
+        : []),
+    ],
+  };
+}
+
+/** Creates the stable mindmap projection around a supplied version. */
+function createMindmap(updatedAt: number): MindmapDB {
+  return {
+    _id: "mindmaps:live-fixture" as MindmapDB["_id"],
+    publicId: "live-map",
+    name: "Live fixture",
+    visibility: "private",
+    updatedAt,
+    isOwner: true,
+  };
+}

--- a/components/flow/hooks/useMindmapLiveSync.test.tsx
+++ b/components/flow/hooks/useMindmapLiveSync.test.tsx
@@ -67,7 +67,11 @@ describe("useMindmapLiveSync", () => {
   });
 
   it("defers a live result during a flush and applies it when the queue drains", async () => {
-    const mutation = createDeferred<{ operationId: string; seq: number }>();
+    const mutation = createDeferred<{
+      operationId: string;
+      seq: number;
+      updatedAt: number;
+    }>();
     mocks.mutation.mockReturnValue(mutation.promise);
     const view = renderLiveHarness({ withAutosave: true });
 
@@ -89,14 +93,52 @@ describe("useMindmapLiveSync", () => {
     expect(store.getState().pendingServerState?.updatedAt).toBe(2);
 
     await act(async () => {
-      mutation.resolve({ operationId: "operations:1", seq: 1 });
+      mutation.resolve({
+        operationId: "operations:1",
+        seq: 1,
+        updatedAt: 3,
+      });
       await mutation.promise;
     });
 
     expect(store.getState().pendingOps).toEqual([]);
     expect(store.getState().syncState).toBe("idle");
     expect(store.getState().pendingServerState).toBeNull();
-    expect(store.getState().seededUpdatedAt).toBe(2);
+    expect(store.getState().acknowledgedServerVersion).toBe(3);
+    expect(store.getState().seededUpdatedAt).toBe(1);
+    expect(store.getState().nodesMap["l-ai-created"]).toBeUndefined();
+  });
+
+  it("applies a deferred snapshot at or above the flush watermark", async () => {
+    const mutation = createDeferred<{
+      operationId: string;
+      seq: number;
+      updatedAt: number;
+    }>();
+    mocks.mutation.mockReturnValue(mutation.promise);
+    const view = renderLiveHarness({ withAutosave: true });
+
+    act(() => {
+      store
+        .getState()
+        .actions.onUpdateNode("right-child", { title: "Local edit" });
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+
+    mocks.query.current = createServerState(3, true);
+    view.rerender(createLiveHarness({ withAutosave: true }));
+
+    await act(async () => {
+      mutation.resolve({
+        operationId: "operations:1",
+        seq: 1,
+        updatedAt: 3,
+      });
+      await mutation.promise;
+    });
+
+    expect(store.getState().pendingServerState).toBeNull();
+    expect(store.getState().seededUpdatedAt).toBe(3);
     expect(store.getState().nodesMap["l-ai-created"]).toBeDefined();
   });
 

--- a/components/flow/hooks/useMindmapLiveSync.ts
+++ b/components/flow/hooks/useMindmapLiveSync.ts
@@ -28,8 +28,10 @@ function useMindmapLiveSync(): void {
     }
 
     reconcileServerState({
+      name: serverState.mindmap.name,
       nodes: serverState.nodes as MindmapNodeProjection[],
       updatedAt: serverState.mindmap.updatedAt,
+      visibility: serverState.mindmap.visibility,
     });
   }, [reconcileServerState, serverState]);
 }

--- a/components/flow/hooks/useMindmapLiveSync.ts
+++ b/components/flow/hooks/useMindmapLiveSync.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { useEffect } from "react";
+
+import { api } from "@/convex/_generated/api";
+import type { MindmapNodeProjection } from "@/types/Mindmap";
+
+import { useMindmapFlow } from "../providers/MindmapFlowProvider";
+
+/**
+ * Reconciles the owner canvas with Convex's live, versioned node projection.
+ */
+function useMindmapLiveSync(): void {
+  const readOnly = useMindmapFlow((state) => state.readOnly);
+  const mindmapId = useMindmapFlow((state) => state.mindmapDB._id);
+  const reconcileServerState = useMindmapFlow(
+    (state) => state.actions.reconcileServerState
+  );
+  const serverState = useQuery(
+    api.mindmaps.get,
+    readOnly ? "skip" : { mindmapId }
+  );
+
+  useEffect(() => {
+    if (serverState === undefined) {
+      return;
+    }
+
+    reconcileServerState({
+      nodes: serverState.nodes as MindmapNodeProjection[],
+      updatedAt: serverState.mindmap.updatedAt,
+    });
+  }, [reconcileServerState, serverState]);
+}
+
+export { useMindmapLiveSync };

--- a/components/flow/hooks/useMindmapNavigation.test.tsx
+++ b/components/flow/hooks/useMindmapNavigation.test.tsx
@@ -148,6 +148,23 @@ describe("useMindmapNavigation", () => {
     expect(fixture.setAiEditNode).toHaveBeenCalledWith(null);
   });
 
+  it("leaves button activation and focus traversal native with canvas bindings mounted", () => {
+    const fixture = createNavigationFixture("left-a");
+    const view = render(<NavigationWithButton fixture={fixture} />);
+    const button = view.getByRole("button", { name: "Plain action" });
+    button.focus();
+
+    // Component-isolated keyboard tests hid an entire bug class: the real
+    // window-level canvas bindings coexist with every control on the page.
+    const enterEvent = dispatchKeyOn(button, { key: "Enter" });
+    const tabEvent = dispatchKeyOn(button, { key: "Tab" });
+
+    expect(fixture.setSelectedNode).not.toHaveBeenCalled();
+    expect(fixture.onAddNode).not.toHaveBeenCalled();
+    expect(enterEvent.defaultPrevented).toBe(false);
+    expect(tabEvent.defaultPrevented).toBe(false);
+  });
+
   it("keeps navigation but does not bind mutation keys in read-only mode", () => {
     const fixture = renderNavigationHook("left-a", true);
 
@@ -168,6 +185,15 @@ describe("useMindmapNavigation", () => {
  * Renders the navigation hook with a fresh mindmap and independently observable callbacks.
  */
 function renderNavigationHook(activeNode: string | null, readOnly = false) {
+  const fixture = createNavigationFixture(activeNode, readOnly);
+
+  renderHook(() => useMindmapNavigation(fixture));
+
+  return fixture;
+}
+
+/** Builds observable navigation inputs shared by hook and integration tests. */
+function createNavigationFixture(activeNode: string | null, readOnly = false) {
   const { leveledNodes, nodesMap } = buildMindmapFixture();
   const setActiveNode = vi.fn<(nodeId: string | null) => void>();
   const onAddNode =
@@ -175,25 +201,26 @@ function renderNavigationHook(activeNode: string | null, readOnly = false) {
   const setSelectedNode = vi.fn<(nodeId: string | null) => void>();
   const setAiEditNode = vi.fn<(nodeId: string | null) => void>();
 
-  renderHook(() =>
-    useMindmapNavigation({
-      readOnly,
-      activeNode,
-      setActiveNode,
-      mindmapNodesMap: nodesMap,
-      leveledNodes,
-      onAddNode,
-      setSelectedNode,
-      setAiEditNode,
-    })
-  );
-
   return {
+    readOnly,
+    activeNode,
+    mindmapNodesMap: nodesMap,
+    leveledNodes,
     setActiveNode,
     onAddNode,
     setSelectedNode,
     setAiEditNode,
   };
+}
+
+/** Mounts the real canvas bindings beside an ordinary page control. */
+function NavigationWithButton({
+  fixture,
+}: {
+  fixture: ReturnType<typeof createNavigationFixture>;
+}) {
+  useMindmapNavigation(fixture);
+  return <button type="button">Plain action</button>;
 }
 
 /** Dispatches a cancelable keydown event through the hook's real window listeners. */
@@ -206,14 +233,19 @@ function dispatchKey(init: KeyboardEventInit): void {
 }
 
 /** Dispatches a bubbling keydown from an element so window sees its real target. */
-function dispatchKeyOn(target: Element, init: KeyboardEventInit): void {
-  act(() => {
-    target.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        ...init,
-        bubbles: true,
-        cancelable: true,
-      })
-    );
+function dispatchKeyOn(
+  target: Element,
+  init: KeyboardEventInit
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    ...init,
+    bubbles: true,
+    cancelable: true,
   });
+
+  act(() => {
+    target.dispatchEvent(event);
+  });
+
+  return event;
 }

--- a/components/flow/hooks/useMindmapSync.test.tsx
+++ b/components/flow/hooks/useMindmapSync.test.tsx
@@ -35,7 +35,11 @@ afterEach(() => {
 
 describe("useMindmapSync", () => {
   it("flushes one coalesced batch after a burst's trailing debounce", async () => {
-    mutationMock.mockResolvedValue({ operationId: "operation-1", seq: 1 });
+    mutationMock.mockResolvedValue({
+      operationId: "operation-1",
+      seq: 1,
+      updatedAt: 2,
+    });
     renderSyncHarness();
 
     act(() => {
@@ -78,10 +82,15 @@ describe("useMindmapSync", () => {
     const firstMutation = createDeferred<{
       operationId: string;
       seq: number;
+      updatedAt: number;
     }>();
     mutationMock
       .mockReturnValueOnce(firstMutation.promise)
-      .mockResolvedValueOnce({ operationId: "operation-2", seq: 2 });
+      .mockResolvedValueOnce({
+        operationId: "operation-2",
+        seq: 2,
+        updatedAt: 3,
+      });
     renderSyncHarness();
 
     act(() => {
@@ -107,7 +116,11 @@ describe("useMindmapSync", () => {
     expect(mutationMock).toHaveBeenCalledOnce();
 
     await act(async () => {
-      firstMutation.resolve({ operationId: "operation-1", seq: 1 });
+      firstMutation.resolve({
+        operationId: "operation-1",
+        seq: 1,
+        updatedAt: 2,
+      });
       await firstMutation.promise;
     });
 
@@ -130,7 +143,11 @@ describe("useMindmapSync", () => {
   });
 
   it("uses one cross-instance mutex for duplicate hook instances", async () => {
-    mutationMock.mockResolvedValue({ operationId: "operation-1", seq: 1 });
+    mutationMock.mockResolvedValue({
+      operationId: "operation-1",
+      seq: 1,
+      updatedAt: 2,
+    });
     renderSyncHarness(2);
 
     act(() => {
@@ -148,6 +165,7 @@ describe("useMindmapSync", () => {
     const pendingMutation = createDeferred<{
       operationId: string;
       seq: number;
+      updatedAt: number;
     }>();
     mutationMock.mockReturnValue(pendingMutation.promise);
     const rendered = renderSyncHarness();
@@ -164,7 +182,11 @@ describe("useMindmapSync", () => {
     rendered.unmount();
 
     await act(async () => {
-      pendingMutation.resolve({ operationId: "operation-1", seq: 1 });
+      pendingMutation.resolve({
+        operationId: "operation-1",
+        seq: 1,
+        updatedAt: 2,
+      });
       await pendingMutation.promise;
     });
 
@@ -235,7 +257,11 @@ describe("useMindmapSync", () => {
   it("retrySync bypasses backoff and flushes immediately", async () => {
     mutationMock
       .mockRejectedValueOnce(new Error("Offline"))
-      .mockResolvedValueOnce({ operationId: "operation-2", seq: 2 });
+      .mockResolvedValueOnce({
+        operationId: "operation-2",
+        seq: 2,
+        updatedAt: 2,
+      });
     renderSyncHarness();
 
     act(() => {
@@ -256,7 +282,11 @@ describe("useMindmapSync", () => {
   });
 
   it("flushNow drains a dirty queue and reports whether it is safe to navigate", async () => {
-    mutationMock.mockResolvedValue({ operationId: "operation-1", seq: 1 });
+    mutationMock.mockResolvedValue({
+      operationId: "operation-1",
+      seq: 1,
+      updatedAt: 2,
+    });
     renderSyncHarness();
 
     act(() => {
@@ -277,7 +307,11 @@ describe("useMindmapSync", () => {
   });
 
   it("restores persisted pages from queue truth and re-arms saving", async () => {
-    mutationMock.mockResolvedValue({ operationId: "operation-1", seq: 1 });
+    mutationMock.mockResolvedValue({
+      operationId: "operation-1",
+      seq: 1,
+      updatedAt: 2,
+    });
     renderSyncHarness();
 
     act(() => {
@@ -293,7 +327,11 @@ describe("useMindmapSync", () => {
   });
 
   it("fires a final peeked mutation when unmounting with a dirty queue", async () => {
-    mutationMock.mockResolvedValue({ operationId: "operation-1", seq: 1 });
+    mutationMock.mockResolvedValue({
+      operationId: "operation-1",
+      seq: 1,
+      updatedAt: 2,
+    });
     const rendered = renderSyncHarness();
 
     act(() => {
@@ -321,8 +359,16 @@ describe("useMindmapSync", () => {
 
   it("preserves order while splitting consecutive user and AI runs", async () => {
     mutationMock
-      .mockResolvedValueOnce({ operationId: "operation-1", seq: 1 })
-      .mockResolvedValueOnce({ operationId: "operation-2", seq: 2 });
+      .mockResolvedValueOnce({
+        operationId: "operation-1",
+        seq: 1,
+        updatedAt: 2,
+      })
+      .mockResolvedValueOnce({
+        operationId: "operation-2",
+        seq: 2,
+        updatedAt: 3,
+      });
     renderSyncHarness();
 
     act(() => {

--- a/components/flow/hooks/useMindmapSync.ts
+++ b/components/flow/hooks/useMindmapSync.ts
@@ -215,6 +215,10 @@ function useMindmapSync(): void {
           schedulePending();
         }
 
+        // A live result observed while this batch was in flight was held back
+        // so local state stayed ahead. Apply it only after the queue drains.
+        store.getState().actions.applyPendingServerState();
+
         return !state.desyncedSinceRejection;
       } finally {
         if (isDisposed) {

--- a/components/flow/hooks/useMindmapSync.ts
+++ b/components/flow/hooks/useMindmapSync.ts
@@ -159,12 +159,17 @@ function useMindmapSync(): void {
       try {
         for (const run of groupPendingOpsBySource(batch.ops)) {
           try {
-            await applyOps({
+            const result = await applyOps({
               mindmapId: store.getState().mindmapDB._id,
               ops: toWireOps(run.ops),
               description: describePendingOps(run.ops),
               source: run.source,
             });
+
+            if (isDisposed) return false;
+            store
+              .getState()
+              .actions.commitFlushedOps(run.count, result.updatedAt);
           } catch (error) {
             if (isDisposed) return false;
 
@@ -193,9 +198,6 @@ function useMindmapSync(): void {
             return false;
           }
 
-          if (isDisposed) return false;
-
-          store.getState().actions.commitFlushedOps(run.count);
           consecutiveFailures = 0;
         }
 

--- a/components/flow/mindmap/mindmapNodesToFlowNodes.ts
+++ b/components/flow/mindmap/mindmapNodesToFlowNodes.ts
@@ -82,7 +82,8 @@ function transformMindmapNodesToFlowNodesAndEdges(
   const flowEdges: FlowEdge[] = [];
 
   const rootMindmapNode = mindmapNodes[ROOT_NODE_ID];
-  // A partially written or empty snapshot must let Flow render its starter map.
+  // A partially written or empty snapshot intentionally remains empty; the
+  // server projection is the source of truth for server-seeded canvases.
   if (!rootMindmapNode) {
     return { nodes: flowNodes, edges: flowEdges };
   }

--- a/components/flow/nodes/Node/Node.tsx
+++ b/components/flow/nodes/Node/Node.tsx
@@ -49,7 +49,7 @@ const BaseNodeContent = (props: {
       className={cn(
         "w-[300px] py-3 px-5 items-start text-left",
         "rounded-lg border border-line-strong bg-card text-card-foreground",
-        "transition-[border-color,box-shadow] duration-200 ease-organic",
+        "transition-[border-color,box-shadow] duration-200 ease-organic motion-reduce:transition-none",
         {
           "border-primary shadow-[0_0_0_2px_var(--background),0_0_0_4px_var(--primary)]":
             isSelected,

--- a/components/flow/nodes/Node/Node.tsx
+++ b/components/flow/nodes/Node/Node.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 
 import { useMindmapFlow } from "../../providers/MindmapFlowProvider";
 import { NodeAiEdit } from "./NodeAiEdit";
-import NodeDataInput from "./NodeDataInput";
+import { NodeDataInput } from "./NodeDataInput";
 
 /**
  * The card that every mindmap node renders into.

--- a/components/flow/nodes/Node/NodeDataInput.test.tsx
+++ b/components/flow/nodes/Node/NodeDataInput.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Edge } from "@xyflow/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MindmapDB } from "@/types/Mindmap";
+
+import { ROOT_NODE_ID } from "../../const";
+import { createEdge } from "../../mindmap/createEdge";
+import { createBaseFlowNodeFromPartialBaseFlowNode } from "../../mindmap/createNode";
+import {
+  MindmapFlowProvider,
+  useMindmapStoreApi,
+} from "../../providers/MindmapFlowProvider";
+import { BaseFlowNode, NodeTypes } from "../../types";
+import { NodeDataInput } from "./NodeDataInput";
+
+let store: ReturnType<typeof useMindmapStoreApi>;
+
+afterEach(cleanup);
+
+describe("NodeDataInput", () => {
+  it("updates an untouched field when the server reseeds the node", () => {
+    renderEditor();
+
+    reseedNode({ description: "Server description", title: "Server title" });
+
+    expect(screen.getByLabelText("Title")).toHaveProperty(
+      "value",
+      "Server title"
+    );
+    expect(screen.getByLabelText("Description")).toHaveProperty(
+      "value",
+      "Server description"
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("keeps a touched field and warns when the server changes it", async () => {
+    const user = userEvent.setup();
+    renderEditor();
+
+    const title = screen.getByLabelText("Title");
+    await user.clear(title);
+    await user.type(title, "My local title");
+    reseedNode({ description: "Server description", title: "Server title" });
+
+    expect(title).toHaveProperty("value", "My local title");
+    expect(screen.getByLabelText("Description")).toHaveProperty(
+      "value",
+      "Server description"
+    );
+    expect(screen.getByRole("status").textContent).toBe(
+      "This node changed elsewhere — saving will overwrite."
+    );
+  });
+});
+
+/** Mounts the real editor over a selected node in the canvas store. */
+function renderEditor(): void {
+  render(
+    <MindmapFlowProvider {...createEditorFixture()}>
+      <StoreProbe />
+      <NodeDataInput />
+    </MindmapFlowProvider>
+  );
+
+  act(() => store.getState().setSelectedNode("right-child"));
+}
+
+/** Captures the provider store so tests can deliver a live server reseed. */
+function StoreProbe() {
+  store = useMindmapStoreApi();
+  return null;
+}
+
+/** Replaces the selected node with a newer server projection. */
+function reseedNode(data: { description: string; title: string }): void {
+  act(() => {
+    store.getState().actions.reseedFromServer({
+      name: "Editor fixture",
+      nodes: [
+        {
+          nodeId: ROOT_NODE_ID,
+          order: 0,
+          parentId: null,
+          title: "Root",
+          type: "root",
+        },
+        {
+          description: data.description,
+          nodeId: "right-child",
+          order: 0,
+          parentId: ROOT_NODE_ID,
+          title: data.title,
+          type: "right",
+        },
+      ],
+      updatedAt: 2,
+      visibility: "private",
+    });
+  });
+}
+
+/** Creates the smallest editable graph accepted by the provider. */
+function createEditorFixture(): {
+  mindmapDB: MindmapDB;
+  initialNodes: BaseFlowNode[];
+  initialEdges: Edge[];
+} {
+  return {
+    mindmapDB: {
+      _id: "mindmaps:editor-fixture" as MindmapDB["_id"],
+      isOwner: true,
+      name: "Editor fixture",
+      publicId: "editor-map",
+      updatedAt: 1,
+      visibility: "private",
+    },
+    initialNodes: [
+      createBaseFlowNodeFromPartialBaseFlowNode({
+        data: { title: "Root" },
+        id: ROOT_NODE_ID,
+        type: NodeTypes.ROOT,
+      }),
+      createBaseFlowNodeFromPartialBaseFlowNode({
+        data: { description: "Original description", title: "Original title" },
+        id: "right-child",
+        type: NodeTypes.RIGHT,
+      }),
+    ],
+    initialEdges: [createEdge(ROOT_NODE_ID, "right-child")],
+  };
+}

--- a/components/flow/nodes/Node/NodeDataInput.tsx
+++ b/components/flow/nodes/Node/NodeDataInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -7,6 +7,12 @@ import { Stack } from "@/components/ui/stack";
 import { Textarea } from "@/components/ui/textarea";
 
 import { useMindmapFlow } from "../../providers/MindmapFlowProvider";
+
+type NodeFormData = {
+  title: string;
+  description: string;
+  link: string;
+};
 
 function NodeDataInputForm({
   title: _title,
@@ -19,12 +25,66 @@ function NodeDataInputForm({
   link?: string;
   nodeId: string;
 }) {
-  const [title, setTitle] = useState(_title);
-  const [description, setDescription] = useState(_description ?? "");
-  const [link, setLink] = useState(_link ?? "");
+  const sourceData = useMemo<NodeFormData>(
+    () => ({
+      title: _title,
+      description: _description ?? "",
+      link: _link ?? "",
+    }),
+    [_description, _link, _title]
+  );
+  const seededDataRef = useRef<NodeFormData>(sourceData);
+  const [title, setTitle] = useState(sourceData.title);
+  const [description, setDescription] = useState(sourceData.description);
+  const [link, setLink] = useState(sourceData.link);
+  const [conflictedFields, setConflictedFields] = useState<
+    Set<keyof NodeFormData>
+  >(new Set());
 
   const setSelectedNode = useMindmapFlow((state) => state.setSelectedNode);
   const onUpdateNode = useMindmapFlow((state) => state.actions.onUpdateNode);
+
+  useEffect(() => {
+    const seededData = seededDataRef.current;
+    const currentData = { title, description, link };
+    const nextConflictedFields = new Set(conflictedFields);
+    let conflictsChanged = false;
+
+    /**
+     * Advances one field's server baseline without overwriting local work.
+     */
+    function mergeField(
+      field: keyof NodeFormData,
+      updateValue: (value: string) => void
+    ): void {
+      if (sourceData[field] === seededData[field]) {
+        return;
+      }
+
+      if (currentData[field] === seededData[field]) {
+        updateValue(sourceData[field]);
+        if (nextConflictedFields.delete(field)) {
+          conflictsChanged = true;
+        }
+      } else if (currentData[field] !== sourceData[field]) {
+        if (!nextConflictedFields.has(field)) {
+          nextConflictedFields.add(field);
+          conflictsChanged = true;
+        }
+      } else if (nextConflictedFields.delete(field)) {
+        conflictsChanged = true;
+      }
+    }
+
+    mergeField("title", setTitle);
+    mergeField("description", setDescription);
+    mergeField("link", setLink);
+    seededDataRef.current = sourceData;
+
+    if (conflictsChanged) {
+      setConflictedFields(nextConflictedFields);
+    }
+  }, [conflictedFields, description, link, sourceData, title]);
 
   const handleSave = useCallback(() => {
     setSelectedNode(null);
@@ -117,12 +177,20 @@ function NodeDataInputForm({
         />
       </Stack>
 
-      <Button onClick={handleSave}>Save</Button>
+      {conflictedFields.size > 0 ? (
+        <p className="text-xs text-muted-foreground" role="status">
+          This node changed elsewhere — saving will overwrite.
+        </p>
+      ) : null}
+
+      <Button onClick={handleSave} type="button">
+        Save
+      </Button>
     </form>
   );
 }
 
-export default function NodeDataInput() {
+function NodeDataInput() {
   const selectedNode = useMindmapFlow((state) => state.selectedNode);
   const nodesMap = useMindmapFlow((state) => state.nodesMap);
 
@@ -136,9 +204,12 @@ export default function NodeDataInput() {
       <NodeDataInputForm
         title={node.data.title}
         description={node.data.description}
+        key={node.id}
         link={node.data.link}
         nodeId={node.id}
       />
     </Stack>
   );
 }
+
+export { NodeDataInput };

--- a/components/flow/providers/MindmapFlowProvider.test.tsx
+++ b/components/flow/providers/MindmapFlowProvider.test.tsx
@@ -1,16 +1,13 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
-import { Edge } from "@xyflow/react";
 import { StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { MindmapDB } from "@/types/Mindmap";
+import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 
 import { ROOT_NODE_ID } from "../const";
-import { createEdge } from "../mindmap/createEdge";
-import { createBaseFlowNodeFromPartialBaseFlowNode } from "../mindmap/createNode";
-import { BaseFlowNode, NodeTypes } from "../types";
+import { NodeTypes } from "../types";
 import { MindmapFlowProvider, useMindmapFlow } from "./MindmapFlowProvider";
 
 afterEach(cleanup);
@@ -72,6 +69,40 @@ describe("MindmapFlowProvider", () => {
 
     expect(view.getByTestId("read-only").textContent).toBe("true");
   });
+
+  it("seeds empty and root-only server snapshots exactly as received", () => {
+    const fixture = createProviderFixture();
+    const empty = render(
+      <MindmapFlowProvider {...fixture} serverNodes={[]}>
+        <SeedProbe />
+      </MindmapFlowProvider>
+    );
+
+    expect(empty.getByTestId("node-ids").textContent).toBe("");
+    expect(empty.getByTestId("edge-count").textContent).toBe("0");
+    empty.unmount();
+
+    const rootOnly = render(
+      <MindmapFlowProvider
+        {...fixture}
+        serverNodes={[
+          {
+            nodeId: ROOT_NODE_ID,
+            order: 0,
+            parentId: null,
+            title: "Server root",
+            type: "root",
+          },
+        ]}
+      >
+        <SeedProbe />
+      </MindmapFlowProvider>
+    );
+
+    expect(rootOnly.getByTestId("node-ids").textContent).toBe(ROOT_NODE_ID);
+    expect(rootOnly.getByTestId("node-titles").textContent).toBe("Server root");
+    expect(rootOnly.getByTestId("edge-count").textContent).toBe("0");
+  });
 });
 
 /** Exposes selected store writes while recording renders of the active slice. */
@@ -106,25 +137,29 @@ function ReadOnlyProbe() {
   return <output data-testid="read-only">{String(readOnly)}</output>;
 }
 
+/** Reports the graph contents seeded into the provider's isolated store. */
+function SeedProbe() {
+  const nodes = useMindmapFlow((state) => state.nodes);
+  const edgeCount = useMindmapFlow((state) => state.edges.length);
+
+  return (
+    <>
+      <output data-testid="node-ids">
+        {nodes.map((node) => node.id).join(",")}
+      </output>
+      <output data-testid="node-titles">
+        {nodes.map((node) => node.data.title).join(",")}
+      </output>
+      <output data-testid="edge-count">{edgeCount}</output>
+    </>
+  );
+}
+
 /** Creates a minimal rooted mindmap for provider wiring tests. */
 function createProviderFixture(): {
   mindmapDB: MindmapDB;
-  initialNodes: BaseFlowNode[];
-  initialEdges: Edge[];
+  serverNodes: MindmapNodeProjection[];
 } {
-  const initialNodes = [
-    createBaseFlowNodeFromPartialBaseFlowNode({
-      id: ROOT_NODE_ID,
-      type: NodeTypes.ROOT,
-      data: { title: "Root" },
-    }),
-    createBaseFlowNodeFromPartialBaseFlowNode({
-      id: "l-child",
-      type: NodeTypes.LEFT,
-      data: { title: "Left child" },
-    }),
-  ];
-  const initialEdges = [createEdge(ROOT_NODE_ID, "l-child")];
   const mindmapDB: MindmapDB = {
     _id: "mindmaps:provider-fixture" as MindmapDB["_id"],
     publicId: "provider-map",
@@ -134,5 +169,23 @@ function createProviderFixture(): {
     isOwner: true,
   };
 
-  return { mindmapDB, initialNodes, initialEdges };
+  return {
+    mindmapDB,
+    serverNodes: [
+      {
+        nodeId: ROOT_NODE_ID,
+        order: 0,
+        parentId: null,
+        title: "Root",
+        type: NodeTypes.ROOT,
+      },
+      {
+        nodeId: "l-child",
+        order: 0,
+        parentId: ROOT_NODE_ID,
+        title: "Left child",
+        type: NodeTypes.LEFT,
+      },
+    ],
+  };
 }

--- a/components/flow/providers/MindmapFlowProvider.tsx
+++ b/components/flow/providers/MindmapFlowProvider.tsx
@@ -3,8 +3,9 @@ import { createContext, useCallback, useContext, useState } from "react";
 import { StoreApi, useStore } from "zustand";
 
 import { useKey } from "@/hooks/use-key";
-import { MindmapDB } from "@/types/Mindmap";
+import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 
+import { INITIAL_EDGES, INITIAL_NODES } from "../initialNodesAndEdges";
 import { BaseFlowNode } from "../types";
 import { createMindmapStore, MindmapStore } from "./store";
 import { MindmapFlowContext as MindmapFlowContextType } from "./types";
@@ -34,28 +35,48 @@ function useMindmapStoreApi(): StoreApi<MindmapStore> {
   return store;
 }
 
-type MindmapFlowProviderProps = {
+type MindmapFlowProviderBaseProps = {
   children: React.ReactNode;
   readOnly?: boolean;
   mindmapDB: MindmapDB;
-  initialNodes: BaseFlowNode[];
-  initialEdges: Edge[];
 };
+
+type MindmapFlowProviderProps =
+  | (MindmapFlowProviderBaseProps & {
+      serverNodes: MindmapNodeProjection[];
+    })
+  | (MindmapFlowProviderBaseProps & {
+      initialNodes: BaseFlowNode[];
+      initialEdges: Edge[];
+    });
 
 /**
  * Provides one isolated mindmap store initialized from the supplied mindmap.
  */
-const MindmapFlowProvider = ({
-  children,
-  readOnly = false,
-  mindmapDB,
-  initialNodes,
-  initialEdges,
-}: MindmapFlowProviderProps) => {
+const MindmapFlowProvider = (props: MindmapFlowProviderProps) => {
+  const { children, mindmapDB } = props;
+  const readOnly = props.readOnly ?? false;
+
   // A lazy state initializer guarantees one prop-seeded store per provider.
-  const [store] = useState(() =>
-    createMindmapStore({ readOnly, mindmapDB, initialNodes, initialEdges })
-  );
+  const [store] = useState(() => {
+    if ("serverNodes" in props && props.serverNodes.length > 0) {
+      return createMindmapStore({
+        readOnly,
+        mindmapDB,
+        serverNodes: props.serverNodes,
+      });
+    }
+
+    const fallbackSeed =
+      "initialNodes" in props
+        ? {
+            initialNodes: props.initialNodes,
+            initialEdges: props.initialEdges,
+          }
+        : { initialNodes: INITIAL_NODES, initialEdges: INITIAL_EDGES };
+
+    return createMindmapStore({ readOnly, mindmapDB, ...fallbackSeed });
+  });
 
   const debugLogger = useCallback(() => {
     // eslint-disable-next-line no-console -- needed for debug logging

--- a/components/flow/providers/MindmapFlowProvider.tsx
+++ b/components/flow/providers/MindmapFlowProvider.tsx
@@ -5,7 +5,6 @@ import { StoreApi, useStore } from "zustand";
 import { useKey } from "@/hooks/use-key";
 import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 
-import { INITIAL_EDGES, INITIAL_NODES } from "../initialNodesAndEdges";
 import { BaseFlowNode } from "../types";
 import { createMindmapStore, MindmapStore } from "./store";
 import { MindmapFlowContext as MindmapFlowContextType } from "./types";
@@ -59,7 +58,7 @@ const MindmapFlowProvider = (props: MindmapFlowProviderProps) => {
 
   // A lazy state initializer guarantees one prop-seeded store per provider.
   const [store] = useState(() => {
-    if ("serverNodes" in props && props.serverNodes.length > 0) {
+    if ("serverNodes" in props) {
       return createMindmapStore({
         readOnly,
         mindmapDB,
@@ -67,15 +66,12 @@ const MindmapFlowProvider = (props: MindmapFlowProviderProps) => {
       });
     }
 
-    const fallbackSeed =
-      "initialNodes" in props
-        ? {
-            initialNodes: props.initialNodes,
-            initialEdges: props.initialEdges,
-          }
-        : { initialNodes: INITIAL_NODES, initialEdges: INITIAL_EDGES };
-
-    return createMindmapStore({ readOnly, mindmapDB, ...fallbackSeed });
+    return createMindmapStore({
+      readOnly,
+      mindmapDB,
+      initialNodes: props.initialNodes,
+      initialEdges: props.initialEdges,
+    });
   });
 
   const debugLogger = useCallback(() => {

--- a/components/flow/providers/store.test.ts
+++ b/components/flow/providers/store.test.ts
@@ -277,8 +277,10 @@ describe("createMindmapStore", () => {
     store.getState().actions.markSyncState("saving");
 
     const reseeded = store.getState().actions.reseedFromServer({
+      name: "Server fixture",
       nodes: createServerNodes(),
       updatedAt: 2,
+      visibility: "shared",
     });
     const state = store.getState();
 
@@ -300,6 +302,9 @@ describe("createMindmapStore", () => {
       },
     ]);
     expect(state.syncState).toBe("saving");
+    expect(state.mindmapDB.name).toBe("Server fixture");
+    expect(state.mindmapDB.visibility).toBe("shared");
+    expect(state.reseedCount).toBe(1);
     expect(state.seededUpdatedAt).toBe(2);
     expectDerivedStateInvariant(state);
   });
@@ -313,8 +318,10 @@ describe("createMindmapStore", () => {
     const previousNodes = store.getState().nodes;
 
     const reseeded = store.getState().actions.reseedFromServer({
+      name: "Server fixture",
       nodes: createServerNodes(),
       updatedAt: 2,
+      visibility: "shared",
     });
 
     expect(reseeded).toBe(false);
@@ -324,6 +331,27 @@ describe("createMindmapStore", () => {
       "[MindmapFlowProvider] ignored reseedFromServer in read-only mode"
     );
     warning.mockRestore();
+  });
+
+  it("ignores a queued snapshot older than the acknowledged flush", () => {
+    const store = createFixtureStore();
+
+    store.getState().actions.onUpdateNode("r-child", { title: "Local edit" });
+    const batch = store.getState().actions.peekPendingOps()!;
+    store.getState().actions.reconcileServerState({
+      name: "Stale server fixture",
+      nodes: createServerNodes(),
+      updatedAt: 2,
+      visibility: "shared",
+    });
+
+    store.getState().actions.commitFlushedOps(batch.count, 3);
+
+    expect(store.getState().acknowledgedServerVersion).toBe(3);
+    expect(store.getState().pendingServerState).toBeNull();
+    expect(store.getState().actions.applyPendingServerState()).toBe(false);
+    expect(store.getState().mindmapDB.name).toBe("Store fixture");
+    expect(store.getState().mindmapDB.visibility).toBe("private");
   });
 
   it("rejects mutation actions when seeded read-only", () => {

--- a/components/flow/providers/store.test.ts
+++ b/components/flow/providers/store.test.ts
@@ -3,7 +3,7 @@
 import { Edge } from "@xyflow/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { MindmapDB } from "@/types/Mindmap";
+import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 
 import { ROOT_NODE_ID } from "../const";
 import { initGraphs, initLayout } from "../layout/init";
@@ -263,6 +263,69 @@ describe("createMindmapStore", () => {
     expectDerivedStateInvariant(store.getState());
   });
 
+  it("reseeds every derived graph while preserving valid UI and sync state", () => {
+    const store = createFixtureStore();
+    const previousLayout = store.getState().layout;
+
+    store.getState().setActiveNode("l-child");
+    store.getState().setSelectedNode("r-child");
+    store.getState().setAiEditNode("l-child");
+    store.getState().setAiTouchedNodeIds(["l-child"]);
+    store
+      .getState()
+      .actions.onUpdateNode("r-child", { title: "Unsaved local edit" });
+    store.getState().actions.markSyncState("saving");
+
+    const reseeded = store.getState().actions.reseedFromServer({
+      nodes: createServerNodes(),
+      updatedAt: 2,
+    });
+    const state = store.getState();
+
+    expect(reseeded).toBe(true);
+    expect(state.layout).not.toBe(previousLayout);
+    expect(state.layout.rightGraph.hasNode("r-server")).toBe(true);
+    expect(state.nodesMap["r-server"].data.title).toBe("Server child");
+    expect(state.mindmapNodesMap["root"].children.has("r-server")).toBe(true);
+    expect(state.activeNode).toBe("l-child");
+    expect(state.selectedNode).toBeNull();
+    expect(state.aiEditNode).toBe("l-child");
+    expect(state.aiTouchedNodeIds).toEqual(["l-child"]);
+    expect(state.pendingOps).toEqual([
+      {
+        kind: "update",
+        source: "user",
+        nodeId: "r-child",
+        patch: { title: "Unsaved local edit" },
+      },
+    ]);
+    expect(state.syncState).toBe("saving");
+    expect(state.seededUpdatedAt).toBe(2);
+    expectDerivedStateInvariant(state);
+  });
+
+  it("does not reseed a read-only store", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = createMindmapStore({
+      ...createStoreFixture(),
+      readOnly: true,
+    });
+    const previousNodes = store.getState().nodes;
+
+    const reseeded = store.getState().actions.reseedFromServer({
+      nodes: createServerNodes(),
+      updatedAt: 2,
+    });
+
+    expect(reseeded).toBe(false);
+    expect(store.getState().nodes).toBe(previousNodes);
+    expect(store.getState().seededUpdatedAt).toBe(1);
+    expect(warning).toHaveBeenCalledWith(
+      "[MindmapFlowProvider] ignored reseedFromServer in read-only mode"
+    );
+    warning.mockRestore();
+  });
+
   it("rejects mutation actions when seeded read-only", () => {
     const fixture = createStoreFixture();
     const store = createMindmapStore({ ...fixture, readOnly: true });
@@ -412,6 +475,33 @@ function createStoreFixture(): {
   };
 
   return { mindmapDB, initialNodes, initialEdges };
+}
+
+/** Creates a newer server projection with one retained and one created node. */
+function createServerNodes(): MindmapNodeProjection[] {
+  return [
+    {
+      nodeId: ROOT_NODE_ID,
+      parentId: null,
+      type: "root",
+      title: "Server root",
+      order: 0,
+    },
+    {
+      nodeId: "l-child",
+      parentId: ROOT_NODE_ID,
+      type: "left",
+      title: "Left child from server",
+      order: 0,
+    },
+    {
+      nodeId: "r-server",
+      parentId: ROOT_NODE_ID,
+      type: "right",
+      title: "Server child",
+      order: 0,
+    },
+  ];
 }
 
 /** Checks that every source node appears in exactly one non-empty derived level. */

--- a/components/flow/providers/store.ts
+++ b/components/flow/providers/store.ts
@@ -1,7 +1,7 @@
 import { applyNodeChanges, Edge } from "@xyflow/react";
 import { createStore, StoreApi } from "zustand";
 
-import { MindmapDB } from "@/types/Mindmap";
+import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 
 import { ROOT_NODE_ID } from "../const";
 import { generateLeveledNodes } from "../layout/generateLeveledNodes";
@@ -12,7 +12,10 @@ import {
   initLayout,
   NODE_DIMENSIONS,
 } from "../layout/init";
-import { createEdge } from "../mindmap/createEdge";
+import {
+  createEdge,
+  createFlowEdgeFromPartialBaseFlowEdge,
+} from "../mindmap/createEdge";
 import {
   createBaseFlowNodeFromPartialBaseFlowNode,
   createNode,
@@ -22,16 +25,38 @@ import {
   createMindmapNodeFromFlowNode,
   transformFlowNodesAndEdgesToMindmapNodes,
 } from "../mindmap/flowNodeToMindmapNode";
-import { transformMindmapNodesToFlowNodesAndEdges } from "../mindmap/mindmapNodesToFlowNodes";
+import {
+  PartialBaseFlowEdge,
+  PartialBaseFlowNode,
+  transformConvexNodesToFlowNodesAndEdges,
+  transformMindmapNodesToFlowNodesAndEdges,
+} from "../mindmap/mindmapNodesToFlowNodes";
 import { appendPendingOp, PendingNodePatch } from "../mindmap/pendingOps";
 import { BaseFlowNode, FlowNode, MindmapNode, NodeTypes } from "../types";
-import { MindmapFlowContext } from "./types";
+import { MindmapFlowContext, ServerMindmapState } from "./types";
 
 type MindmapStore = MindmapFlowContext;
 
-type MindmapStoreSeed = {
+type MindmapStoreSeedBase = {
   readOnly?: boolean;
   mindmapDB: MindmapDB;
+};
+
+type MindmapStoreSeed =
+  | (MindmapStoreSeedBase & {
+      serverNodes: MindmapNodeProjection[];
+    })
+  | (MindmapStoreSeedBase & {
+      initialNodes: BaseFlowNode[];
+      initialEdges: Edge[];
+    });
+
+type SeededGraphState = Pick<
+  MindmapStore,
+  "layout" | "nodes" | "edges" | "nodesMap" | "mindmapNodesMap" | "leveledNodes"
+>;
+
+type FlowGraphSeed = {
   initialNodes: BaseFlowNode[];
   initialEdges: Edge[];
 };
@@ -49,6 +74,48 @@ function deriveLeveledNodes(
   mindmapNodesMap: Record<string, MindmapNode>
 ): MindmapNode[][] {
   return generateLeveledNodes(mindmapNodesMap);
+}
+
+/**
+ * Runs the canonical layout pipeline and derives every graph representation.
+ */
+function createSeededGraphState({
+  initialNodes,
+  initialEdges,
+}: FlowGraphSeed): SeededGraphState {
+  const layout = initGraphs();
+  const nodes = initLayout(layout, initialNodes, initialEdges);
+  const edges = initialEdges;
+  const mindmapNodesMap = transformFlowNodesAndEdgesToMindmapNodes(
+    nodes,
+    edges
+  );
+
+  return {
+    layout,
+    nodes,
+    edges,
+    nodesMap: deriveNodesMap(nodes),
+    mindmapNodesMap,
+    leveledNodes: deriveLeveledNodes(mindmapNodesMap),
+  };
+}
+
+/**
+ * Transforms one sorted Convex projection through the canonical seed pipeline.
+ */
+function createSeededGraphStateFromServer(
+  serverNodes: MindmapNodeProjection[]
+): SeededGraphState {
+  const graph = transformConvexNodesToFlowNodesAndEdges(serverNodes);
+  const initialNodes = graph.nodes.map((node) =>
+    createBaseFlowNodeFromPartialBaseFlowNode(node as PartialBaseFlowNode)
+  );
+  const initialEdges = graph.edges.map((edge) =>
+    createFlowEdgeFromPartialBaseFlowEdge(edge as PartialBaseFlowEdge)
+  );
+
+  return createSeededGraphState({ initialNodes, initialEdges });
 }
 
 /** Builds a minimal wire patch while preserving explicit optional removals. */
@@ -87,21 +154,70 @@ function warnReadOnlyMutation(action: string): void {
  * Graph objects stay mutable as before, while each state write also refreshes
  * every derived view affected by that write.
  */
-function createMindmapStore({
-  readOnly = false,
-  mindmapDB,
-  initialNodes,
-  initialEdges,
-}: MindmapStoreSeed): StoreApi<MindmapStore> {
-  const layout = initGraphs();
-  const nodes = initLayout(layout, initialNodes, initialEdges);
-  const edges = initialEdges;
-  const initialMindmapNodesMap = transformFlowNodesAndEdgesToMindmapNodes(
-    nodes,
-    edges
-  );
+function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
+  const { mindmapDB } = seed;
+  const readOnly = seed.readOnly ?? false;
+  const initialGraphState =
+    "serverNodes" in seed
+      ? createSeededGraphStateFromServer(seed.serverNodes)
+      : createSeededGraphState(seed);
 
   return createStore<MindmapStore>((set, get) => {
+    /**
+     * Replaces server-backed graph views while retaining local and UI state.
+     */
+    const reseedFromServer = (serverState: ServerMindmapState): boolean => {
+      const current = get();
+
+      if (readOnly) {
+        warnReadOnlyMutation("reseedFromServer");
+        return false;
+      }
+
+      if (serverState.updatedAt <= current.seededUpdatedAt) {
+        return false;
+      }
+
+      const graphState = createSeededGraphStateFromServer(serverState.nodes);
+      const liveNodeIds = new Set(Object.keys(graphState.nodesMap));
+      const pendingTouchedNodeIds = current.pendingAiTouchedNodeIds;
+
+      // The first commit mounts the server nodes; the second starts any queued
+      // bloom only after those nodes can receive the CSS class.
+      set((state) => ({
+        ...graphState,
+        activeNode:
+          state.activeNode !== null && liveNodeIds.has(state.activeNode)
+            ? state.activeNode
+            : null,
+        selectedNode:
+          state.selectedNode !== null && liveNodeIds.has(state.selectedNode)
+            ? state.selectedNode
+            : null,
+        aiEditNode:
+          state.aiEditNode !== null && liveNodeIds.has(state.aiEditNode)
+            ? state.aiEditNode
+            : null,
+        mindmapDB: {
+          ...state.mindmapDB,
+          updatedAt: serverState.updatedAt,
+        },
+        seededUpdatedAt: serverState.updatedAt,
+        pendingServerState:
+          state.pendingServerState !== null &&
+          state.pendingServerState.updatedAt > serverState.updatedAt
+            ? state.pendingServerState
+            : null,
+        pendingAiTouchedNodeIds: [],
+      }));
+
+      if (pendingTouchedNodeIds.length > 0) {
+        set({ aiTouchedNodeIds: pendingTouchedNodeIds });
+      }
+
+      return true;
+    };
+
     /** Applies XYFlow node changes and refreshes the node lookup atomically. */
     const onNodesChange: MindmapFlowContext["actions"]["onNodesChange"] = (
       changes
@@ -145,7 +261,8 @@ function createMindmapStore({
         return null;
       }
 
-      const currentMindmapNodesMap = get().mindmapNodesMap;
+      const currentState = get();
+      const currentMindmapNodesMap = currentState.mindmapNodesMap;
 
       if (!currentMindmapNodesMap[parentNodeId]) {
         // eslint-disable-next-line no-console -- needed
@@ -169,9 +286,13 @@ function createMindmapStore({
       }
 
       const newGraph =
-        type === NodeTypes.LEFT ? layout.leftGraph : layout.rightGraph;
+        type === NodeTypes.LEFT
+          ? currentState.layout.leftGraph
+          : currentState.layout.rightGraph;
       const oldGraph =
-        type === NodeTypes.LEFT ? layout.rightGraph : layout.leftGraph;
+        type === NodeTypes.LEFT
+          ? currentState.layout.rightGraph
+          : currentState.layout.leftGraph;
 
       if (!newGraph.hasNode(parentNodeId)) {
         // eslint-disable-next-line no-console -- needed
@@ -308,8 +429,8 @@ function createMindmapStore({
         const updatedNode = { ...currentNode, data };
         const graph =
           updatedNode.type === NodeTypes.LEFT
-            ? layout.leftGraph
-            : layout.rightGraph;
+            ? state.layout.leftGraph
+            : state.layout.rightGraph;
         const patch = createNodeDataPatch(currentNode.data, data);
         const hasChanges = Object.keys(patch).length > 0;
 
@@ -349,12 +470,7 @@ function createMindmapStore({
 
     return {
       readOnly,
-      layout,
-      nodes,
-      edges,
-      nodesMap: deriveNodesMap(nodes),
-      mindmapNodesMap: initialMindmapNodesMap,
-      leveledNodes: deriveLeveledNodes(initialMindmapNodesMap),
+      ...initialGraphState,
       activeNode: ROOT_NODE_ID,
       setActiveNode: (activeNode) => set({ activeNode }),
       selectedNode: null,
@@ -370,6 +486,7 @@ function createMindmapStore({
         }
       },
       aiTouchedNodeIds: [],
+      pendingAiTouchedNodeIds: [],
       setAiTouchedNodeIds: (nodeIds) => {
         if (readOnly) {
           warnReadOnlyMutation("setAiTouchedNodeIds");
@@ -380,6 +497,8 @@ function createMindmapStore({
         set({ aiTouchedNodeIds: nodeIds });
       },
       mindmapDB,
+      seededUpdatedAt: mindmapDB.updatedAt,
+      pendingServerState: null,
       pendingOps: [],
       flushedWatermark: 0,
       lastSyncError: null,
@@ -390,6 +509,66 @@ function createMindmapStore({
         onNodesChange,
         onAddNode,
         onUpdateNode,
+        reseedFromServer,
+        reconcileServerState: (serverState) => {
+          const state = get();
+
+          if (readOnly || serverState.updatedAt <= state.seededUpdatedAt) {
+            return;
+          }
+
+          if (state.pendingOps.length > 0 || state.syncState === "saving") {
+            if (
+              state.pendingServerState === null ||
+              serverState.updatedAt > state.pendingServerState.updatedAt
+            ) {
+              set({ pendingServerState: serverState });
+            }
+            return;
+          }
+
+          reseedFromServer(serverState);
+        },
+        applyPendingServerState: () => {
+          const state = get();
+
+          if (
+            state.pendingServerState === null ||
+            state.pendingOps.length > 0 ||
+            state.syncState === "saving"
+          ) {
+            return false;
+          }
+
+          return reseedFromServer(state.pendingServerState);
+        },
+        setAiTouchedNodeIdsAfterReseed: (
+          nodeIds,
+          seededUpdatedAtAtTurnStart
+        ) => {
+          if (readOnly) {
+            warnReadOnlyMutation("setAiTouchedNodeIdsAfterReseed");
+            return;
+          }
+
+          const state = get();
+          const touchedNodesAreMounted = nodeIds.every(
+            (nodeId) => state.nodesMap[nodeId] !== undefined
+          );
+          if (
+            state.seededUpdatedAt > seededUpdatedAtAtTurnStart &&
+            touchedNodesAreMounted
+          ) {
+            state.setAiTouchedNodeIds(nodeIds);
+            return;
+          }
+
+          set((current) => ({
+            pendingAiTouchedNodeIds: Array.from(
+              new Set([...current.pendingAiTouchedNodeIds, ...nodeIds])
+            ),
+          }));
+        },
         peekPendingOps: () => {
           const ops = get().pendingOps;
 
@@ -472,6 +651,7 @@ function createMindmapStore({
 export {
   createMindmapStore,
   createNodeDataPatch,
+  createSeededGraphStateFromServer,
   deriveLeveledNodes,
   deriveNodesMap,
   type MindmapStore,

--- a/components/flow/providers/store.ts
+++ b/components/flow/providers/store.ts
@@ -84,6 +84,19 @@ function createSeededGraphState({
   initialEdges,
 }: FlowGraphSeed): SeededGraphState {
   const layout = initGraphs();
+
+  // An empty server snapshot is authoritative. Dagre needs a root node to
+  // calculate translations, so skip layout while preserving the empty seed.
+  if (initialNodes.length === 0) {
+    return {
+      layout,
+      nodes: [],
+      edges: initialEdges,
+      nodesMap: {},
+      mindmapNodesMap: {},
+      leveledNodes: [],
+    };
+  }
   const nodes = initLayout(layout, initialNodes, initialEdges);
   const edges = initialEdges;
   const mindmapNodesMap = transformFlowNodesAndEdgesToMindmapNodes(

--- a/components/flow/providers/store.ts
+++ b/components/flow/providers/store.ts
@@ -174,7 +174,10 @@ function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
         return false;
       }
 
-      if (serverState.updatedAt <= current.seededUpdatedAt) {
+      if (
+        serverState.updatedAt <= current.seededUpdatedAt ||
+        serverState.updatedAt < current.acknowledgedServerVersion
+      ) {
         return false;
       }
 
@@ -200,8 +203,11 @@ function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
             : null,
         mindmapDB: {
           ...state.mindmapDB,
+          name: serverState.name,
           updatedAt: serverState.updatedAt,
+          visibility: serverState.visibility,
         },
+        reseedCount: state.reseedCount + 1,
         seededUpdatedAt: serverState.updatedAt,
         pendingServerState:
           state.pendingServerState !== null &&
@@ -497,6 +503,8 @@ function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
         set({ aiTouchedNodeIds: nodeIds });
       },
       mindmapDB,
+      acknowledgedServerVersion: mindmapDB.updatedAt,
+      reseedCount: 0,
       seededUpdatedAt: mindmapDB.updatedAt,
       pendingServerState: null,
       pendingOps: [],
@@ -513,7 +521,11 @@ function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
         reconcileServerState: (serverState) => {
           const state = get();
 
-          if (readOnly || serverState.updatedAt <= state.seededUpdatedAt) {
+          if (
+            readOnly ||
+            serverState.updatedAt <= state.seededUpdatedAt ||
+            serverState.updatedAt < state.acknowledgedServerVersion
+          ) {
             return;
           }
 
@@ -537,6 +549,13 @@ function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
             state.pendingOps.length > 0 ||
             state.syncState === "saving"
           ) {
+            return false;
+          }
+
+          if (
+            state.pendingServerState.updatedAt < state.acknowledgedServerVersion
+          ) {
+            set({ pendingServerState: null });
             return false;
           }
 
@@ -580,7 +599,7 @@ function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
           set({ flushedWatermark: ops.length });
           return { ops: [...ops], count: ops.length };
         },
-        commitFlushedOps: (count) => {
+        commitFlushedOps: (count, acknowledgedUpdatedAt) => {
           set((state) => {
             if (
               count < 0 ||
@@ -590,9 +609,23 @@ function createMindmapStore(seed: MindmapStoreSeed): StoreApi<MindmapStore> {
               throw new Error("Cannot commit outside the flushed prefix");
             }
 
+            const acknowledgedServerVersion =
+              acknowledgedUpdatedAt === undefined
+                ? state.acknowledgedServerVersion
+                : Math.max(
+                    state.acknowledgedServerVersion,
+                    acknowledgedUpdatedAt
+                  );
+
             return {
+              acknowledgedServerVersion,
               pendingOps: state.pendingOps.slice(count),
               flushedWatermark: state.flushedWatermark - count,
+              pendingServerState:
+                state.pendingServerState !== null &&
+                state.pendingServerState.updatedAt < acknowledgedServerVersion
+                  ? null
+                  : state.pendingServerState,
             };
           });
         },

--- a/components/flow/providers/types.ts
+++ b/components/flow/providers/types.ts
@@ -1,14 +1,20 @@
 import { EdgeLabel, GraphLabel, graphlib, NodeLabel } from "@dagrejs/dagre";
 import { ReactFlowProps } from "@xyflow/react";
 
-import { MindmapDB } from "@/types/Mindmap";
+import { MindmapDB, MindmapNodeProjection } from "@/types/Mindmap";
 
 import { NodeOp, PendingOpSource } from "../mindmap/pendingOps";
 import { FlowEdge, FlowNode, MindmapNode, NodeTypes } from "../types";
 
 type DagreGraph = graphlib.Graph<GraphLabel, NodeLabel, EdgeLabel>;
 
-// todo: add documentation for the context
+/** A versioned server graph waiting for the local operation queue to drain. */
+type ServerMindmapState = {
+  nodes: MindmapNodeProjection[];
+  updatedAt: number;
+};
+
+/** All mutable and derived state owned by one canvas provider. */
 type MindmapFlowContext = {
   readOnly: boolean;
   layout: {
@@ -40,8 +46,11 @@ type MindmapFlowContext = {
    */
   aiTouchedNodeIds: string[];
   setAiTouchedNodeIds: (nodeIds: string[]) => void;
+  pendingAiTouchedNodeIds: string[];
 
   mindmapDB: MindmapDB;
+  seededUpdatedAt: number;
+  pendingServerState: ServerMindmapState | null;
   pendingOps: NodeOp[];
   flushedWatermark: number;
   lastSyncError: string | null;
@@ -65,6 +74,13 @@ type MindmapFlowContext = {
       data: FlowNode["data"],
       options?: { source?: PendingOpSource }
     ) => void;
+    reseedFromServer: (serverState: ServerMindmapState) => boolean;
+    reconcileServerState: (serverState: ServerMindmapState) => void;
+    applyPendingServerState: () => boolean;
+    setAiTouchedNodeIdsAfterReseed: (
+      nodeIds: string[],
+      seededUpdatedAtAtTurnStart: number
+    ) => void;
     peekPendingOps: () => {
       ops: NodeOp[];
       count: number;
@@ -82,4 +98,4 @@ type MindmapFlowContext = {
   };
 };
 
-export { type MindmapFlowContext };
+export { type MindmapFlowContext, type ServerMindmapState };

--- a/components/flow/providers/types.ts
+++ b/components/flow/providers/types.ts
@@ -10,8 +10,10 @@ type DagreGraph = graphlib.Graph<GraphLabel, NodeLabel, EdgeLabel>;
 
 /** A versioned server graph waiting for the local operation queue to drain. */
 type ServerMindmapState = {
+  name: string;
   nodes: MindmapNodeProjection[];
   updatedAt: number;
+  visibility: MindmapDB["visibility"];
 };
 
 /** All mutable and derived state owned by one canvas provider. */
@@ -49,6 +51,8 @@ type MindmapFlowContext = {
   pendingAiTouchedNodeIds: string[];
 
   mindmapDB: MindmapDB;
+  acknowledgedServerVersion: number;
+  reseedCount: number;
   seededUpdatedAt: number;
   pendingServerState: ServerMindmapState | null;
   pendingOps: NodeOp[];
@@ -85,7 +89,7 @@ type MindmapFlowContext = {
       ops: NodeOp[];
       count: number;
     } | null;
-    commitFlushedOps: (count: number) => void;
+    commitFlushedOps: (count: number, acknowledgedUpdatedAt?: number) => void;
     releaseFlushedOps: () => void;
     retrySync: () => void;
     flushNow: () => Promise<boolean>;

--- a/components/sidebar/floating-sidebar.tsx
+++ b/components/sidebar/floating-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import * as React from "react";
 
@@ -24,13 +25,6 @@ import { TypographyWithTooltip } from "../ui/typography-with-tooltip";
 import { NewMindmapButton } from "./new-mindmap-btn";
 
 /**
- * Navigation panel listing every mindmap the signed-in user owns.
- *
- * A floating panel laid over the canvas: card surface, hairline boundary, no
- * elevation. Identity is carried by the wordmark and the moss rail on the
- * active row, not by an icon.
- */
-/**
  * Live wrapper: reads the route param to highlight the active map. Kept apart
  * from FloatingSidebar so the Suspense fallback can render the same shell
  * without touching request-time data (useParams breaks static prerender).
@@ -46,6 +40,13 @@ function ActiveFloatingSidebar({
   );
 }
 
+/**
+ * Navigation panel listing every map the signed-in user owns.
+ *
+ * A floating panel laid over the canvas: card surface, hairline boundary, no
+ * elevation. Identity is carried by the wordmark and the moss rail on the
+ * active row, not by an icon.
+ */
 export function FloatingSidebar({
   mindmaps,
   activePublicId,
@@ -82,9 +83,7 @@ export function FloatingSidebar({
 
       <SidebarContent>
         <SidebarGroup className="px-3 py-3">
-          <SidebarGroupLabel className="px-2.5">
-            Your mindmaps
-          </SidebarGroupLabel>
+          <SidebarGroupLabel className="px-2.5">Your maps</SidebarGroupLabel>
           <SidebarMenu>
             <SidebarMenuItem>
               {mindmaps.length ? (
@@ -95,14 +94,16 @@ export function FloatingSidebar({
                         asChild
                         isActive={mindmap.publicId === publicId}
                       >
-                        <a href={`/maps/${mindmap.publicId}`}>
+                        {/* Client navigation, so switching maps keeps this
+                            panel mounted instead of reloading the document. */}
+                        <Link href={`/maps/${mindmap.publicId}`}>
                           <TypographyWithTooltip
                             className="text-sm"
                             variant="p"
                           >
                             {mindmap.name}
                           </TypographyWithTooltip>
-                        </a>
+                        </Link>
                       </SidebarMenuSubButton>
                     </SidebarMenuSubItem>
                   ))}
@@ -112,7 +113,7 @@ export function FloatingSidebar({
                   className="px-2.5 py-2 text-sm text-muted-foreground"
                   variant="p"
                 >
-                  Nothing here yet. Start one and it will show up in this list.
+                  Nothing growing yet. Start a map and it will show up here.
                 </Typography>
               )}
             </SidebarMenuItem>

--- a/components/sidebar/new-mindmap-btn.tsx
+++ b/components/sidebar/new-mindmap-btn.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
-/** Starts a new mindmap. Sits in the sidebar header, next to the wordmark. */
+/** Starts a new map. Sits in the sidebar header, next to the wordmark. */
 export function NewMindmapButton() {
   const router = useRouter();
 
@@ -22,12 +22,13 @@ export function NewMindmapButton() {
           variant="ghost"
           size="icon"
           onClick={handleNewMindmap}
+          type="button"
         >
           <Plus />
-          <span className="sr-only">New mindmap</span>
+          <span className="sr-only">New map</span>
         </Button>
       </TooltipTrigger>
-      <TooltipContent>New mindmap</TooltipContent>
+      <TooltipContent>New map</TooltipContent>
     </Tooltip>
   );
 }

--- a/components/submit-button.tsx
+++ b/components/submit-button.tsx
@@ -11,7 +11,7 @@ type Props = ComponentProps<typeof Button> & {
 
 export function SubmitButton({
   children,
-  pendingText = "Submitting...",
+  pendingText = "Submitting…",
   ...props
 }: Props) {
   const { pending } = useFormStatus();

--- a/components/theme-switcher.tsx
+++ b/components/theme-switcher.tsx
@@ -9,6 +9,14 @@ import { useEventCallback } from "@/hooks/use-event-callback";
 
 const THEME_OPTIONS = ["light", "dark", "system"];
 
+/**
+ * The one global theme control: a single button that cycles light → dark →
+ * system rather than a menu, because the choice is small enough that opening
+ * anything would cost more than trying the next option.
+ *
+ * It renders nothing until mounted: the resolved theme is client-only, and a
+ * server-rendered icon would be a guess the first client paint has to undo.
+ */
 const ThemeSwitcher = () => {
   const [mounted, setMounted] = useState(false);
   const { theme, setTheme } = useTheme();
@@ -38,6 +46,8 @@ const ThemeSwitcher = () => {
       className="absolute top-3.5 right-[var(--theme-switcher-inset)] z-10 text-muted-foreground hover:text-foreground"
       aria-label={`Theme: ${theme}. Click to change.`}
       onClick={() => handleThemeChange()}
+      title={`Theme: ${theme}. Click to change.`}
+      type="button"
     >
       {theme === "light" ? (
         <Sun
@@ -60,45 +70,6 @@ const ThemeSwitcher = () => {
       )}
     </Button>
   );
-
-  // return (
-  //   <DropdownMenu>
-  //     <DropdownMenuTrigger asChild>
-  //       <Button
-  //         variant="ghost"
-  //         size="icon"
-  //         className="absolute top-8 right-8 z-10"
-  //       >
-  //         {theme === "light" ? (
-  //           <Sun key="light" size={ICON_SIZE} />
-  //         ) : theme === "dark" ? (
-  //           <Moon key="dark" size={ICON_SIZE} />
-  //         ) : (
-  //           <Laptop key="system" size={ICON_SIZE} />
-  //         )}
-  //       </Button>
-  //     </DropdownMenuTrigger>
-  //     <DropdownMenuContent className="w-content" align="end">
-  //       <DropdownMenuRadioGroup
-  //         value={theme}
-  //         onValueChange={(e) => setTheme(e)}
-  //       >
-  //         <DropdownMenuRadioItem className="flex gap-2" value="light">
-  //           <Sun size={ICON_SIZE} className="text-muted-foreground" />
-  //           <span>Light</span>
-  //         </DropdownMenuRadioItem>
-  //         <DropdownMenuRadioItem className="flex gap-2" value="dark">
-  //           <Moon size={ICON_SIZE} className="text-muted-foreground" />
-  //           <span>Dark</span>
-  //         </DropdownMenuRadioItem>
-  //         <DropdownMenuRadioItem className="flex gap-2" value="system">
-  //           <Laptop size={ICON_SIZE} className="text-muted-foreground" />
-  //           <span>System</span>
-  //         </DropdownMenuRadioItem>
-  //       </DropdownMenuRadioGroup>
-  //     </DropdownMenuContent>
-  //   </DropdownMenu>
-  // );
 };
 
 export { ThemeSwitcher };

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -65,7 +65,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm text-muted-foreground transition-colors duration-200 ease-organic hover:text-foreground disabled:pointer-events-none">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm text-muted-foreground transition-colors duration-200 ease-organic motion-reduce:transition-none hover:text-foreground disabled:pointer-events-none">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -459,7 +459,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground transition-colors duration-200 ease-organic hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground transition-colors duration-200 ease-organic motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 after:md:hidden",
         "group-data-[collapsible=icon]:hidden",
@@ -511,7 +511,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-colors duration-200 ease-organic hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-colors duration-200 ease-organic motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -605,7 +605,7 @@ const SidebarMenuAction = React.forwardRef<
       ref={ref}
       data-sidebar="menu-action"
       className={cn(
-        "absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground transition-colors duration-200 ease-organic hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground transition-colors duration-200 ease-organic motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 after:md:hidden",
         "peer-data-[size=sm]/menu-button:top-1",
@@ -721,7 +721,7 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-9 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2.5 text-muted-foreground transition-colors duration-200 ease-organic hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-9 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2.5 text-muted-foreground transition-colors duration-200 ease-organic motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
         // The active map is marked by a moss rail inset into the row, so the
         // cue survives the row's own hover fill.
         "data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[active=true]:shadow-[inset_2px_0_0_var(--primary)]",

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /**
  * Generated `api` utility.
  *

--- a/convex/ops.test.ts
+++ b/convex/ops.test.ts
@@ -828,7 +828,15 @@ describe("ops.undo and history", () => {
     });
     const after = await readNodeRows(t, map.mindmapId);
 
-    expect(undone.seq).toBe(changed.seq);
+    expect(undone).toEqual({
+      seq: changed.seq,
+      updatedAt: expect.any(Number),
+    });
+    expect(changed).toEqual({
+      operationId: changed.operationId,
+      seq: 2,
+      updatedAt: expect.any(Number),
+    });
     expect(after).toEqual(before);
   });
 
@@ -1100,7 +1108,11 @@ describe("ops.undo and history", () => {
       mindmapId: map.mindmapId,
     });
 
-    expect(undone).toEqual({ undoneCount: 2, seq: 5 });
+    expect(undone).toEqual({
+      undoneCount: 2,
+      seq: 5,
+      updatedAt: expect.any(Number),
+    });
     expect(result.nodes.map((node) => node.nodeId)).toEqual(["root"]);
   });
 
@@ -1188,7 +1200,11 @@ describe("ops.undo and history", () => {
       operationId: target.operationId,
     });
 
-    expect(result).toEqual({ undoneCount: 3, seq: 1 });
+    expect(result).toEqual({
+      undoneCount: 3,
+      seq: 1,
+      updatedAt: expect.any(Number),
+    });
     expect(
       (
         await asAlice.query(api.mindmaps.get, {

--- a/convex/ops.ts
+++ b/convex/ops.ts
@@ -599,7 +599,11 @@ function deserializeInverseOps(value: unknown): NodeOp[] {
 export async function applyOps(
   ctx: MutationCtx,
   { mindmapId, ops, actor, description, source }: ApplyOpsArgs
-): Promise<{ operationId: Id<"operations">; seq: number }> {
+): Promise<{
+  operationId: Id<"operations">;
+  seq: number;
+  updatedAt: number;
+}> {
   if (ops.length > MAX_OPS_PER_BATCH) {
     throw new ConvexError("Invalid op: too many operations");
   }
@@ -624,11 +628,10 @@ export async function applyOps(
     actor,
     source,
   });
-  await ctx.db.patch("mindmaps", mindmapId, {
-    updatedAt: Date.now(),
-  });
+  const updatedAt = Date.now();
+  await ctx.db.patch("mindmaps", mindmapId, { updatedAt });
 
-  return { operationId, seq };
+  return { operationId, seq, updatedAt };
 }
 
 /**
@@ -697,11 +700,10 @@ export const undo = mutation({
     await validateOps(ctx, operation.mindmapId, inversePatch);
     await writeOps(ctx, operation.mindmapId, inversePatch);
     await ctx.db.patch("operations", operation._id, { undone: true });
-    await ctx.db.patch("mindmaps", operation.mindmapId, {
-      updatedAt: Date.now(),
-    });
+    const updatedAt = Date.now();
+    await ctx.db.patch("mindmaps", operation.mindmapId, { updatedAt });
 
-    return { seq: operation.seq };
+    return { seq: operation.seq, updatedAt };
   },
 });
 
@@ -749,11 +751,10 @@ export const undoTo = mutation({
       undoneCount += 1;
     }
 
-    await ctx.db.patch("mindmaps", target.mindmapId, {
-      updatedAt: Date.now(),
-    });
+    const updatedAt = Date.now();
+    await ctx.db.patch("mindmaps", target.mindmapId, { updatedAt });
 
-    return { undoneCount, seq: target.seq };
+    return { undoneCount, seq: target.seq, updatedAt };
   },
 });
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,114 @@
+# Production cutover runbook
+
+Everything below is **human-in-the-loop**: no agent or script performs these
+steps. Each stage lists its unlock and its verification. Local development
+needs none of this — the zero-key setup (anonymous Convex, keyless Clerk,
+Claude-subscription OAuth token) keeps working unchanged.
+
+## 0. Current state (end of P9)
+
+- Convex: anonymous local deployment (`CONVEX_DEPLOYMENT=anonymous:…`,
+  backend on 127.0.0.1:3211). Schema, functions, and codegen are committed.
+- Clerk: keyless dev instance. Claim URL is printed on every `pnpm dev`
+  start. Custom sign-in/up flows work; OAuth buttons are flag-gated off;
+  the Convex JWT bridge is written but inert (no issuer configured).
+- AI: `ANTHROPIC_OAUTH_TOKEN` (personal Claude-subscription token) — dev
+  only. No API-key path exists in `lib/anthropic.ts` yet.
+- Data: legacy Supabase project still holds pre-overhaul mindmaps;
+  `pnpm migrate:supabase` (dry-run default) is ready.
+
+## 1. Claim the Clerk instance
+
+1. Open the claim URL from the dev log (`Claim your keys` link) and attach
+   the instance to a Clerk account.
+2. In the Clerk dashboard: create the JWT template named **`convex`**
+   (Convex template preset). Note the issuer domain
+   (`https://<slug>.clerk.accounts.dev` or your custom domain).
+3. Enable Google + GitHub OAuth providers (this unlocks
+   `NEXT_PUBLIC_ENABLE_OAUTH=true`; the buttons and `sso()` flow shipped in
+   P5). Configure authorized redirect origins for the production domain.
+4. Record `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY`.
+
+Verify: sign in locally with real keys in `.env.local`; confirm
+`auth().getToken({ template: "convex" })` returns a JWT (the canvas loads
+data once step 2's issuer is configured in Convex — step 2 below).
+
+## 2. Promote Convex to cloud
+
+1. `pnpm exec convex login`, then `pnpm exec convex deploy` from the repo —
+   this creates the cloud deployment from the committed schema/functions.
+2. In the Convex dashboard, set the environment variable
+   `CLERK_JWT_ISSUER_DOMAIN=<issuer from step 1.2>` — `convex/auth.config.ts`
+   activates the provider only when it is present.
+3. Record `CONVEX_DEPLOYMENT` (prod) and the deployment URL for
+   `NEXT_PUBLIC_CONVEX_URL` (`https://<slug>.convex.cloud`) and
+   `NEXT_PUBLIC_CONVEX_SITE_URL` (`https://<slug>.convex.site`).
+
+Verify: `pnpm exec convex run mindmaps:listMine` fails with
+"Unauthenticated" (auth enforced), not with a config error.
+
+## 3. AI in production — decision required
+
+`lib/anthropic.ts` authenticates ONLY via `ANTHROPIC_OAUTH_TOKEN` (personal
+subscription OAuth; short-lived). That is not a production credential.
+Options, pick one before launch:
+
+- **A (recommended)**: add an `ANTHROPIC_API_KEY` fallback to
+  `lib/anthropic.ts` (few lines — prefer API key when set, keep the OAuth
+  path for dev) and provision a real Anthropic API key with billing.
+- **B**: ship without server AI (`/api/chat` returns its 503 "AI is not
+  configured" path; the panel shows the configuration notice).
+
+## 4. Migrate legacy data
+
+1. Ensure `.env.local` (or the shell) has the legacy
+   `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` (they were
+   removed from the app env; the script reads them explicitly).
+2. Dry run against prod Convex: `CONVEX_DEPLOYMENT=<prod> pnpm
+   migrate:supabase` — review the per-map diff report (adds/changes/
+   removes, rejected maps with reasons).
+3. Execute: append `--execute --owner <your Clerk subject>` (find the
+   subject in Clerk dashboard → your user → User ID, `user_…`).
+4. Re-run the dry run: it must report every map as unchanged (idempotency
+   check).
+5. Retire the Supabase project only after step 6's verification.
+
+## 5. Vercel environment
+
+Set for Production (and Preview if desired):
+
+| var | value |
+| --- | --- |
+| `NEXT_PUBLIC_CONVEX_URL` | step 2.3 |
+| `NEXT_PUBLIC_CONVEX_SITE_URL` | step 2.3 |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | step 1.4 |
+| `CLERK_SECRET_KEY` | step 1.4 |
+| `NEXT_PUBLIC_ENABLE_OAUTH` | `true` once step 1.3 is done |
+| `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` | step 3 |
+| `SPRIG_AI_MODEL` | optional override (default `claude-sonnet-5`) |
+
+The build itself needs no env vars (verified in CI every merge).
+
+## 6. Launch verification checklist
+
+- [ ] `/` renders static shell fast (PPR); CTA resolves per auth state.
+- [ ] Sign-up with email code end-to-end; password reset flow; OAuth both
+      providers.
+- [ ] `/maps` lists migrated maps; open one; edit; autosave pill cycles
+      dirty → saving → saved; reload shows the edit.
+- [ ] AI panel: create nodes via chat; bloom flash; "Undo to here"
+      reverses the turn; canvas updates live without reload.
+- [ ] Share: set a map shared (UI from P9b), open `/share/<publicId>` in a
+      private window; read-only enforced; revoke → link 404s content-wise.
+- [ ] `robots.txt`, `sitemap.xml` public; deep link → sign-in → returns to
+      the deep link.
+
+## Known deferred work (post-v1)
+
+- Node deletion has no canvas UI (backend delete op exists; AI can delete).
+- `.sprig-ai-active` (per-node in-flight state) is unwired — no per-node
+  signal exists mid-stream.
+- Multi-writer collaboration: `mindmaps.get` invalidates wholesale per
+  write; per-node subscriptions needed before real-time co-editing.
+- Thread history pagination (`listMessages` unbounded per thread).
+- `operations` log grows monotonically; no compaction.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -2,8 +2,11 @@
 
 Everything below is **human-in-the-loop**: no agent or script performs these
 steps. Each stage lists its unlock and its verification. Local development
-needs none of this — the zero-key setup (anonymous Convex, keyless Clerk,
-Claude-subscription OAuth token) keeps working unchanged.
+can run the UI with keyless Clerk and anonymous Convex, but Convex auth is
+deliberately fail-closed until a Clerk issuer is configured. Authenticated data
+flows therefore need steps 1 and 2; without them, the UI shell runs while map
+data remains inert. Sprig also remains unavailable without its dev-local
+Claude-subscription OAuth token.
 
 ## 0. Current state (end of P9)
 
@@ -11,7 +14,8 @@ Claude-subscription OAuth token) keeps working unchanged.
   backend on 127.0.0.1:3211). Schema, functions, and codegen are committed.
 - Clerk: keyless dev instance. Claim URL is printed on every `pnpm dev`
   start. Custom sign-in/up flows work; OAuth buttons are flag-gated off;
-  the Convex JWT bridge is written but inert (no issuer configured).
+  the Convex JWT bridge is written but deliberately rejects data access until
+  an issuer is configured.
 - AI: `ANTHROPIC_OAUTH_TOKEN` (personal Claude-subscription token) — dev
   only. No API-key path exists in `lib/anthropic.ts` yet.
 - Data: legacy Supabase project still holds pre-overhaul mindmaps;
@@ -62,8 +66,8 @@ Options, pick one before launch:
 ## 4. Migrate legacy data
 
 1. Ensure `.env.local` (or the shell) has the legacy
-   `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` (they were
-   removed from the app env; the script reads them explicitly).
+   `SUPABASE_URL` / `SUPABASE_API_KEY` (operator-only inputs read explicitly
+   by the migration script).
 2. Dry run against prod Convex: `CONVEX_DEPLOYMENT=<prod> pnpm
    migrate:supabase` — review the per-map diff report (adds/changes/
    removes, rejected maps with reasons).
@@ -84,7 +88,7 @@ Set for Production (and Preview if desired):
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | step 1.4 |
 | `CLERK_SECRET_KEY` | step 1.4 |
 | `NEXT_PUBLIC_ENABLE_OAUTH` | `true` once step 1.3 is done |
-| `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` | step 3 |
+| `ANTHROPIC_API_KEY` | step 3 option A only; omit when shipping option B |
 | `SPRIG_AI_MODEL` | optional override (default `claude-sonnet-5`) |
 
 The build itself needs no env vars (verified in CI every merge).
@@ -99,7 +103,8 @@ The build itself needs no env vars (verified in CI every merge).
 - [ ] AI panel: create nodes via chat; bloom flash; "Undo to here"
       reverses the turn; canvas updates live without reload.
 - [ ] Share: set a map shared (UI from P9b), open `/share/<publicId>` in a
-      private window; read-only enforced; revoke → link 404s content-wise.
+      private window; read-only enforced; revoke → the owner UI reflects the
+      private server state via live reseed and the link 404s content-wise.
 - [ ] `robots.txt`, `sitemap.xml` public; deep link → sign-in → returns to
       the deep link.
 

--- a/hooks/use-key.test.tsx
+++ b/hooks/use-key.test.tsx
@@ -79,6 +79,121 @@ describe("useKey", () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      "button",
+      <button key="button" type="button">
+        Action
+      </button>,
+    ],
+    [
+      "link",
+      <a href="https://example.com" key="link">
+        Example
+      </a>,
+    ],
+    [
+      "select",
+      <select aria-label="Map" key="select">
+        <option>One</option>
+      </select>,
+    ],
+    [
+      "menu",
+      <div key="menu" role="menu">
+        Menu
+      </div>,
+    ],
+    [
+      "menu item",
+      <div key="menuitem" role="menuitem">
+        Item
+      </div>,
+    ],
+    [
+      "radio menu item",
+      <div aria-checked="false" key="menuitemradio" role="menuitemradio">
+        Item
+      </div>,
+    ],
+    [
+      "switch",
+      <div aria-checked="false" key="switch" role="switch">
+        Sharing
+      </div>,
+    ],
+    [
+      "dialog",
+      <div key="dialog" role="dialog">
+        Editor
+      </div>,
+    ],
+    [
+      "Radix popper content",
+      <div data-radix-popper-content-wrapper="" key="radix">
+        Popover
+      </div>,
+    ],
+  ])("leaves a modifier-free binding native on a %s", (_label, element) => {
+    const callback = vi.fn();
+    const view = render(element);
+    const target = view.container.firstElementChild!;
+    renderHook(() => useKey("Enter", callback));
+
+    const event = dispatchKeyOn(target, { key: "Enter" });
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("guards content nested inside an interactive ancestor", () => {
+    const callback = vi.fn();
+    const view = render(
+      <button type="button">
+        <span>Action label</span>
+      </button>
+    );
+    const target = view.getByText("Action label");
+    renderHook(() => useKey("Enter", callback));
+
+    const event = dispatchKeyOn(target, { key: "Enter" });
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("allows an opted-in Escape binding from an input inside a dialog", () => {
+    const callback = vi.fn();
+    const view = render(
+      <div role="dialog">
+        <input aria-label="Title" />
+      </div>
+    );
+    const input = view.getByRole("textbox");
+    renderHook(() => useKey("Escape", callback, { allowWhenTyping: true }));
+
+    const event = dispatchKeyOn(input, { key: "Escape" });
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("bails when an upstream listener already prevented the event", () => {
+    const callback = vi.fn();
+    renderHook(() => useKey("k", callback));
+    const event = new KeyboardEvent("keydown", {
+      cancelable: true,
+      key: "k",
+    });
+    event.preventDefault();
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
   it("does not fire a plain binding when shift is held", () => {
     const callback = vi.fn();
     renderHook(() => useKey("k", callback));
@@ -148,14 +263,19 @@ function dispatchKey(init: KeyboardEventInit): void {
 }
 
 /** Dispatches a bubbling keydown from an element so window sees its real target. */
-function dispatchKeyOn(target: Element, init: KeyboardEventInit): void {
-  act(() => {
-    target.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        ...init,
-        bubbles: true,
-        cancelable: true,
-      })
-    );
+function dispatchKeyOn(
+  target: Element,
+  init: KeyboardEventInit
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    ...init,
+    bubbles: true,
+    cancelable: true,
   });
+
+  act(() => {
+    target.dispatchEvent(event);
+  });
+
+  return event;
 }

--- a/hooks/use-key.ts
+++ b/hooks/use-key.ts
@@ -9,6 +9,18 @@ type UseKeyOptions = {
   allowWhenTyping?: boolean;
 };
 
+const INTERACTIVE_TARGET_SELECTOR = [
+  "button",
+  "a",
+  "select",
+  '[role="menu"]',
+  '[role="menuitem"]',
+  '[role="menuitemradio"]',
+  '[role="switch"]',
+  '[role="dialog"]',
+  "[data-radix-popper-content-wrapper]",
+].join(",");
+
 /** Runs a keyboard callback when its key and requested modifiers match. */
 export function useKey(
   key: KeyboardEvent["key"] | KeyboardEvent["code"],
@@ -30,28 +42,50 @@ export function useKey(
     }
 
     const handleKey = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
       const target = event.target;
       const isEditableTarget =
         target instanceof HTMLInputElement ||
         target instanceof HTMLTextAreaElement ||
         (target instanceof HTMLElement && target.isContentEditable);
+      const isInteractiveTarget =
+        target instanceof Element &&
+        target.closest(INTERACTIVE_TARGET_SELECTOR) !== null;
       const hasCtrlOrMetaBinding = isMetaKey || isCtrlKey;
+      const isModifierFreeBinding =
+        !isMetaKey && !isCtrlKey && !isShiftKey && !isAltKey;
       const ctrlOrMetaMatches = hasCtrlOrMetaBinding
         ? (isMetaKey && event.metaKey) || (isCtrlKey && event.ctrlKey)
         : !event.metaKey && !event.ctrlKey;
 
-      if (
-        (event.key === key || event.code === `Key${key.toUpperCase()}`) &&
-        ctrlOrMetaMatches &&
-        event.shiftKey === isShiftKey &&
-        event.altKey === isAltKey &&
-        (allowWhenTyping || hasCtrlOrMetaBinding || !isEditableTarget)
-      ) {
-        event.preventDefault();
-        event.stopPropagation();
-
-        callback();
+      if (event.key !== key && event.code !== `Key${key.toUpperCase()}`) {
+        return;
       }
+
+      if (
+        !ctrlOrMetaMatches ||
+        event.shiftKey !== isShiftKey ||
+        event.altKey !== isAltKey
+      ) {
+        return;
+      }
+
+      if (!allowWhenTyping && !hasCtrlOrMetaBinding && isEditableTarget) {
+        return;
+      }
+
+      // Escape bindings deliberately opt into typing contexts so editors can
+      // close from inputs, including inputs nested inside dialogs.
+      if (!allowWhenTyping && isModifierFreeBinding && isInteractiveTarget) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      callback();
     };
 
     window.addEventListener("keydown", handleKey);


### PR DESCRIPTION
Final phase of the [Sprig overhaul plan](https://hatim-s.github.io/planloft-plans/p/Ad43uXfOzC/). Two commits: `2968547` live sync + runbook (Codex + orchestrator), switcher/share/polish (Opus).

**Live canvas reconciliation** — the P8 reload banner is gone. Owner canvases subscribe to `mindmaps.get`; `reseedFromServer` rebuilds through the shared seed pipeline preserving selection, pending ops, and sync state. Reconciliation defers behind a non-empty op queue and applies on drain; self-echoes no-op via `updatedAt` versioning; AI-created nodes now bloom after reseed.

**Thread switcher** — menuitemradio popover, newest-first, mid-stream switching refused with the reason in the accessible name; replay-once invariants from P8.1 preserved.

**Share toggle** — pill beside the save status: `role="switch"` with truthful pending state (no optimistic lie), `/share/<publicId>` copy affordance, inline errors. Backend (`setVisibility`, `getShared`) shipped in P7.

**Runbook** — `docs/RUNBOOK.md`: the full HITL production cutover (claim Clerk → JWT template + OAuth, promote Convex, the AI credential decision A/B, idempotent migration procedure, Vercel env, launch checklist, deferred-work register).

**Polish sweep** — 10 bounded diffs (reduced-motion gaps in sidebar/sheet/node card, sidebar `<a>` → `next/link` full-reload fix, copy voice alignment, dead code removal).

Known theoretical races (disclosed by the implementation report): same-millisecond `updatedAt` collisions ignore the second write until the next one; an unrelated concurrent server update during an AI turn can start a bloom a beat early on pre-existing nodes.

331 tests; build error-grepped clean with the full PPR route table intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01446fKN7Xz6f47x9ui5eBGB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation switching for AI-assisted maps, including saved thread selection and streaming safeguards.
  * Added map sharing controls with public links, visibility toggling, and copy-to-clipboard support.
  * Improved live map updates, synchronization, and AI-created node highlighting.
* **Bug Fixes**
  * Preserved locally edited node fields when server updates arrive and surfaced overwrite warnings.
  * Improved AI error messaging and prevented unintended keyboard actions in interactive controls.
* **Style**
  * Refined loading labels, reduced-motion behavior, navigation wording, and theme control accessibility.
* **Documentation**
  * Added a production launch and verification runbook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->