### PR TITLE
feat(ai): add owner-scoped connection metadata

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,8 +8,10 @@
  * @module
  */
 
+import type * as aiConnections from "../aiConnections.js";
 import type * as lib_access from "../lib/access.js";
 import type * as lib_nodeOps from "../lib/nodeOps.js";
+import type * as lib_personalBeta from "../lib/personalBeta.js";
 import type * as migration from "../migration.js";
 import type * as mindmaps from "../mindmaps.js";
 import type * as ops from "../ops.js";
@@ -22,8 +24,10 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  aiConnections: typeof aiConnections;
   "lib/access": typeof lib_access;
   "lib/nodeOps": typeof lib_nodeOps;
+  "lib/personalBeta": typeof lib_personalBeta;
   migration: typeof migration;
   mindmaps: typeof mindmaps;
   ops: typeof ops;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,7 +9,10 @@
  */
 
 import type * as aiConnections from "../aiConnections.js";
+import type * as aiConnectionsInternal from "../aiConnectionsInternal.js";
+import type * as connectionRateBudget from "../connectionRateBudget.js";
 import type * as lib_access from "../lib/access.js";
+import type * as lib_connectionRateBudget from "../lib/connectionRateBudget.js";
 import type * as lib_nodeOps from "../lib/nodeOps.js";
 import type * as lib_personalBeta from "../lib/personalBeta.js";
 import type * as migration from "../migration.js";
@@ -25,7 +28,10 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   aiConnections: typeof aiConnections;
+  aiConnectionsInternal: typeof aiConnectionsInternal;
+  connectionRateBudget: typeof connectionRateBudget;
   "lib/access": typeof lib_access;
+  "lib/connectionRateBudget": typeof lib_connectionRateBudget;
   "lib/nodeOps": typeof lib_nodeOps;
   "lib/personalBeta": typeof lib_personalBeta;
   migration: typeof migration;

--- a/convex/aiConnections.test.ts
+++ b/convex/aiConnections.test.ts
@@ -1,0 +1,334 @@
+// @vitest-environment edge-runtime
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { PERSONAL_BETA_SUBJECTS_ENV } from "./lib/personalBeta";
+import schema from "./schema";
+
+const modules = import.meta.glob(["./**/*.*s", "!./**/*.test.ts"]);
+
+type ConnectionSeed = {
+  ownerId: string;
+  status?: "pending" | "connected" | "error" | "expired" | "revoked";
+  isDefault?: boolean;
+  gatewayCredentialId?: string;
+};
+
+/** Creates an isolated connection harness with two authenticated Clerk subjects. */
+function createHarness() {
+  const t = convexTest(schema, modules);
+
+  return {
+    t,
+    anonymous: t,
+    asAlice: t.withIdentity({ subject: "user_alice" }),
+    asBob: t.withIdentity({ subject: "user_bob" }),
+  };
+}
+
+/** Seeds gateway-derived metadata without exposing a public lifecycle mutation. */
+async function seedConnection(
+  t: ReturnType<typeof convexTest>,
+  {
+    ownerId,
+    status = "connected",
+    isDefault = false,
+    gatewayCredentialId = `gateway-${ownerId}`,
+  }: ConnectionSeed
+): Promise<Id<"aiConnections">> {
+  return t.run((ctx) =>
+    ctx.db.insert("aiConnections", {
+      ownerId,
+      provider: "codex",
+      label: "Codex",
+      status,
+      authenticationMethod: "device_code",
+      gatewayCredentialId,
+      accountHint: `${ownerId.slice(-3)}***`,
+      planLabel: "Subscription",
+      isDefault,
+      createdAt: 1,
+      updatedAt: 1,
+      lastValidationAt: 1,
+      lastErrorCode: status === "error" ? "PROVIDER_UNAVAILABLE" : undefined,
+    })
+  );
+}
+
+/** Requires the complete stable error message, avoiding substring oracles. */
+async function expectErrorMessage(
+  promise: Promise<unknown>,
+  expectedMessage: string
+): Promise<void> {
+  const error = await promise.then(
+    () => null,
+    (caught: unknown) => caught
+  );
+
+  expect(error).toBeInstanceOf(Error);
+  if (!(error instanceof Error)) {
+    return;
+  }
+
+  expect(error.message).toBe(expectedMessage);
+}
+
+beforeEach(() => {
+  vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_alice,user_bob");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("ai connections", () => {
+  it("creates pending Codex metadata entirely from server-derived fields", async () => {
+    const { t, asAlice } = createHarness();
+    const { connectionId } = await asAlice.mutation(
+      api.aiConnections.createPendingCodex,
+      {}
+    );
+    const stored = await t.run((ctx) => ctx.db.get(connectionId));
+
+    expect(stored).toMatchObject({
+      ownerId: "user_alice",
+      provider: "codex",
+      label: "Codex",
+      status: "pending",
+      authenticationMethod: "device_code",
+      isDefault: false,
+    });
+    expect(stored?.gatewayCredentialId).toBeUndefined();
+    expect(stored?.accountHint).toBeUndefined();
+    expect(stored?.planLabel).toBeUndefined();
+    expect(stored?.lastValidationAt).toBeUndefined();
+    expect(stored?.lastErrorCode).toBeUndefined();
+  });
+
+  it.each([
+    ["ownerId", "user_bob"],
+    ["provider", "claude"],
+    ["status", "connected"],
+    ["gatewayCredentialId", "stolen"],
+    ["accountHint", "victim@example.com"],
+    ["planLabel", "Enterprise"],
+    ["lastValidationAt", 1],
+    ["lastErrorCode", "raw provider output"],
+  ])("rejects the client-supplied %s field", async (field, value) => {
+    const { asAlice } = createHarness();
+
+    await expectErrorMessage(
+      asAlice.mutation(api.aiConnections.createPendingCodex, {
+        [field]: value,
+      } as never),
+      `Validator error: Unexpected field \`${field}\` in object`
+    );
+  });
+
+  it("denies duplicate pending connections without affecting another owner", async () => {
+    const { asAlice, asBob } = createHarness();
+
+    await asAlice.mutation(api.aiConnections.createPendingCodex, {});
+    await asBob.mutation(api.aiConnections.createPendingCodex, {});
+
+    await expectErrorMessage(
+      asAlice.mutation(api.aiConnections.createPendingCodex, {}),
+      "Connection already pending"
+    );
+
+    expect(await asAlice.query(api.aiConnections.list, {})).toHaveLength(1);
+    expect(await asBob.query(api.aiConnections.list, {})).toHaveLength(1);
+  });
+
+  it.each([undefined, "", "user_bob"])(
+    "fails create closed for unavailable beta configuration (%s)",
+    async (configuredSubjects) => {
+      const { asAlice } = createHarness();
+
+      if (configuredSubjects === undefined) {
+        vi.unstubAllEnvs();
+      } else {
+        vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, configuredSubjects);
+      }
+
+      await expectErrorMessage(
+        asAlice.mutation(api.aiConnections.createPendingCodex, {}),
+        "Personal beta access unavailable"
+      );
+    }
+  );
+
+  it("lists only the owner's safe display metadata", async () => {
+    const { t, asAlice } = createHarness();
+    const aliceConnection = await seedConnection(t, {
+      ownerId: "user_alice",
+      isDefault: true,
+    });
+    await seedConnection(t, { ownerId: "user_bob" });
+
+    const connections = await asAlice.query(api.aiConnections.list, {});
+
+    expect(connections).toHaveLength(1);
+    expect(connections[0]).toMatchObject({
+      _id: aliceConnection,
+      provider: "codex",
+      status: "connected",
+      accountHint: "ice***",
+      planLabel: "Subscription",
+      isDefault: true,
+    });
+    expect(connections[0]).not.toHaveProperty("ownerId");
+    expect(connections[0]).not.toHaveProperty("gatewayCredentialId");
+  });
+
+  it("keeps safe owner-only reads available after de-allowlisting", async () => {
+    const { t, asAlice } = createHarness();
+    const connectionId = await seedConnection(t, { ownerId: "user_alice" });
+    vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_bob");
+
+    const listed = await asAlice.query(api.aiConnections.list, {});
+    const status = await asAlice.query(api.aiConnections.getStatus, {
+      connectionId,
+    });
+
+    expect(listed.map((connection) => connection._id)).toEqual([connectionId]);
+    expect(status._id).toBe(connectionId);
+  });
+
+  it("returns the same stable error for missing and cross-owner status probes", async () => {
+    const { t, asAlice } = createHarness();
+    const bobConnection = await seedConnection(t, { ownerId: "user_bob" });
+    const missingConnection = await seedConnection(t, {
+      ownerId: "user_alice",
+    });
+    await t.run((ctx) => ctx.db.delete(missingConnection));
+
+    await expectErrorMessage(
+      asAlice.query(api.aiConnections.getStatus, {
+        connectionId: bobConnection,
+      }),
+      "Connection unavailable"
+    );
+    await expectErrorMessage(
+      asAlice.query(api.aiConnections.getStatus, {
+        connectionId: missingConnection,
+      }),
+      "Connection unavailable"
+    );
+  });
+
+  it("atomically replaces duplicate defaults only within the owner", async () => {
+    const { t, asAlice } = createHarness();
+    const firstAlice = await seedConnection(t, {
+      ownerId: "user_alice",
+      isDefault: true,
+    });
+    const selectedAlice = await seedConnection(t, {
+      ownerId: "user_alice",
+      isDefault: true,
+    });
+    const bobDefault = await seedConnection(t, {
+      ownerId: "user_bob",
+      isDefault: true,
+    });
+
+    await asAlice.mutation(api.aiConnections.selectDefaultCodex, {
+      connectionId: selectedAlice,
+    });
+
+    const [first, selected, bob] = await t.run(async (ctx) =>
+      Promise.all([
+        ctx.db.get(firstAlice),
+        ctx.db.get(selectedAlice),
+        ctx.db.get(bobDefault),
+      ])
+    );
+    expect(first?.isDefault).toBe(false);
+    expect(selected?.isDefault).toBe(true);
+    expect(bob?.isDefault).toBe(true);
+  });
+
+  it.each(["pending", "error", "expired", "revoked"] as const)(
+    "rejects selecting a %s connection without changing defaults",
+    async (status) => {
+      const { t, asAlice } = createHarness();
+      const currentDefault = await seedConnection(t, {
+        ownerId: "user_alice",
+        isDefault: true,
+      });
+      const invalid = await seedConnection(t, {
+        ownerId: "user_alice",
+        status,
+      });
+
+      await expectErrorMessage(
+        asAlice.mutation(api.aiConnections.selectDefaultCodex, {
+          connectionId: invalid,
+        }),
+        "Connection unavailable"
+      );
+
+      expect(
+        (await t.run((ctx) => ctx.db.get(currentDefault)))?.isDefault
+      ).toBe(true);
+      expect((await t.run((ctx) => ctx.db.get(invalid)))?.isDefault).toBe(
+        false
+      );
+    }
+  );
+
+  it("blocks cross-owner selection and preserves both owners' defaults", async () => {
+    const { t, asAlice } = createHarness();
+    const aliceDefault = await seedConnection(t, {
+      ownerId: "user_alice",
+      isDefault: true,
+    });
+    const bobDefault = await seedConnection(t, {
+      ownerId: "user_bob",
+      isDefault: true,
+    });
+
+    await expectErrorMessage(
+      asAlice.mutation(api.aiConnections.selectDefaultCodex, {
+        connectionId: bobDefault,
+      }),
+      "Connection unavailable"
+    );
+
+    expect((await t.run((ctx) => ctx.db.get(aliceDefault)))?.isDefault).toBe(
+      true
+    );
+    expect((await t.run((ctx) => ctx.db.get(bobDefault)))?.isDefault).toBe(
+      true
+    );
+  });
+
+  it("fails selection closed immediately after de-allowlisting", async () => {
+    const { t, asAlice } = createHarness();
+    const connectionId = await seedConnection(t, { ownerId: "user_alice" });
+    vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_bob");
+
+    await expectErrorMessage(
+      asAlice.mutation(api.aiConnections.selectDefaultCodex, { connectionId }),
+      "Personal beta access unavailable"
+    );
+    expect((await t.run((ctx) => ctx.db.get(connectionId)))?.isDefault).toBe(
+      false
+    );
+  });
+
+  it("requires Clerk authentication for every entry point", async () => {
+    const { anonymous } = createHarness();
+
+    await expectErrorMessage(
+      anonymous.query(api.aiConnections.list, {}),
+      "Unauthenticated"
+    );
+    await expectErrorMessage(
+      anonymous.mutation(api.aiConnections.createPendingCodex, {}),
+      "Unauthenticated"
+    );
+  });
+});

--- a/convex/aiConnections.test.ts
+++ b/convex/aiConnections.test.ts
@@ -86,7 +86,7 @@ afterEach(() => {
 describe("ai connections", () => {
   it("creates pending Codex metadata entirely from server-derived fields", async () => {
     const { t, asAlice } = createHarness();
-    const { connectionId } = await asAlice.mutation(
+    const { connectionId } = await asAlice.action(
       api.aiConnections.createPendingCodex,
       {}
     );
@@ -117,29 +117,32 @@ describe("ai connections", () => {
     ["lastValidationAt", 1],
     ["lastErrorCode", "raw provider output"],
   ])("rejects the client-supplied %s field", async (field, value) => {
-    const { asAlice } = createHarness();
+    const { t, asAlice } = createHarness();
 
     await expectErrorMessage(
-      asAlice.mutation(api.aiConnections.createPendingCodex, {
+      asAlice.action(api.aiConnections.createPendingCodex, {
         [field]: value,
       } as never),
-      `Validator error: Unexpected field \`${field}\` in object`
+      "Invalid connection request"
     );
+    expect(
+      await t.run((ctx) => ctx.db.query("aiConnections").collect())
+    ).toEqual([]);
   });
 
   it("denies duplicate pending connections without affecting another owner", async () => {
     const { asAlice, asBob } = createHarness();
 
-    await asAlice.mutation(api.aiConnections.createPendingCodex, {});
-    await asBob.mutation(api.aiConnections.createPendingCodex, {});
+    await asAlice.action(api.aiConnections.createPendingCodex, {});
+    await asBob.action(api.aiConnections.createPendingCodex, {});
 
     await expectErrorMessage(
-      asAlice.mutation(api.aiConnections.createPendingCodex, {}),
+      asAlice.action(api.aiConnections.createPendingCodex, {}),
       "Connection already pending"
     );
 
-    expect(await asAlice.query(api.aiConnections.list, {})).toHaveLength(1);
-    expect(await asBob.query(api.aiConnections.list, {})).toHaveLength(1);
+    expect(await asAlice.action(api.aiConnections.list, {})).toHaveLength(1);
+    expect(await asBob.action(api.aiConnections.list, {})).toHaveLength(1);
   });
 
   it.each([undefined, "", "user_bob"])(
@@ -154,7 +157,7 @@ describe("ai connections", () => {
       }
 
       await expectErrorMessage(
-        asAlice.mutation(api.aiConnections.createPendingCodex, {}),
+        asAlice.action(api.aiConnections.createPendingCodex, {}),
         "Personal beta access unavailable"
       );
     }
@@ -168,7 +171,7 @@ describe("ai connections", () => {
     });
     await seedConnection(t, { ownerId: "user_bob" });
 
-    const connections = await asAlice.query(api.aiConnections.list, {});
+    const connections = await asAlice.action(api.aiConnections.list, {});
 
     expect(connections).toHaveLength(1);
     expect(connections[0]).toMatchObject({
@@ -188,8 +191,8 @@ describe("ai connections", () => {
     const connectionId = await seedConnection(t, { ownerId: "user_alice" });
     vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_bob");
 
-    const listed = await asAlice.query(api.aiConnections.list, {});
-    const status = await asAlice.query(api.aiConnections.getStatus, {
+    const listed = await asAlice.action(api.aiConnections.list, {});
+    const status = await asAlice.action(api.aiConnections.getStatus, {
       connectionId,
     });
 
@@ -206,13 +209,13 @@ describe("ai connections", () => {
     await t.run((ctx) => ctx.db.delete(missingConnection));
 
     await expectErrorMessage(
-      asAlice.query(api.aiConnections.getStatus, {
+      asAlice.action(api.aiConnections.getStatus, {
         connectionId: bobConnection,
       }),
       "Connection unavailable"
     );
     await expectErrorMessage(
-      asAlice.query(api.aiConnections.getStatus, {
+      asAlice.action(api.aiConnections.getStatus, {
         connectionId: missingConnection,
       }),
       "Connection unavailable"
@@ -234,7 +237,7 @@ describe("ai connections", () => {
       isDefault: true,
     });
 
-    await asAlice.mutation(api.aiConnections.selectDefaultCodex, {
+    await asAlice.action(api.aiConnections.selectDefaultCodex, {
       connectionId: selectedAlice,
     });
 
@@ -264,7 +267,7 @@ describe("ai connections", () => {
       });
 
       await expectErrorMessage(
-        asAlice.mutation(api.aiConnections.selectDefaultCodex, {
+        asAlice.action(api.aiConnections.selectDefaultCodex, {
           connectionId: invalid,
         }),
         "Connection unavailable"
@@ -291,7 +294,7 @@ describe("ai connections", () => {
     });
 
     await expectErrorMessage(
-      asAlice.mutation(api.aiConnections.selectDefaultCodex, {
+      asAlice.action(api.aiConnections.selectDefaultCodex, {
         connectionId: bobDefault,
       }),
       "Connection unavailable"
@@ -311,7 +314,7 @@ describe("ai connections", () => {
     vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_bob");
 
     await expectErrorMessage(
-      asAlice.mutation(api.aiConnections.selectDefaultCodex, { connectionId }),
+      asAlice.action(api.aiConnections.selectDefaultCodex, { connectionId }),
       "Personal beta access unavailable"
     );
     expect((await t.run((ctx) => ctx.db.get(connectionId)))?.isDefault).toBe(
@@ -320,14 +323,25 @@ describe("ai connections", () => {
   });
 
   it("requires Clerk authentication for every entry point", async () => {
-    const { anonymous } = createHarness();
+    const { t, anonymous } = createHarness();
+    const connectionId = await seedConnection(t, { ownerId: "user_alice" });
 
     await expectErrorMessage(
-      anonymous.query(api.aiConnections.list, {}),
+      anonymous.action(api.aiConnections.list, {}),
       "Unauthenticated"
     );
     await expectErrorMessage(
-      anonymous.mutation(api.aiConnections.createPendingCodex, {}),
+      anonymous.action(api.aiConnections.createPendingCodex, {}),
+      "Unauthenticated"
+    );
+    await expectErrorMessage(
+      anonymous.action(api.aiConnections.getStatus, { connectionId }),
+      "Unauthenticated"
+    );
+    await expectErrorMessage(
+      anonymous.action(api.aiConnections.selectDefaultCodex, {
+        connectionId,
+      }),
       "Unauthenticated"
     );
   });

--- a/convex/aiConnections.ts
+++ b/convex/aiConnections.ts
@@ -1,0 +1,162 @@
+import { ConvexError, v } from "convex/values";
+
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
+import { requireUser } from "./lib/access";
+import { isPersonalBetaSubjectAllowed } from "./lib/personalBeta";
+
+const PERSONAL_BETA_ACCESS_UNAVAILABLE = "Personal beta access unavailable";
+const CONNECTION_ALREADY_PENDING = "Connection already pending";
+const CONNECTION_UNAVAILABLE = "Connection unavailable";
+
+type ConnectionContext = MutationCtx | QueryCtx;
+type SafeConnection = Omit<
+  Doc<"aiConnections">,
+  "ownerId" | "gatewayCredentialId"
+>;
+
+/** Removes owner and gateway-only identifiers from an owner-facing connection. */
+function toSafeConnection(connection: Doc<"aiConnections">): SafeConnection {
+  return {
+    _id: connection._id,
+    _creationTime: connection._creationTime,
+    provider: connection.provider,
+    label: connection.label,
+    status: connection.status,
+    authenticationMethod: connection.authenticationMethod,
+    accountHint: connection.accountHint,
+    planLabel: connection.planLabel,
+    isDefault: connection.isDefault,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
+    lastValidationAt: connection.lastValidationAt,
+    lastErrorCode: connection.lastErrorCode,
+  };
+}
+
+/** Requires the current Clerk subject to remain on the server-controlled beta list. */
+function requirePersonalBetaAccess(subject: string): void {
+  if (!isPersonalBetaSubjectAllowed(subject)) {
+    throw new ConvexError(PERSONAL_BETA_ACCESS_UNAVAILABLE);
+  }
+}
+
+/** Loads an owned connection without revealing whether another owner's id exists. */
+async function getOwnedConnection(
+  ctx: ConnectionContext,
+  connectionId: Id<"aiConnections">,
+  subject: string
+): Promise<Doc<"aiConnections">> {
+  const connection = await ctx.db.get("aiConnections", connectionId);
+
+  if (connection === null || connection.ownerId !== subject) {
+    throw new ConvexError(CONNECTION_UNAVAILABLE);
+  }
+
+  return connection;
+}
+
+/** Lists only secret-free metadata for the authenticated owner. */
+const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const subject = await requireUser(ctx);
+    const connections = await ctx.db
+      .query("aiConnections")
+      .withIndex("by_owner", (index) => index.eq("ownerId", subject))
+      .order("desc")
+      .collect();
+
+    return connections.map(toSafeConnection);
+  },
+});
+
+/** Reads safe status for one owned connection, including after de-allowlisting. */
+const getStatus = query({
+  args: { connectionId: v.id("aiConnections") },
+  handler: async (ctx, { connectionId }) => {
+    const subject = await requireUser(ctx);
+    const connection = await getOwnedConnection(ctx, connectionId, subject);
+
+    return toSafeConnection(connection);
+  },
+});
+
+/** Creates one server-derived pending Codex device-code connection per owner at a time. */
+const createPendingCodex = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const subject = await requireUser(ctx);
+    requirePersonalBetaAccess(subject);
+
+    const existingPending = await ctx.db
+      .query("aiConnections")
+      .withIndex("by_owner_provider_status", (index) =>
+        index
+          .eq("ownerId", subject)
+          .eq("provider", "codex")
+          .eq("status", "pending")
+      )
+      .first();
+
+    if (existingPending !== null) {
+      throw new ConvexError(CONNECTION_ALREADY_PENDING);
+    }
+
+    const now = Date.now();
+    const connectionId = await ctx.db.insert("aiConnections", {
+      ownerId: subject,
+      provider: "codex",
+      label: "Codex",
+      status: "pending",
+      authenticationMethod: "device_code",
+      isDefault: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { connectionId };
+  },
+});
+
+/** Atomically makes one connected Codex connection the owner's sole default. */
+const selectDefaultCodex = mutation({
+  args: { connectionId: v.id("aiConnections") },
+  handler: async (ctx, { connectionId }) => {
+    const subject = await requireUser(ctx);
+    requirePersonalBetaAccess(subject);
+    const selected = await getOwnedConnection(ctx, connectionId, subject);
+
+    if (selected.provider !== "codex" || selected.status !== "connected") {
+      throw new ConvexError(CONNECTION_UNAVAILABLE);
+    }
+
+    const connections = await ctx.db
+      .query("aiConnections")
+      .withIndex("by_owner", (index) => index.eq("ownerId", subject))
+      .collect();
+    const now = Date.now();
+
+    // Convex mutations are transactional, so clearing stale duplicate defaults
+    // and selecting the target cannot expose an intermediate state.
+    await Promise.all(
+      connections.map((connection) => {
+        const shouldBeDefault = connection._id === selected._id;
+
+        if (connection.isDefault === shouldBeDefault) {
+          return Promise.resolve();
+        }
+
+        return ctx.db.patch(connection._id, {
+          isDefault: shouldBeDefault,
+          updatedAt: now,
+        });
+      })
+    );
+
+    return { connectionId: selected._id };
+  },
+});
+
+export { createPendingCodex, getStatus, list, selectDefaultCodex };

--- a/convex/aiConnections.ts
+++ b/convex/aiConnections.ts
@@ -1,39 +1,51 @@
+import { makeFunctionReference } from "convex/server";
 import { ConvexError, v } from "convex/values";
 
 import type { Doc, Id } from "./_generated/dataModel";
-import type { MutationCtx, QueryCtx } from "./_generated/server";
-import { mutation, query } from "./_generated/server";
+import { action } from "./_generated/server";
 import { requireUser } from "./lib/access";
 import { isPersonalBetaSubjectAllowed } from "./lib/personalBeta";
 
 const PERSONAL_BETA_ACCESS_UNAVAILABLE = "Personal beta access unavailable";
-const CONNECTION_ALREADY_PENDING = "Connection already pending";
-const CONNECTION_UNAVAILABLE = "Connection unavailable";
+const INVALID_CONNECTION_REQUEST = "Invalid connection request";
 
-type ConnectionContext = MutationCtx | QueryCtx;
+type ConnectionRateEndpoint =
+  | "createPendingCodex"
+  | "selectDefaultCodex"
+  | "list"
+  | "getStatus";
 type SafeConnection = Omit<
   Doc<"aiConnections">,
   "ownerId" | "gatewayCredentialId"
 >;
 
-/** Removes owner and gateway-only identifiers from an owner-facing connection. */
-function toSafeConnection(connection: Doc<"aiConnections">): SafeConnection {
-  return {
-    _id: connection._id,
-    _creationTime: connection._creationTime,
-    provider: connection.provider,
-    label: connection.label,
-    status: connection.status,
-    authenticationMethod: connection.authenticationMethod,
-    accountHint: connection.accountHint,
-    planLabel: connection.planLabel,
-    isDefault: connection.isDefault,
-    createdAt: connection.createdAt,
-    updatedAt: connection.updatedAt,
-    lastValidationAt: connection.lastValidationAt,
-    lastErrorCode: connection.lastErrorCode,
-  };
-}
+// Explicit references avoid a generated-API type cycle in the module whose
+// public actions call these internal functions.
+const consumeRateBudget = makeFunctionReference<
+  "mutation",
+  { subject: string; endpoint: ConnectionRateEndpoint },
+  null
+>("connectionRateBudget:consume");
+const listOwned = makeFunctionReference<
+  "query",
+  { subject: string },
+  SafeConnection[]
+>("aiConnectionsInternal:listOwned");
+const getOwnedStatus = makeFunctionReference<
+  "query",
+  { subject: string; connectionId: string },
+  SafeConnection
+>("aiConnectionsInternal:getOwnedStatus");
+const createPendingCodexOwned = makeFunctionReference<
+  "mutation",
+  { subject: string },
+  { connectionId: Id<"aiConnections"> }
+>("aiConnectionsInternal:createPendingCodexOwned");
+const selectDefaultCodexOwned = makeFunctionReference<
+  "mutation",
+  { subject: string; connectionId: string },
+  { connectionId: Id<"aiConnections"> }
+>("aiConnectionsInternal:selectDefaultCodexOwned");
 
 /** Requires the current Clerk subject to remain on the server-controlled beta list. */
 function requirePersonalBetaAccess(subject: string): void {
@@ -42,120 +54,98 @@ function requirePersonalBetaAccess(subject: string): void {
   }
 }
 
-/** Loads an owned connection without revealing whether another owner's id exists. */
-async function getOwnedConnection(
-  ctx: ConnectionContext,
-  connectionId: Id<"aiConnections">,
-  subject: string
-): Promise<Doc<"aiConnections">> {
-  const connection = await ctx.db.get("aiConnections", connectionId);
-
-  if (connection === null || connection.ownerId !== subject) {
-    throw new ConvexError(CONNECTION_UNAVAILABLE);
+/** Requires a public call to supply an exact empty argument object. */
+function requireEmptyArguments(args: unknown): void {
+  if (
+    typeof args !== "object" ||
+    args === null ||
+    Array.isArray(args) ||
+    Object.keys(args).length !== 0
+  ) {
+    throw new ConvexError(INVALID_CONNECTION_REQUEST);
   }
-
-  return connection;
 }
 
-/** Lists only secret-free metadata for the authenticated owner. */
-const list = query({
-  args: {},
-  handler: async (ctx) => {
+/** Parses the sole connection id only after the known owner has spent capacity. */
+function requireConnectionIdString(args: unknown): string {
+  if (
+    typeof args !== "object" ||
+    args === null ||
+    Array.isArray(args) ||
+    Object.keys(args).length !== 1 ||
+    !("connectionId" in args) ||
+    typeof args.connectionId !== "string"
+  ) {
+    throw new ConvexError(INVALID_CONNECTION_REQUEST);
+  }
+
+  return args.connectionId;
+}
+
+/** Lists rate-limited, secret-free metadata for the authenticated owner. */
+const list = action({
+  // Broad validation lets malformed known-owner attempts consume capacity
+  // before the handler returns a stable application-level error.
+  args: v.record(v.string(), v.any()),
+  handler: async (ctx, args: unknown) => {
     const subject = await requireUser(ctx);
-    const connections = await ctx.db
-      .query("aiConnections")
-      .withIndex("by_owner", (index) => index.eq("ownerId", subject))
-      .order("desc")
-      .collect();
-
-    return connections.map(toSafeConnection);
-  },
-});
-
-/** Reads safe status for one owned connection, including after de-allowlisting. */
-const getStatus = query({
-  args: { connectionId: v.id("aiConnections") },
-  handler: async (ctx, { connectionId }) => {
-    const subject = await requireUser(ctx);
-    const connection = await getOwnedConnection(ctx, connectionId, subject);
-
-    return toSafeConnection(connection);
-  },
-});
-
-/** Creates one server-derived pending Codex device-code connection per owner at a time. */
-const createPendingCodex = mutation({
-  args: {},
-  handler: async (ctx) => {
-    const subject = await requireUser(ctx);
-    requirePersonalBetaAccess(subject);
-
-    const existingPending = await ctx.db
-      .query("aiConnections")
-      .withIndex("by_owner_provider_status", (index) =>
-        index
-          .eq("ownerId", subject)
-          .eq("provider", "codex")
-          .eq("status", "pending")
-      )
-      .first();
-
-    if (existingPending !== null) {
-      throw new ConvexError(CONNECTION_ALREADY_PENDING);
-    }
-
-    const now = Date.now();
-    const connectionId = await ctx.db.insert("aiConnections", {
-      ownerId: subject,
-      provider: "codex",
-      label: "Codex",
-      status: "pending",
-      authenticationMethod: "device_code",
-      isDefault: false,
-      createdAt: now,
-      updatedAt: now,
+    await ctx.runMutation(consumeRateBudget, {
+      subject,
+      endpoint: "list",
     });
+    requireEmptyArguments(args);
 
-    return { connectionId };
+    return ctx.runQuery(listOwned, { subject });
   },
 });
 
-/** Atomically makes one connected Codex connection the owner's sole default. */
-const selectDefaultCodex = mutation({
-  args: { connectionId: v.id("aiConnections") },
-  handler: async (ctx, { connectionId }) => {
+/** Reads rate-limited safe status, including after owner de-allowlisting. */
+const getStatus = action({
+  args: v.record(v.string(), v.any()),
+  handler: async (ctx, args: unknown) => {
     const subject = await requireUser(ctx);
+    await ctx.runMutation(consumeRateBudget, {
+      subject,
+      endpoint: "getStatus",
+    });
+    const connectionId = requireConnectionIdString(args);
+
+    return ctx.runQuery(getOwnedStatus, {
+      subject,
+      connectionId,
+    });
+  },
+});
+
+/** Creates one server-derived pending Codex connection after charging capacity. */
+const createPendingCodex = action({
+  args: v.record(v.string(), v.any()),
+  handler: async (ctx, args: unknown) => {
+    const subject = await requireUser(ctx);
+    await ctx.runMutation(consumeRateBudget, {
+      subject,
+      endpoint: "createPendingCodex",
+    });
+    requireEmptyArguments(args);
     requirePersonalBetaAccess(subject);
-    const selected = await getOwnedConnection(ctx, connectionId, subject);
 
-    if (selected.provider !== "codex" || selected.status !== "connected") {
-      throw new ConvexError(CONNECTION_UNAVAILABLE);
-    }
+    return ctx.runMutation(createPendingCodexOwned, { subject });
+  },
+});
 
-    const connections = await ctx.db
-      .query("aiConnections")
-      .withIndex("by_owner", (index) => index.eq("ownerId", subject))
-      .collect();
-    const now = Date.now();
+/** Selects a connected Codex default after charging capacity and checking beta access. */
+const selectDefaultCodex = action({
+  args: v.record(v.string(), v.any()),
+  handler: async (ctx, args: unknown) => {
+    const subject = await requireUser(ctx);
+    await ctx.runMutation(consumeRateBudget, {
+      subject,
+      endpoint: "selectDefaultCodex",
+    });
+    const connectionId = requireConnectionIdString(args);
+    requirePersonalBetaAccess(subject);
 
-    // Convex mutations are transactional, so clearing stale duplicate defaults
-    // and selecting the target cannot expose an intermediate state.
-    await Promise.all(
-      connections.map((connection) => {
-        const shouldBeDefault = connection._id === selected._id;
-
-        if (connection.isDefault === shouldBeDefault) {
-          return Promise.resolve();
-        }
-
-        return ctx.db.patch(connection._id, {
-          isDefault: shouldBeDefault,
-          updatedAt: now,
-        });
-      })
-    );
-
-    return { connectionId: selected._id };
+    return ctx.runMutation(selectDefaultCodexOwned, { subject, connectionId });
   },
 });
 

--- a/convex/aiConnectionsInternal.ts
+++ b/convex/aiConnectionsInternal.ts
@@ -1,0 +1,170 @@
+import { ConvexError, v } from "convex/values";
+
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import { internalMutation, internalQuery } from "./_generated/server";
+
+const CONNECTION_ALREADY_PENDING = "Connection already pending";
+const CONNECTION_UNAVAILABLE = "Connection unavailable";
+const INVALID_CONNECTION_REQUEST = "Invalid connection request";
+
+type ConnectionContext = MutationCtx | QueryCtx;
+type SafeConnection = Omit<
+  Doc<"aiConnections">,
+  "ownerId" | "gatewayCredentialId"
+>;
+
+/** Removes owner and gateway-only identifiers from an owner-facing connection. */
+function toSafeConnection(connection: Doc<"aiConnections">): SafeConnection {
+  return {
+    _id: connection._id,
+    _creationTime: connection._creationTime,
+    provider: connection.provider,
+    label: connection.label,
+    status: connection.status,
+    authenticationMethod: connection.authenticationMethod,
+    accountHint: connection.accountHint,
+    planLabel: connection.planLabel,
+    isDefault: connection.isDefault,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
+    lastValidationAt: connection.lastValidationAt,
+    lastErrorCode: connection.lastErrorCode,
+  };
+}
+
+/** Normalizes an untrusted string without exposing Convex's validator details. */
+function requireConnectionId(
+  ctx: ConnectionContext,
+  connectionId: string
+): Id<"aiConnections"> {
+  try {
+    const normalized = ctx.db.normalizeId("aiConnections", connectionId);
+    if (normalized !== null) {
+      return normalized;
+    }
+  } catch {
+    // Normalize storage/runtime validation failures to the stable public code.
+  }
+
+  throw new ConvexError(INVALID_CONNECTION_REQUEST);
+}
+
+/** Loads an owned connection without revealing whether another owner's id exists. */
+async function getOwnedConnection(
+  ctx: ConnectionContext,
+  connectionId: Id<"aiConnections">,
+  subject: string
+): Promise<Doc<"aiConnections">> {
+  const connection = await ctx.db.get("aiConnections", connectionId);
+
+  if (connection === null || connection.ownerId !== subject) {
+    throw new ConvexError(CONNECTION_UNAVAILABLE);
+  }
+
+  return connection;
+}
+
+/** Returns secret-free metadata for one server-asserted owner. */
+const listOwned = internalQuery({
+  args: { subject: v.string() },
+  handler: async (ctx, { subject }) => {
+    const connections = await ctx.db
+      .query("aiConnections")
+      .withIndex("by_owner", (index) => index.eq("ownerId", subject))
+      .order("desc")
+      .collect();
+
+    return connections.map(toSafeConnection);
+  },
+});
+
+/** Returns safe status only when a server-asserted owner owns the connection. */
+const getOwnedStatus = internalQuery({
+  args: { subject: v.string(), connectionId: v.string() },
+  handler: async (ctx, { subject, connectionId: rawConnectionId }) => {
+    const connectionId = requireConnectionId(ctx, rawConnectionId);
+    const connection = await getOwnedConnection(ctx, connectionId, subject);
+
+    return toSafeConnection(connection);
+  },
+});
+
+/** Creates one server-derived pending Codex record per owner at a time. */
+const createPendingCodexOwned = internalMutation({
+  args: { subject: v.string() },
+  handler: async (ctx, { subject }) => {
+    const existingPending = await ctx.db
+      .query("aiConnections")
+      .withIndex("by_owner_provider_status", (index) =>
+        index
+          .eq("ownerId", subject)
+          .eq("provider", "codex")
+          .eq("status", "pending")
+      )
+      .first();
+
+    if (existingPending !== null) {
+      throw new ConvexError(CONNECTION_ALREADY_PENDING);
+    }
+
+    const now = Date.now();
+    const connectionId = await ctx.db.insert("aiConnections", {
+      ownerId: subject,
+      provider: "codex",
+      label: "Codex",
+      status: "pending",
+      authenticationMethod: "device_code",
+      isDefault: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { connectionId };
+  },
+});
+
+/** Atomically makes one connected Codex record the server-asserted owner's sole default. */
+const selectDefaultCodexOwned = internalMutation({
+  args: { subject: v.string(), connectionId: v.string() },
+  handler: async (ctx, { subject, connectionId: rawConnectionId }) => {
+    const connectionId = requireConnectionId(ctx, rawConnectionId);
+    const selected = await getOwnedConnection(ctx, connectionId, subject);
+
+    if (selected.provider !== "codex" || selected.status !== "connected") {
+      throw new ConvexError(CONNECTION_UNAVAILABLE);
+    }
+
+    const connections = await ctx.db
+      .query("aiConnections")
+      .withIndex("by_owner", (index) => index.eq("ownerId", subject))
+      .collect();
+    const now = Date.now();
+
+    // Convex mutations are transactional, so clearing stale duplicate defaults
+    // and selecting the target cannot expose an intermediate state.
+    await Promise.all(
+      connections.map((connection) => {
+        const shouldBeDefault = connection._id === selected._id;
+
+        if (connection.isDefault === shouldBeDefault) {
+          return Promise.resolve();
+        }
+
+        return ctx.db.patch(connection._id, {
+          isDefault: shouldBeDefault,
+          updatedAt: now,
+        });
+      })
+    );
+
+    return { connectionId: selected._id };
+  },
+});
+
+export {
+  createPendingCodexOwned,
+  getOwnedStatus,
+  listOwned,
+  selectDefaultCodexOwned,
+};

--- a/convex/connectionRateBudget.test.ts
+++ b/convex/connectionRateBudget.test.ts
@@ -1,0 +1,293 @@
+// @vitest-environment edge-runtime
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  CONNECTION_RATE_BUDGET_POLICIES,
+  consumeConnectionRateBudget,
+} from "./lib/connectionRateBudget";
+import { PERSONAL_BETA_SUBJECTS_ENV } from "./lib/personalBeta";
+import schema from "./schema";
+
+const modules = import.meta.glob(["./**/*.*s", "!./**/*.test.ts"]);
+
+type RateEndpoint = Doc<"aiConnectionRateBudgets">["endpoint"];
+
+/** Creates an isolated Convex harness for rate-budget tests. */
+function createHarness() {
+  return convexTest(schema, modules);
+}
+
+type Harness = ReturnType<typeof createHarness>;
+
+/** Requires the complete stable application error message. */
+async function expectErrorMessage(
+  promise: Promise<unknown>,
+  expectedMessage: string
+): Promise<void> {
+  const error = await promise.then(
+    () => null,
+    (caught: unknown) => caught
+  );
+
+  expect(error).toBeInstanceOf(Error);
+  if (!(error instanceof Error)) {
+    return;
+  }
+
+  expect(error.message).toBe(expectedMessage);
+}
+
+/** Reads the single logical budget row for one scope and endpoint. */
+async function getBudget(
+  t: Harness,
+  scope: "owner" | "global",
+  scopeKey: string,
+  endpoint: RateEndpoint
+): Promise<Doc<"aiConnectionRateBudgets"> | null> {
+  return t.run((ctx) =>
+    ctx.db
+      .query("aiConnectionRateBudgets")
+      .withIndex("by_scope_endpoint", (index) =>
+        index
+          .eq("scope", scope)
+          .eq("scopeKey", scopeKey)
+          .eq("endpoint", endpoint)
+      )
+      .unique()
+  );
+}
+
+/** Seeds a connected Codex row as if gateway reconciliation had succeeded. */
+async function seedConnectedConnection(
+  t: Harness,
+  ownerId: string
+): Promise<Id<"aiConnections">> {
+  return t.run((ctx) =>
+    ctx.db.insert("aiConnections", {
+      ownerId,
+      provider: "codex",
+      label: "Codex",
+      status: "connected",
+      authenticationMethod: "device_code",
+      gatewayCredentialId: `gateway-${ownerId}`,
+      isDefault: false,
+      createdAt: 1,
+      updatedAt: 1,
+    })
+  );
+}
+
+beforeEach(() => {
+  vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_alice,user_bob");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("connection rate budgets", () => {
+  it("charges allowlist rejections and enforces the per-owner create budget", async () => {
+    const t = createHarness();
+    const asAlice = t.withIdentity({ subject: "user_alice" });
+    vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_bob");
+
+    for (
+      let attempt = 0;
+      attempt < CONNECTION_RATE_BUDGET_POLICIES.createPendingCodex.ownerLimit;
+      attempt += 1
+    ) {
+      await expectErrorMessage(
+        asAlice.action(api.aiConnections.createPendingCodex, {}),
+        "Personal beta access unavailable"
+      );
+    }
+
+    await expectErrorMessage(
+      asAlice.action(api.aiConnections.createPendingCodex, {}),
+      "Connection rate limit exceeded"
+    );
+    expect(
+      await getBudget(t, "owner", "user_alice", "createPendingCodex")
+    ).toMatchObject({
+      consumed: CONNECTION_RATE_BUDGET_POLICIES.createPendingCodex.ownerLimit,
+    });
+  });
+
+  it("enforces the global create budget across distinct authenticated owners", async () => {
+    const t = createHarness();
+    const globalLimit =
+      CONNECTION_RATE_BUDGET_POLICIES.createPendingCodex.globalLimit;
+
+    for (let attempt = 0; attempt < globalLimit; attempt += 1) {
+      const owner = t.withIdentity({ subject: `global-owner-${attempt}` });
+      await expectErrorMessage(
+        owner.action(api.aiConnections.createPendingCodex, {
+          ownerId: "client-supplied",
+        } as never),
+        "Invalid connection request"
+      );
+    }
+
+    const overflowOwner = t.withIdentity({ subject: "global-owner-overflow" });
+    await expectErrorMessage(
+      overflowOwner.action(api.aiConnections.createPendingCodex, {
+        ownerId: "client-supplied",
+      } as never),
+      "Connection rate limit exceeded"
+    );
+    expect(
+      await getBudget(t, "global", "all", "createPendingCodex")
+    ).toMatchObject({ consumed: globalLimit });
+  });
+
+  it("charges cross-owner selection probes before ownership rejection", async () => {
+    const t = createHarness();
+    const asAlice = t.withIdentity({ subject: "user_alice" });
+    const bobConnection = await seedConnectedConnection(t, "user_bob");
+    const ownerLimit =
+      CONNECTION_RATE_BUDGET_POLICIES.selectDefaultCodex.ownerLimit;
+
+    for (let attempt = 0; attempt < ownerLimit; attempt += 1) {
+      await expectErrorMessage(
+        asAlice.action(api.aiConnections.selectDefaultCodex, {
+          connectionId: bobConnection,
+        }),
+        "Connection unavailable"
+      );
+    }
+
+    await expectErrorMessage(
+      asAlice.action(api.aiConnections.selectDefaultCodex, {
+        connectionId: bobConnection,
+      }),
+      "Connection rate limit exceeded"
+    );
+  });
+
+  it("resets an expired persisted window before charging the next attempt", async () => {
+    const t = createHarness();
+    const asAlice = t.withIdentity({ subject: "user_alice" });
+    await t.run((ctx) =>
+      ctx.db.insert("aiConnectionRateBudgets", {
+        scope: "owner",
+        scopeKey: "user_alice",
+        endpoint: "createPendingCodex",
+        windowStartedAt: 0,
+        windowMs: 1,
+        limit: 1,
+        consumed: 1,
+      })
+    );
+
+    await expectErrorMessage(
+      asAlice.action(api.aiConnections.createPendingCodex, {
+        provider: "claude",
+      } as never),
+      "Invalid connection request"
+    );
+
+    const reset = await getBudget(
+      t,
+      "owner",
+      "user_alice",
+      "createPendingCodex"
+    );
+    expect(reset).toMatchObject({
+      consumed: 1,
+      limit: CONNECTION_RATE_BUDGET_POLICIES.createPendingCodex.ownerLimit,
+      windowMs: CONNECTION_RATE_BUDGET_POLICIES.createPendingCodex.windowMs,
+    });
+    expect(reset?.windowStartedAt).toBeGreaterThan(0);
+  });
+
+  it.each([
+    { consumed: -1, label: "malformed" },
+    { consumed: 4, label: "over-limit" },
+  ])(
+    "fails closed for $label persisted limiter state",
+    async ({ consumed }) => {
+      const t = createHarness();
+      const asAlice = t.withIdentity({ subject: "user_alice" });
+      await t.run((ctx) =>
+        ctx.db.insert("aiConnectionRateBudgets", {
+          scope: "owner",
+          scopeKey: "user_alice",
+          endpoint: "createPendingCodex",
+          windowStartedAt: Date.now() - 1,
+          windowMs: 60_000,
+          limit: 3,
+          consumed,
+        })
+      );
+
+      await expectErrorMessage(
+        asAlice.action(api.aiConnections.createPendingCodex, {}),
+        "Connection rate limit unavailable"
+      );
+    }
+  );
+
+  it("fails closed when duplicate persistent scope rows make enforcement ambiguous", async () => {
+    const t = createHarness();
+    const asAlice = t.withIdentity({ subject: "user_alice" });
+
+    await t.run(async (ctx) => {
+      const row = {
+        scope: "owner" as const,
+        scopeKey: "user_alice",
+        endpoint: "createPendingCodex" as const,
+        windowStartedAt: Date.now() - 1,
+        windowMs: 60_000,
+        limit: 3,
+        consumed: 1,
+      };
+      await ctx.db.insert("aiConnectionRateBudgets", row);
+      await ctx.db.insert("aiConnectionRateBudgets", row);
+    });
+
+    await expectErrorMessage(
+      asAlice.action(api.aiConnections.createPendingCodex, {}),
+      "Connection rate limit unavailable"
+    );
+  });
+
+  it.each([null, {}, { createPendingCodex: { windowMs: 0 } }])(
+    "fails closed for unavailable or malformed policy configuration",
+    async (policySource) => {
+      const t = createHarness();
+
+      await expectErrorMessage(
+        t.run((ctx) =>
+          consumeConnectionRateBudget(
+            ctx,
+            "user_alice",
+            "createPendingCodex",
+            60_000,
+            policySource
+          )
+        ),
+        "Connection rate limit unavailable"
+      );
+    }
+  );
+
+  it("persistently charges safe list and status reads without requiring allowlist access", async () => {
+    const t = createHarness();
+    const asAlice = t.withIdentity({ subject: "user_alice" });
+    const connectionId = await seedConnectedConnection(t, "user_alice");
+    vi.stubEnv(PERSONAL_BETA_SUBJECTS_ENV, "user_bob");
+
+    await asAlice.action(api.aiConnections.list, {});
+    await asAlice.action(api.aiConnections.getStatus, { connectionId });
+
+    expect(await getBudget(t, "owner", "user_alice", "list")).toMatchObject({
+      consumed: 1,
+    });
+    expect(
+      await getBudget(t, "owner", "user_alice", "getStatus")
+    ).toMatchObject({ consumed: 1 });
+  });
+});

--- a/convex/connectionRateBudget.ts
+++ b/convex/connectionRateBudget.ts
@@ -1,0 +1,22 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "./_generated/server";
+import { consumeConnectionRateBudget } from "./lib/connectionRateBudget";
+
+/** Persists one owner/global endpoint attempt before the calling action continues. */
+const consume = internalMutation({
+  args: {
+    subject: v.string(),
+    endpoint: v.union(
+      v.literal("createPendingCodex"),
+      v.literal("selectDefaultCodex"),
+      v.literal("list"),
+      v.literal("getStatus")
+    ),
+  },
+  handler: async (ctx, { subject, endpoint }) => {
+    await consumeConnectionRateBudget(ctx, subject, endpoint);
+  },
+});
+
+export { consume };

--- a/convex/lib/access.ts
+++ b/convex/lib/access.ts
@@ -1,9 +1,10 @@
 import { ConvexError } from "convex/values";
 
 import type { Doc, Id } from "../_generated/dataModel";
-import type { MutationCtx, QueryCtx } from "../_generated/server";
+import type { ActionCtx, MutationCtx, QueryCtx } from "../_generated/server";
 
-type AuthenticatedCtx = QueryCtx | MutationCtx;
+type AuthenticatedCtx = ActionCtx | MutationCtx | QueryCtx;
+type DatabaseCtx = MutationCtx | QueryCtx;
 
 type AuthorizedMindmap = {
   mindmap: Doc<"mindmaps">;
@@ -27,7 +28,7 @@ export async function requireUser(ctx: AuthenticatedCtx): Promise<string> {
  * Loads a mindmap after verifying that the current user owns it.
  */
 export async function requireOwner(
-  ctx: AuthenticatedCtx,
+  ctx: DatabaseCtx,
   mindmapId: Id<"mindmaps">,
   authenticatedSubject?: string
 ): Promise<AuthorizedMindmap> {
@@ -49,7 +50,7 @@ export async function requireOwner(
  * Loads a mindmap that is owned by the user or shared with authenticated users.
  */
 export async function requireReadable(
-  ctx: AuthenticatedCtx,
+  ctx: DatabaseCtx,
   mindmapId: Id<"mindmaps">,
   authenticatedSubject?: string
 ): Promise<AuthorizedMindmap> {

--- a/convex/lib/connectionRateBudget.ts
+++ b/convex/lib/connectionRateBudget.ts
@@ -1,0 +1,275 @@
+import { ConvexError } from "convex/values";
+
+import type { Doc } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+const CONNECTION_RATE_LIMIT_EXCEEDED = "Connection rate limit exceeded";
+const CONNECTION_RATE_LIMIT_UNAVAILABLE = "Connection rate limit unavailable";
+const GLOBAL_SCOPE_KEY = "all";
+const MAX_BUDGET_LIMIT = 10_000;
+const MAX_WINDOW_MS = 86_400_000;
+
+type ConnectionRateEndpoint =
+  | "createPendingCodex"
+  | "selectDefaultCodex"
+  | "list"
+  | "getStatus";
+
+type ConnectionRatePolicy = {
+  windowMs: number;
+  ownerLimit: number;
+  globalLimit: number;
+};
+
+type ConnectionRatePolicySource = Record<
+  ConnectionRateEndpoint,
+  ConnectionRatePolicy
+>;
+
+type RateScope = "owner" | "global";
+type RateBudgetContext = Pick<MutationCtx, "db">;
+
+const CONNECTION_RATE_BUDGET_POLICIES = {
+  createPendingCodex: {
+    windowMs: 60_000,
+    ownerLimit: 3,
+    globalLimit: 20,
+  },
+  selectDefaultCodex: {
+    windowMs: 60_000,
+    ownerLimit: 10,
+    globalLimit: 100,
+  },
+  list: { windowMs: 60_000, ownerLimit: 60, globalLimit: 1_000 },
+  getStatus: { windowMs: 60_000, ownerLimit: 120, globalLimit: 2_000 },
+} satisfies ConnectionRatePolicySource;
+
+/** Returns true only for finite, bounded integer rate-policy values. */
+function isValidPolicy(policy: unknown): policy is ConnectionRatePolicy {
+  if (typeof policy !== "object" || policy === null) {
+    return false;
+  }
+
+  const candidate = policy as Partial<ConnectionRatePolicy>;
+  return (
+    Number.isSafeInteger(candidate.windowMs) &&
+    (candidate.windowMs ?? 0) > 0 &&
+    (candidate.windowMs ?? 0) <= MAX_WINDOW_MS &&
+    Number.isSafeInteger(candidate.ownerLimit) &&
+    (candidate.ownerLimit ?? 0) > 0 &&
+    (candidate.ownerLimit ?? 0) <= MAX_BUDGET_LIMIT &&
+    Number.isSafeInteger(candidate.globalLimit) &&
+    (candidate.globalLimit ?? 0) >= (candidate.ownerLimit ?? 0) &&
+    (candidate.globalLimit ?? 0) <= MAX_BUDGET_LIMIT
+  );
+}
+
+/** Resolves one endpoint policy from server-owned configuration or fails closed. */
+function requirePolicy(
+  endpoint: ConnectionRateEndpoint,
+  policySource: unknown
+): ConnectionRatePolicy {
+  if (typeof policySource !== "object" || policySource === null) {
+    throw new ConvexError(CONNECTION_RATE_LIMIT_UNAVAILABLE);
+  }
+
+  const policy = (policySource as Partial<ConnectionRatePolicySource>)[
+    endpoint
+  ];
+  if (!isValidPolicy(policy)) {
+    throw new ConvexError(CONNECTION_RATE_LIMIT_UNAVAILABLE);
+  }
+
+  return policy;
+}
+
+/** Validates persisted limiter state before it can influence authorization. */
+function isValidBudgetState(
+  budget: Doc<"aiConnectionRateBudgets">,
+  now: number
+): boolean {
+  if (
+    !Number.isSafeInteger(budget.windowStartedAt) ||
+    budget.windowStartedAt < 0 ||
+    budget.windowStartedAt > now ||
+    !Number.isSafeInteger(budget.windowMs) ||
+    budget.windowMs <= 0 ||
+    budget.windowMs > MAX_WINDOW_MS ||
+    !Number.isSafeInteger(budget.limit) ||
+    budget.limit <= 0 ||
+    budget.limit > MAX_BUDGET_LIMIT ||
+    !Number.isSafeInteger(budget.consumed) ||
+    budget.consumed <= 0 ||
+    budget.consumed > budget.limit
+  ) {
+    return false;
+  }
+
+  return Number.isSafeInteger(budget.windowStartedAt + budget.windowMs);
+}
+
+/** Returns whether a valid persisted fixed window still contains this attempt. */
+function isBudgetWindowActive(
+  budget: Doc<"aiConnectionRateBudgets">,
+  now: number
+): boolean {
+  return now < budget.windowStartedAt + budget.windowMs;
+}
+
+/** Loads exactly one persisted scope row, treating duplicates as unavailable state. */
+async function loadBudget(
+  ctx: RateBudgetContext,
+  scope: RateScope,
+  scopeKey: string,
+  endpoint: ConnectionRateEndpoint
+): Promise<Doc<"aiConnectionRateBudgets"> | null> {
+  const budgets = await ctx.db
+    .query("aiConnectionRateBudgets")
+    .withIndex("by_scope_endpoint", (index) =>
+      index.eq("scope", scope).eq("scopeKey", scopeKey).eq("endpoint", endpoint)
+    )
+    .take(2);
+
+  if (budgets.length > 1) {
+    throw new ConvexError(CONNECTION_RATE_LIMIT_UNAVAILABLE);
+  }
+
+  return budgets[0] ?? null;
+}
+
+/** Persists one consumption against a previously validated owner/global row. */
+async function persistConsumption(
+  ctx: RateBudgetContext,
+  budget: Doc<"aiConnectionRateBudgets"> | null,
+  scope: RateScope,
+  scopeKey: string,
+  endpoint: ConnectionRateEndpoint,
+  now: number,
+  policy: ConnectionRatePolicy,
+  configuredLimit: number
+): Promise<void> {
+  if (budget !== null && isBudgetWindowActive(budget, now)) {
+    const effectiveLimit = Math.min(budget.limit, configuredLimit);
+    if (budget.consumed >= effectiveLimit) {
+      throw new ConvexError(CONNECTION_RATE_LIMIT_EXCEEDED);
+    }
+
+    await ctx.db.patch(budget._id, { consumed: budget.consumed + 1 });
+    return;
+  }
+
+  const windowStartedAt = Math.floor(now / policy.windowMs) * policy.windowMs;
+  const nextState = {
+    windowStartedAt,
+    windowMs: policy.windowMs,
+    limit: configuredLimit,
+    consumed: 1,
+  };
+
+  if (budget === null) {
+    await ctx.db.insert("aiConnectionRateBudgets", {
+      scope,
+      scopeKey,
+      endpoint,
+      ...nextState,
+    });
+    return;
+  }
+
+  await ctx.db.patch(budget._id, nextState);
+}
+
+/**
+ * Atomically consumes persistent per-owner and global capacity for one endpoint.
+ *
+ * The helper never uses process memory. Any missing/malformed policy, duplicate
+ * or malformed persisted state, or database enforcement failure becomes the
+ * same stable fail-closed error. Tests may inject time and policy data without
+ * exposing either value through a public Convex function.
+ */
+async function consumeConnectionRateBudget(
+  ctx: RateBudgetContext,
+  subject: string,
+  endpoint: ConnectionRateEndpoint,
+  now = Date.now(),
+  policySource: unknown = CONNECTION_RATE_BUDGET_POLICIES
+): Promise<void> {
+  const policy = requirePolicy(endpoint, policySource);
+  if (!Number.isSafeInteger(now) || now < 0) {
+    throw new ConvexError(CONNECTION_RATE_LIMIT_UNAVAILABLE);
+  }
+
+  let ownerBudget: Doc<"aiConnectionRateBudgets"> | null;
+  let globalBudget: Doc<"aiConnectionRateBudgets"> | null;
+
+  try {
+    [ownerBudget, globalBudget] = await Promise.all([
+      loadBudget(ctx, "owner", subject, endpoint),
+      loadBudget(ctx, "global", GLOBAL_SCOPE_KEY, endpoint),
+    ]);
+  } catch {
+    throw new ConvexError(CONNECTION_RATE_LIMIT_UNAVAILABLE);
+  }
+
+  if (
+    (ownerBudget !== null && !isValidBudgetState(ownerBudget, now)) ||
+    (globalBudget !== null && !isValidBudgetState(globalBudget, now))
+  ) {
+    throw new ConvexError(CONNECTION_RATE_LIMIT_UNAVAILABLE);
+  }
+
+  // Check both capacities before either write. Convex then commits both scope
+  // updates atomically and retries conflicting concurrent attempts.
+  if (
+    (ownerBudget !== null &&
+      isBudgetWindowActive(ownerBudget, now) &&
+      ownerBudget.consumed >= Math.min(ownerBudget.limit, policy.ownerLimit)) ||
+    (globalBudget !== null &&
+      isBudgetWindowActive(globalBudget, now) &&
+      globalBudget.consumed >= Math.min(globalBudget.limit, policy.globalLimit))
+  ) {
+    throw new ConvexError(CONNECTION_RATE_LIMIT_EXCEEDED);
+  }
+
+  try {
+    await Promise.all([
+      persistConsumption(
+        ctx,
+        ownerBudget,
+        "owner",
+        subject,
+        endpoint,
+        now,
+        policy,
+        policy.ownerLimit
+      ),
+      persistConsumption(
+        ctx,
+        globalBudget,
+        "global",
+        GLOBAL_SCOPE_KEY,
+        endpoint,
+        now,
+        policy,
+        policy.globalLimit
+      ),
+    ]);
+  } catch (error) {
+    if (
+      error instanceof ConvexError &&
+      error.data === CONNECTION_RATE_LIMIT_EXCEEDED
+    ) {
+      throw error;
+    }
+
+    throw new ConvexError(CONNECTION_RATE_LIMIT_UNAVAILABLE);
+  }
+}
+
+export {
+  CONNECTION_RATE_BUDGET_POLICIES,
+  CONNECTION_RATE_LIMIT_EXCEEDED,
+  CONNECTION_RATE_LIMIT_UNAVAILABLE,
+  consumeConnectionRateBudget,
+};
+export type { ConnectionRateEndpoint, ConnectionRatePolicySource };

--- a/convex/lib/personalBeta.test.ts
+++ b/convex/lib/personalBeta.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment edge-runtime
+import { describe, expect, it } from "vitest";
+
+import {
+  isPersonalBetaSubjectAllowed,
+  PERSONAL_BETA_SUBJECTS_ENV,
+} from "./personalBeta";
+
+describe("personal beta subject allowlist", () => {
+  it("matches only exact trimmed subjects", () => {
+    const readEnvironment = (name: string) => {
+      expect(name).toBe(PERSONAL_BETA_SUBJECTS_ENV);
+      return " user_alice, user_bob ";
+    };
+
+    expect(isPersonalBetaSubjectAllowed("user_alice", readEnvironment)).toBe(
+      true
+    );
+    expect(isPersonalBetaSubjectAllowed("user_al", readEnvironment)).toBe(
+      false
+    );
+    expect(isPersonalBetaSubjectAllowed("*", readEnvironment)).toBe(false);
+  });
+
+  it.each([undefined, "", "   ", ", ,"])(
+    "denies missing or empty configuration (%s)",
+    (configuredSubjects) => {
+      expect(
+        isPersonalBetaSubjectAllowed("user_alice", () => configuredSubjects)
+      ).toBe(false);
+    }
+  );
+
+  it("denies access when the environment is unavailable", () => {
+    expect(
+      isPersonalBetaSubjectAllowed("user_alice", () => {
+        throw new Error("environment unavailable");
+      })
+    ).toBe(false);
+  });
+});

--- a/convex/lib/personalBeta.ts
+++ b/convex/lib/personalBeta.ts
@@ -1,0 +1,41 @@
+const PERSONAL_BETA_SUBJECTS_ENV = "SPRIG_PERSONAL_BETA_CLERK_SUBJECTS";
+
+type EnvironmentReader = (name: string) => string | undefined;
+
+/** Reads one server-owned environment value without turning an unavailable runtime into access. */
+function readProcessEnvironment(name: string): string | undefined {
+  return process.env[name];
+}
+
+/**
+ * Checks an authenticated Clerk subject against the exact personal-beta allowlist.
+ *
+ * Missing, unreadable, empty, and non-matching configuration all deny access.
+ * Wildcards are intentionally treated as ordinary subject text.
+ */
+function isPersonalBetaSubjectAllowed(
+  subject: string,
+  readEnvironment: EnvironmentReader = readProcessEnvironment
+): boolean {
+  let configuredSubjects: string | undefined;
+
+  try {
+    configuredSubjects = readEnvironment(PERSONAL_BETA_SUBJECTS_ENV);
+  } catch {
+    return false;
+  }
+
+  if (configuredSubjects === undefined || configuredSubjects.trim() === "") {
+    return false;
+  }
+
+  // Exact comparison keeps browser input and wildcard-like configuration from
+  // broadening the server-controlled list.
+  return configuredSubjects
+    .split(",")
+    .map((configuredSubject) => configuredSubject.trim())
+    .filter((configuredSubject) => configuredSubject.length > 0)
+    .some((configuredSubject) => configuredSubject === subject);
+}
+
+export { isPersonalBetaSubjectAllowed, PERSONAL_BETA_SUBJECTS_ENV };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,6 +2,30 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+  aiConnections: defineTable({
+    ownerId: v.string(),
+    provider: v.literal("codex"),
+    label: v.string(),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("connected"),
+      v.literal("error"),
+      v.literal("expired"),
+      v.literal("revoked")
+    ),
+    authenticationMethod: v.literal("device_code"),
+    gatewayCredentialId: v.optional(v.string()),
+    accountHint: v.optional(v.string()),
+    planLabel: v.optional(v.string()),
+    isDefault: v.boolean(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    lastValidationAt: v.optional(v.number()),
+    lastErrorCode: v.optional(v.string()),
+  })
+    .index("by_owner", ["ownerId"])
+    .index("by_owner_provider_status", ["ownerId", "provider", "status"]),
+
   mindmaps: defineTable({
     publicId: v.string(),
     name: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -26,6 +26,21 @@ export default defineSchema({
     .index("by_owner", ["ownerId"])
     .index("by_owner_provider_status", ["ownerId", "provider", "status"]),
 
+  aiConnectionRateBudgets: defineTable({
+    scope: v.union(v.literal("owner"), v.literal("global")),
+    scopeKey: v.string(),
+    endpoint: v.union(
+      v.literal("createPendingCodex"),
+      v.literal("selectDefaultCodex"),
+      v.literal("list"),
+      v.literal("getStatus")
+    ),
+    windowStartedAt: v.number(),
+    windowMs: v.number(),
+    limit: v.number(),
+    consumed: v.number(),
+  }).index("by_scope_endpoint", ["scope", "scopeKey", "endpoint"]),
+
   mindmaps: defineTable({
     publicId: v.string(),
     name: v.string(),

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -6,6 +6,7 @@
 | `CLERK_SECRET_KEY` | Clerk's server SDK and request proxy. | Not required in keyless development; production-only in P9. | Configure the production Clerk application in P9. |
 | `NEXT_PUBLIC_ENABLE_OAUTH` | `app/(auth-pages)/oauth-buttons.tsx` renders the Google and GitHub buttons on `/sign-in` and `/sign-up` only when this is exactly `"true"`. | Optional; leave unset in keyless development. | Set to `true` once P9 claims the Clerk instance and enables the Google and GitHub social connections in the Clerk dashboard. |
 | `CLERK_FRONTEND_API_URL` | `convex/auth.config.ts` uses this issuer to validate Clerk JWTs when it is configured. | Optional in keyless/local runs; required in the Convex deployment environment after Clerk is claimed in P9. | Use the claimed Clerk instance's full Frontend API URL, including `https://`. |
+| `SPRIG_PERSONAL_BETA_CLERK_SUBJECTS` | Convex connection create/select mutations require an exact authenticated Clerk subject match in this comma-separated server-only allowlist. Missing, unreadable, empty, and non-matching values deny access. | Required to create or select subscription connection metadata; safe owner-only status reads do not require it. | Add approved Clerk `subject` values to the Convex deployment environment only after the personal-beta cohort is approved. |
 | `CONVEX_DEPLOYMENT` | The Convex CLI uses this deployment identifier for schema generation and local backend commands. | Required for Convex development commands. | Created by the anonymous local Convex setup and stored in `.env.local`. Production deployment values arrive in P9. |
 | `SPRIG_AI_PROVIDER` | Routes every server-side AI path through the Claude Agent SDK or Codex SDK. | Optional; defaults to `claude`. | Set to exactly `claude` or `codex`. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | The Claude Agent SDK authenticates `/api/chat` and the AI generation/editing server actions with the local operator's Claude subscription. | Required for subscription-backed AI features; dev-local and single-operator only. | Run `claude setup-token` and copy the generated token. |
@@ -34,6 +35,12 @@ Social sign-in is gated behind `NEXT_PUBLIC_ENABLE_OAUTH` for the same reason: a
 keyless instance has no OAuth credentials, so the buttons stay out of the markup
 entirely until the instance is claimed. The flag is read at module scope, so
 changing it requires a dev-server restart.
+
+`SPRIG_PERSONAL_BETA_CLERK_SUBJECTS` is server-owned Convex configuration, not
+browser input. It accepts exact Clerk subjects separated by commas. There is no
+wildcard value. Do not deploy the additive `aiConnections` schema or configure
+the allowlist against a real Convex database until a human approves that
+deployment and the personal-beta cohort.
 
 `SPRIG_AI_PROVIDER` switches every AI entry point together: `claude` uses the
 Claude Agent SDK and `codex` uses the OpenAI Codex SDK. Unsupported values are

--- a/docs/adr/0002-subscription-connection-gateway.md
+++ b/docs/adr/0002-subscription-connection-gateway.md
@@ -97,6 +97,15 @@ errors, and fail closed when the rate-limit state is unavailable. Polling may
 have a different finite budget from credential submission or execution, but no
 connection endpoint is unlimited.
 
+The initial Convex metadata API applies this rule to safe `list` and `getStatus`
+reads as well as lifecycle mutations. Because a Convex query cannot persist
+budget consumption, those owner-facing reads are exposed as actions that first
+commit a server-only rate-budget mutation and then run an internal owner-scoped
+query. They remain display-only and available after de-allowlisting, but they
+are not unlimited. Lifecycle actions use the same two-step boundary so a
+known-owner attempt stays charged when a later argument, allowlist, state, or
+ownership check rejects the request.
+
 ### Internal request authentication
 
 Next.js will authenticate each gateway request with a versioned signed internal


### PR DESCRIPTION
## Feature

Adds the first Codex-first Phase 1 metadata foundation for owner-scoped subscription connections.

- adds additive `aiConnections` and persistent `aiConnectionRateBudgets` Convex tables
- derives ownership exclusively from the authenticated Clerk subject
- exposes secret-free owner-only list/status actions
- creates server-derived pending Codex device-code records
- atomically selects exactly one connected default per owner
- keeps safe status reads available after de-allowlisting
- fails create/select closed unless the exact subject is in the server-owned personal-beta allowlist
- rejects client attempts to write ownership, provider status, gateway handles, account/plan hints, validation time, or provider errors
- enforces finite endpoint-specific per-owner and global budgets for every public connection endpoint
- persistently charges rejected known-owner attempts before argument, allowlist, state, or ownership checks
- fails closed with stable secret-free errors when limiter policy/state/enforcement is unavailable or exhausted

## Architecture

```text
Browser
  | Clerk identity + narrow request
  v
Public Convex action
  | authenticate owner
  | commit persistent owner + global budget
  | validate args / allowlist
  v
Internal owner-scoped query or mutation
  |-- list / safe status
  |-- create pending / select connected default
  v
aiConnections metadata
  | Codex-only, secret-free client projection
  | opaque gateway handle is never returned
  v
Future gateway reconciliation (not implemented here)
```

The separate budget mutation is intentional: a later rejected action cannot roll back an already-consumed attempt. Safe `list` and `getStatus` reads are actions because ordinary Convex queries cannot persist rate consumption; their returned data remains read-only and owner-scoped.

This PR intentionally does not add Claude, credential handling, lifecycle reconciliation, provider execution, or a gateway deployment.

## Human deployment gate

Both additive tables and `SPRIG_PERSONAL_BETA_CLERK_SUBJECTS` remain code-only in this PR. No Convex deployment, database migration, credential operation, or environment mutation was run. A human must approve the real Convex schema deployment and the beta cohort before configuring the allowlist.

## Validation

- `pnpm vitest run convex/aiConnections.test.ts convex/connectionRateBudget.test.ts convex/lib/personalBeta.test.ts` (41 tests)
- `pnpm typegen`
- `pnpm typecheck`
- `pnpm test` (57 files, 550 tests)
- `pnpm lint` (passes; 5 existing warnings outside owned source)
- `pnpm format:check`
- `git diff --check`
