### PR TITLE
feat(gateway): add internal assertion auth

### DIFF
--- a/services/agent-gateway/README.md
+++ b/services/agent-gateway/README.md
@@ -24,4 +24,5 @@ key custody/rotation mechanism, durable replay-state topology, backup policy,
 and deployment remain explicit human gates. `BoundedReplayCache` is a
 deterministic test/local primitive only. Any real deployment must inject an
 atomic `ReplayDefense` whose lifecycle prevents reuse across process restarts;
-a multi-process deployment also requires shared replay state.
+a multi-process deployment also requires shared replay state. Verification
+awaits the injected replay contract before evaluating expected request context.

--- a/services/agent-gateway/README.md
+++ b/services/agent-gateway/README.md
@@ -1,0 +1,27 @@
+# Agent gateway service boundary
+
+This directory starts the separately deployable Node 24 gateway defined by
+[ADR 0002](../../docs/adr/0002-subscription-connection-gateway.md). The first
+slice is intentionally limited to dependency-free internal request
+authentication primitives:
+
+- Ed25519-signed, versioned, Codex-only assertions with a maximum 60-second
+  lifetime;
+- exact issuer, audience, owner, connection, provider, and operation matching;
+- explicit current/previous verification-key overlap; and
+- bounded, fail-closed replay defense that consumes signed requests before
+  expected-context validation.
+
+```text
+Next.js issuer -> signed v1 assertion -> signature + time -> replay consume
+                                                         -> context match
+                                                         -> later gateway work
+```
+
+There is no HTTP listener, credential storage, provider execution, environment
+configuration, or deployment in this slice. The persistent host, production
+key custody/rotation mechanism, durable replay-state topology, backup policy,
+and deployment remain explicit human gates. `BoundedReplayCache` is a
+deterministic test/local primitive only. Any real deployment must inject an
+atomic `ReplayDefense` whose lifecycle prevents reuse across process restarts;
+a multi-process deployment also requires shared replay state.

--- a/services/agent-gateway/internal-auth.test.ts
+++ b/services/agent-gateway/internal-auth.test.ts
@@ -51,6 +51,7 @@ function createFixture() {
     connectionId: "connection_a",
     provider: "codex",
     operation: "chat",
+    requestId: "request_1",
   };
   const verificationKeys: VerificationKeys = {
     current: current.verification,
@@ -122,7 +123,16 @@ function resignToken(
   mutate(claims);
 
   const nextClaims = Buffer.from(JSON.stringify(claims)).toString("base64url");
-  const signingInput = `${encodedHeader}.${nextClaims}`;
+  return signEncodedAssertion(encodedHeader, nextClaims, signingKey);
+}
+
+/** Signs pre-encoded JSON segments so tests can authenticate noncanonical forms. */
+function signEncodedAssertion(
+  encodedHeader: string,
+  encodedClaims: string,
+  signingKey: SigningKey
+): string {
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
   const signature = signBytes(
     null,
     Buffer.from(signingInput),
@@ -173,7 +183,11 @@ describe("internal gateway assertions", () => {
 
     const token = issueToken(fixture);
     const [header, claims, signature] = token.split(".");
-    const tamperedSignature = `${signature.slice(0, -1)}${signature.endsWith("A") ? "B" : "A"}`;
+    const tamperedSignatureBytes = Buffer.from(signature, "base64url");
+    // Flipping a decoded signature bit always changes the Ed25519 signature,
+    // unlike replacing a possibly unused base64 padding bit.
+    tamperedSignatureBytes[0] ^= 0x01;
+    const tamperedSignature = tamperedSignatureBytes.toString("base64url");
     expectCode(
       () => verifyToken(fixture, `${header}.${claims}.${tamperedSignature}`),
       "invalid_signature"
@@ -238,6 +252,55 @@ describe("internal gateway assertions", () => {
     );
   });
 
+  it("rejects authenticated noncanonical header and payload JSON", () => {
+    const canonicalToken = issueToken(createFixture());
+    const [encodedHeader, encodedClaims] = canonicalToken.split(".");
+    const header = JSON.parse(
+      Buffer.from(encodedHeader, "base64url").toString("utf8")
+    ) as Record<string, unknown>;
+    const claims = JSON.parse(
+      Buffer.from(encodedClaims, "base64url").toString("utf8")
+    ) as Record<string, unknown>;
+    const canonicalHeaderJson = JSON.stringify(header);
+    const canonicalClaimsJson = JSON.stringify(claims);
+    const encode = (value: string) => Buffer.from(value).toString("base64url");
+
+    const variants: ReadonlyArray<readonly [string, string]> = [
+      [encode(JSON.stringify({ kid: header.kid, ...header })), encodedClaims],
+      [encodedHeader, encode(JSON.stringify({ kid: claims.kid, ...claims }))],
+      [encode(JSON.stringify(header, null, 2)), encodedClaims],
+      [
+        encode(
+          canonicalHeaderJson.replace(
+            '"algorithm":"EdDSA"',
+            '"algorithm":"EdDSA","algorithm":"EdDSA"'
+          )
+        ),
+        encodedClaims,
+      ],
+      [
+        encodedHeader,
+        encode(
+          canonicalClaimsJson.replace(
+            '"requestId":"request_1"',
+            '"requestId":"request_shadow","requestId":"request_1"'
+          )
+        ),
+      ],
+      [`${encodedHeader}=`, encodedClaims],
+    ];
+
+    for (const [noncanonicalHeader, noncanonicalClaims] of variants) {
+      const fixture = createFixture();
+      const token = signEncodedAssertion(
+        noncanonicalHeader,
+        noncanonicalClaims,
+        fixture.current.signing
+      );
+      expectCode(() => verifyToken(fixture, token), "noncanonical_assertion");
+    }
+  });
+
   it.each([
     ["issuer", "issuer_mismatch", { issuer: "unexpected-issuer" }],
     ["audience", "audience_mismatch", { audience: "unexpected-audience" }],
@@ -284,6 +347,25 @@ describe("internal gateway assertions", () => {
     expectCode(
       () => verifyToken(fixture, token, { replayDefense }),
       "provider_mismatch"
+    );
+    expectCode(
+      () => verifyToken(fixture, token, { replayDefense }),
+      "replay_detected"
+    );
+  });
+
+  it("rejects a signed request identifier mismatch and keeps it consumed", () => {
+    const fixture = createFixture();
+    const replayDefense = new BoundedReplayCache(4);
+    const token = issueToken(fixture);
+
+    expectCode(
+      () =>
+        verifyToken(fixture, token, {
+          expected: { ...fixture.expected, requestId: "request_2" },
+          replayDefense,
+        }),
+      "request_id_mismatch"
     );
     expectCode(
       () => verifyToken(fixture, token, { replayDefense }),
@@ -354,7 +436,10 @@ describe("internal gateway assertions", () => {
           requestId: "request_4",
           nonce: "nonce_4",
         }),
-        { replayDefense }
+        {
+          expected: { ...fixture.expected, requestId: "request_4" },
+          replayDefense,
+        }
       ).requestId
     ).toBe("request_4");
   });
@@ -438,8 +523,11 @@ describe("internal gateway assertions", () => {
       requestId: "request_unrelated",
       nonce: "nonce_unrelated",
     });
-    expect(verifyToken(fixture, unrelated, { replayDefense }).subject).toBe(
-      "user_owner_a"
-    );
+    expect(
+      verifyToken(fixture, unrelated, {
+        expected: { ...fixture.expected, requestId: "request_unrelated" },
+        replayDefense,
+      }).subject
+    ).toBe("user_owner_a");
   });
 });

--- a/services/agent-gateway/internal-auth.test.ts
+++ b/services/agent-gateway/internal-auth.test.ts
@@ -141,24 +141,32 @@ function signEncodedAssertion(
   return `${signingInput}.${signature}`;
 }
 
-/** Captures and checks the stable error code from one rejected verification. */
-function expectCode(
-  action: () => unknown,
+/** Awaits a rejected verification and checks only its stable public code. */
+async function expectCode(
+  action: () => unknown | Promise<unknown>,
   code: InternalAssertionError["code"]
-): void {
+): Promise<void> {
+  const error = await captureAssertionError(action);
+  expect(error.code).toBe(code);
+}
+
+/** Captures one stable verifier error without accepting another error type. */
+async function captureAssertionError(
+  action: () => unknown | Promise<unknown>
+): Promise<InternalAssertionError> {
   try {
-    action();
-    throw new Error(`Expected ${code}`);
+    await action();
+    throw new Error("Expected an InternalAssertionError");
   } catch (error) {
     expect(error).toBeInstanceOf(InternalAssertionError);
-    expect((error as InternalAssertionError).code).toBe(code);
+    return error as InternalAssertionError;
   }
 }
 
 describe("internal gateway assertions", () => {
-  it("issues and verifies the exact Codex-only v1 context", () => {
+  it("issues and verifies the exact Codex-only v1 context", async () => {
     const fixture = createFixture();
-    const claims = verifyToken(fixture, issueToken(fixture));
+    const claims = await verifyToken(fixture, issueToken(fixture));
 
     expect(claims).toEqual({
       version: 1,
@@ -176,10 +184,16 @@ describe("internal gateway assertions", () => {
     });
   });
 
-  it("rejects missing, malformed, and signature-tampered assertions", () => {
+  it("rejects missing, malformed, and signature-tampered assertions", async () => {
     const fixture = createFixture();
-    expectCode(() => verifyToken(fixture, undefined), "missing_assertion");
-    expectCode(() => verifyToken(fixture, "not-a-token"), "invalid_assertion");
+    await expectCode(
+      () => verifyToken(fixture, undefined),
+      "missing_assertion"
+    );
+    await expectCode(
+      () => verifyToken(fixture, "not-a-token"),
+      "invalid_assertion"
+    );
 
     const token = issueToken(fixture);
     const [header, claims, signature] = token.split(".");
@@ -188,7 +202,7 @@ describe("internal gateway assertions", () => {
     // unlike replacing a possibly unused base64 padding bit.
     tamperedSignatureBytes[0] ^= 0x01;
     const tamperedSignature = tamperedSignatureBytes.toString("base64url");
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, `${header}.${claims}.${tamperedSignature}`),
       "invalid_signature"
     );
@@ -199,44 +213,47 @@ describe("internal gateway assertions", () => {
         subject: "user_owner_b",
       })
     ).toString("base64url");
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, `${header}.${tamperedClaims}.${signature}`),
       "invalid_signature"
     );
   });
 
-  it("enforces a strict maximum lifetime and exact no-skew boundaries", () => {
+  it("enforces a strict maximum lifetime and exact no-skew boundaries", async () => {
     const fixture = createFixture();
-    expectCode(
+    await expectCode(
       () => issueToken(fixture, { lifetimeSeconds: 61 }),
       "assertion_lifetime_invalid"
     );
 
     const token = issueToken(fixture, { lifetimeSeconds: 10 });
     fixture.clock.set(BASE_TIME - 1);
-    expectCode(() => verifyToken(fixture, token), "assertion_from_future");
+    await expectCode(
+      () => verifyToken(fixture, token),
+      "assertion_from_future"
+    );
 
     fixture.clock.set(BASE_TIME + 9);
-    expect(verifyToken(fixture, token).exp).toBe(BASE_TIME + 10);
+    expect((await verifyToken(fixture, token)).exp).toBe(BASE_TIME + 10);
 
     fixture.clock.set(BASE_TIME + 10);
-    expectCode(() => verifyToken(fixture, token), "assertion_expired");
+    await expectCode(() => verifyToken(fixture, token), "assertion_expired");
   });
 
-  it("rejects signed assertions whose encoded lifetime exceeds the limit", () => {
+  it("rejects signed assertions whose encoded lifetime exceeds the limit", async () => {
     const fixture = createFixture();
     const token = issueToken(fixture);
     const oversized = resignToken(token, fixture.current.signing, (claims) => {
       claims.exp = BASE_TIME + 61;
     });
 
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, oversized),
       "assertion_lifetime_invalid"
     );
   });
 
-  it("rejects a correctly signed assertion from another protocol version", () => {
+  it("rejects a correctly signed assertion from another protocol version", async () => {
     const fixture = createFixture();
     const token = resignToken(
       issueToken(fixture),
@@ -246,13 +263,13 @@ describe("internal gateway assertions", () => {
       }
     );
 
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, token),
       "unsupported_assertion_version"
     );
   });
 
-  it("rejects authenticated noncanonical header and payload JSON", () => {
+  it("rejects authenticated noncanonical header and payload JSON", async () => {
     const canonicalToken = issueToken(createFixture());
     const [encodedHeader, encodedClaims] = canonicalToken.split(".");
     const header = JSON.parse(
@@ -297,7 +314,10 @@ describe("internal gateway assertions", () => {
         noncanonicalClaims,
         fixture.current.signing
       );
-      expectCode(() => verifyToken(fixture, token), "noncanonical_assertion");
+      await expectCode(
+        () => verifyToken(fixture, token),
+        "noncanonical_assertion"
+      );
     }
   });
 
@@ -309,7 +329,7 @@ describe("internal gateway assertions", () => {
     ["operation", "operation_mismatch", { operation: "node-editing" }],
   ] as const)(
     "rejects a wrong expected %s and consumes the signed assertion",
-    (_label, code, expectedOverride) => {
+    async (_label, code, expectedOverride) => {
       const fixture = createFixture();
       const replayDefense = new BoundedReplayCache(4);
       const token = issueToken(fixture);
@@ -318,7 +338,7 @@ describe("internal gateway assertions", () => {
         ...expectedOverride,
       } as ExpectedAssertionContext;
 
-      expectCode(
+      await expectCode(
         () =>
           verifyToken(fixture, token, {
             expected: wrongExpected,
@@ -326,14 +346,14 @@ describe("internal gateway assertions", () => {
           }),
         code
       );
-      expectCode(
+      await expectCode(
         () => verifyToken(fixture, token, { replayDefense }),
         "replay_detected"
       );
     }
   );
 
-  it("rejects a signed non-Codex provider and still consumes it", () => {
+  it("rejects a signed non-Codex provider and still consumes it", async () => {
     const fixture = createFixture();
     const replayDefense = new BoundedReplayCache(4);
     const token = resignToken(
@@ -344,22 +364,22 @@ describe("internal gateway assertions", () => {
       }
     );
 
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, token, { replayDefense }),
       "provider_mismatch"
     );
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, token, { replayDefense }),
       "replay_detected"
     );
   });
 
-  it("rejects a signed request identifier mismatch and keeps it consumed", () => {
+  it("rejects a signed request identifier mismatch and keeps it consumed", async () => {
     const fixture = createFixture();
     const replayDefense = new BoundedReplayCache(4);
     const token = issueToken(fixture);
 
-    expectCode(
+    await expectCode(
       () =>
         verifyToken(fixture, token, {
           expected: { ...fixture.expected, requestId: "request_2" },
@@ -367,25 +387,25 @@ describe("internal gateway assertions", () => {
         }),
       "request_id_mismatch"
     );
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, token, { replayDefense }),
       "replay_detected"
     );
   });
 
-  it("detects request identifier and nonce reuse independently", () => {
+  it("detects request identifier and nonce reuse independently", async () => {
     const fixture = createFixture();
     const replayDefense = new BoundedReplayCache(4);
-    verifyToken(fixture, issueToken(fixture), { replayDefense });
+    await verifyToken(fixture, issueToken(fixture), { replayDefense });
 
-    expectCode(
+    await expectCode(
       () =>
         verifyToken(fixture, issueToken(fixture, { nonce: "nonce_2" }), {
           replayDefense,
         }),
       "replay_detected"
     );
-    expectCode(
+    await expectCode(
       () =>
         verifyToken(fixture, issueToken(fixture, { requestId: "request_2" }), {
           replayDefense,
@@ -394,14 +414,14 @@ describe("internal gateway assertions", () => {
     );
   });
 
-  it("fails closed through the validity of a token rejected at capacity", () => {
+  it("fails closed through the validity of a token rejected at capacity", async () => {
     const fixture = createFixture();
     const replayDefense = new BoundedReplayCache(1);
-    verifyToken(fixture, issueToken(fixture, { lifetimeSeconds: 2 }), {
+    await verifyToken(fixture, issueToken(fixture, { lifetimeSeconds: 2 }), {
       replayDefense,
     });
 
-    expectCode(
+    await expectCode(
       () =>
         verifyToken(
           fixture,
@@ -415,7 +435,7 @@ describe("internal gateway assertions", () => {
     );
 
     fixture.clock.set(BASE_TIME + 2);
-    expectCode(
+    await expectCode(
       () =>
         verifyToken(
           fixture,
@@ -430,65 +450,125 @@ describe("internal gateway assertions", () => {
 
     fixture.clock.set(BASE_TIME + 62);
     expect(
-      verifyToken(
-        fixture,
-        issueToken(fixture, {
-          requestId: "request_4",
-          nonce: "nonce_4",
-        }),
-        {
-          expected: { ...fixture.expected, requestId: "request_4" },
-          replayDefense,
-        }
+      (
+        await verifyToken(
+          fixture,
+          issueToken(fixture, {
+            requestId: "request_4",
+            nonce: "nonce_4",
+          }),
+          {
+            expected: { ...fixture.expected, requestId: "request_4" },
+            replayDefense,
+          }
+        )
       ).requestId
     ).toBe("request_4");
   });
 
-  it("normalizes unavailable replay state into a fail-closed error", () => {
+  it("awaits delayed replay enforcement before resolving verification", async () => {
     const fixture = createFixture();
-    const unavailable: ReplayDefense = {
-      consume() {
-        throw new Error("state backend disconnected");
+    let releaseConsume: (() => void) | undefined;
+    let settled = false;
+    const delayed: ReplayDefense = {
+      async consume() {
+        await new Promise<void>((resolve) => {
+          releaseConsume = resolve;
+        });
       },
     };
 
-    expectCode(
-      () =>
-        verifyToken(fixture, issueToken(fixture), {
-          replayDefense: unavailable,
-        }),
-      "replay_defense_unavailable"
+    const verification = verifyToken(fixture, issueToken(fixture), {
+      replayDefense: delayed,
+    });
+    void verification.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      }
     );
+    await Promise.resolve();
+
+    expect(releaseConsume).toBeTypeOf("function");
+    expect(settled).toBe(false);
+    releaseConsume?.();
+    await expect(verification).resolves.toMatchObject({
+      requestId: "request_1",
+    });
   });
 
-  it("accepts the explicit previous key only during token validity", () => {
+  it("normalizes async replay-store rejection without leaking its message", async () => {
+    const fixture = createFixture();
+    const unavailable: ReplayDefense = {
+      async consume() {
+        throw new Error("redis://user:secret@private-replay-host");
+      },
+    };
+
+    const error = await captureAssertionError(() =>
+      verifyToken(fixture, issueToken(fixture), {
+        replayDefense: unavailable,
+      })
+    );
+    expect(error).toMatchObject({
+      code: "replay_defense_unavailable",
+      message: "Replay defense could not enforce single use",
+    });
+    expect(error.message).not.toContain("secret");
+    expect(error.message).not.toContain("private-replay-host");
+  });
+
+  it("atomically accepts only one concurrent use of an assertion", async () => {
+    const fixture = createFixture();
+    const replayDefense = new BoundedReplayCache(4);
+    const token = issueToken(fixture);
+    const results = await Promise.allSettled([
+      verifyToken(fixture, token, { replayDefense }),
+      verifyToken(fixture, token, { replayDefense }),
+    ]);
+
+    const successes = results.filter((result) => result.status === "fulfilled");
+    const rejections = results.filter((result) => result.status === "rejected");
+    expect(successes).toHaveLength(1);
+    expect(rejections).toHaveLength(1);
+    expect(rejections[0]).toMatchObject({
+      reason: {
+        code: "replay_detected",
+        message: "Internal assertion was already consumed",
+      },
+    });
+  });
+
+  it("accepts the explicit previous key only during token validity", async () => {
     const fixture = createFixture();
     const token = issueToken(
       fixture,
       { lifetimeSeconds: 5 },
       fixture.previous.signing
     );
-    expect(verifyToken(fixture, token).kid).toBe("key-previous");
+    expect((await verifyToken(fixture, token)).kid).toBe("key-previous");
 
     const currentOnly: VerificationKeys = {
       current: fixture.verificationKeys.current,
     };
-    expectCode(
+    await expectCode(
       () => verifyToken(fixture, token, { verificationKeys: currentOnly }),
       "invalid_signature"
     );
 
     fixture.clock.set(BASE_TIME + 5);
-    expectCode(() => verifyToken(fixture, token), "assertion_expired");
+    await expectCode(() => verifyToken(fixture, token), "assertion_expired");
   });
 
-  it("rejects unknown key identifiers and ambiguous rotation configuration", () => {
+  it("rejects unknown key identifiers and ambiguous rotation configuration", async () => {
     const fixture = createFixture();
     const unknown = createKeyPair("key-unknown");
     const token = issueToken(fixture, {}, unknown.signing);
-    expectCode(() => verifyToken(fixture, token), "invalid_signature");
+    await expectCode(() => verifyToken(fixture, token), "invalid_signature");
 
-    expectCode(
+    await expectCode(
       () =>
         verifyToken(fixture, issueToken(fixture), {
           verificationKeys: {
@@ -503,14 +583,14 @@ describe("internal gateway assertions", () => {
     );
   });
 
-  it("keeps replay state isolated from unrelated unique assertions", () => {
+  it("keeps replay state isolated from unrelated unique assertions", async () => {
     const fixture = createFixture();
     const replayDefense = new BoundedReplayCache(3);
     const ownerAMismatch = {
       ...fixture.expected,
       subject: "user_owner_b",
     };
-    expectCode(
+    await expectCode(
       () =>
         verifyToken(fixture, issueToken(fixture), {
           expected: ownerAMismatch,
@@ -524,10 +604,12 @@ describe("internal gateway assertions", () => {
       nonce: "nonce_unrelated",
     });
     expect(
-      verifyToken(fixture, unrelated, {
-        expected: { ...fixture.expected, requestId: "request_unrelated" },
-        replayDefense,
-      }).subject
+      (
+        await verifyToken(fixture, unrelated, {
+          expected: { ...fixture.expected, requestId: "request_unrelated" },
+          replayDefense,
+        })
+      ).subject
     ).toBe("user_owner_a");
   });
 });

--- a/services/agent-gateway/internal-auth.test.ts
+++ b/services/agent-gateway/internal-auth.test.ts
@@ -1,0 +1,445 @@
+import { generateKeyPairSync, sign as signBytes } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BoundedReplayCache,
+  type Clock,
+  type ExpectedAssertionContext,
+  type GatewayOperation,
+  InternalAssertionError,
+  issueInternalAssertion,
+  type ReplayDefense,
+  type SigningKey,
+  type VerificationKeys,
+  verifyInternalAssertion,
+} from "./internal-auth.ts";
+
+const BASE_TIME = 1_800_000_000;
+
+/** Mutable deterministic clock for exact validity-boundary tests. */
+class TestClock implements Clock {
+  constructor(private current: number = BASE_TIME) {}
+
+  nowSeconds(): number {
+    return this.current;
+  }
+
+  set(nowSeconds: number): void {
+    this.current = nowSeconds;
+  }
+}
+
+/** Creates an isolated Ed25519 key pair with the requested identifier. */
+function createKeyPair(keyId: string) {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  return {
+    signing: { keyId, privateKey } satisfies SigningKey,
+    verification: { keyId, publicKey },
+  };
+}
+
+/** Builds one complete verifier fixture without ambient time or key state. */
+function createFixture() {
+  const clock = new TestClock();
+  const current = createKeyPair("key-current");
+  const previous = createKeyPair("key-previous");
+  const expected: ExpectedAssertionContext = {
+    issuer: "sprig-nextjs",
+    audience: "sprig-agent-gateway",
+    subject: "user_owner_a",
+    connectionId: "connection_a",
+    provider: "codex",
+    operation: "chat",
+  };
+  const verificationKeys: VerificationKeys = {
+    current: current.verification,
+    previous: previous.verification,
+  };
+
+  return { clock, current, expected, previous, verificationKeys };
+}
+
+/** Issues a token using stable unique identifiers unless overridden. */
+function issueToken(
+  fixture: ReturnType<typeof createFixture>,
+  overrides: Partial<{
+    audience: string;
+    connectionId: string;
+    issuer: string;
+    lifetimeSeconds: number;
+    nonce: string;
+    operation: GatewayOperation;
+    requestId: string;
+    subject: string;
+  }> = {},
+  signingKey = fixture.current.signing
+): string {
+  return issueInternalAssertion(
+    {
+      issuer: overrides.issuer ?? fixture.expected.issuer,
+      audience: overrides.audience ?? fixture.expected.audience,
+      subject: overrides.subject ?? fixture.expected.subject,
+      connectionId: overrides.connectionId ?? fixture.expected.connectionId,
+      operation: overrides.operation ?? fixture.expected.operation,
+      requestId: overrides.requestId ?? "request_1",
+      nonce: overrides.nonce ?? "nonce_1",
+      lifetimeSeconds: overrides.lifetimeSeconds,
+    },
+    signingKey,
+    fixture.clock
+  );
+}
+
+/** Verifies a token with a fresh cache unless a specific defense is provided. */
+function verifyToken(
+  fixture: ReturnType<typeof createFixture>,
+  token: string | null | undefined,
+  options: Partial<{
+    expected: ExpectedAssertionContext;
+    replayDefense: ReplayDefense;
+    verificationKeys: VerificationKeys;
+  }> = {}
+) {
+  return verifyInternalAssertion(token, {
+    clock: fixture.clock,
+    expected: options.expected ?? fixture.expected,
+    replayDefense: options.replayDefense ?? new BoundedReplayCache(16),
+    verificationKeys: options.verificationKeys ?? fixture.verificationKeys,
+  });
+}
+
+/** Re-signs controlled test claims to exercise post-signature validation. */
+function resignToken(
+  token: string,
+  signingKey: SigningKey,
+  mutate: (claims: Record<string, unknown>) => void
+): string {
+  const [encodedHeader, encodedClaims] = token.split(".");
+  const claims = JSON.parse(
+    Buffer.from(encodedClaims, "base64url").toString("utf8")
+  ) as Record<string, unknown>;
+  mutate(claims);
+
+  const nextClaims = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signingInput = `${encodedHeader}.${nextClaims}`;
+  const signature = signBytes(
+    null,
+    Buffer.from(signingInput),
+    signingKey.privateKey
+  ).toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+/** Captures and checks the stable error code from one rejected verification. */
+function expectCode(
+  action: () => unknown,
+  code: InternalAssertionError["code"]
+): void {
+  try {
+    action();
+    throw new Error(`Expected ${code}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(InternalAssertionError);
+    expect((error as InternalAssertionError).code).toBe(code);
+  }
+}
+
+describe("internal gateway assertions", () => {
+  it("issues and verifies the exact Codex-only v1 context", () => {
+    const fixture = createFixture();
+    const claims = verifyToken(fixture, issueToken(fixture));
+
+    expect(claims).toEqual({
+      version: 1,
+      issuer: "sprig-nextjs",
+      audience: "sprig-agent-gateway",
+      subject: "user_owner_a",
+      connectionId: "connection_a",
+      provider: "codex",
+      operation: "chat",
+      requestId: "request_1",
+      iat: BASE_TIME,
+      exp: BASE_TIME + 60,
+      nonce: "nonce_1",
+      kid: "key-current",
+    });
+  });
+
+  it("rejects missing, malformed, and signature-tampered assertions", () => {
+    const fixture = createFixture();
+    expectCode(() => verifyToken(fixture, undefined), "missing_assertion");
+    expectCode(() => verifyToken(fixture, "not-a-token"), "invalid_assertion");
+
+    const token = issueToken(fixture);
+    const [header, claims, signature] = token.split(".");
+    const tamperedSignature = `${signature.slice(0, -1)}${signature.endsWith("A") ? "B" : "A"}`;
+    expectCode(
+      () => verifyToken(fixture, `${header}.${claims}.${tamperedSignature}`),
+      "invalid_signature"
+    );
+
+    const tamperedClaims = Buffer.from(
+      JSON.stringify({
+        ...JSON.parse(Buffer.from(claims, "base64url").toString("utf8")),
+        subject: "user_owner_b",
+      })
+    ).toString("base64url");
+    expectCode(
+      () => verifyToken(fixture, `${header}.${tamperedClaims}.${signature}`),
+      "invalid_signature"
+    );
+  });
+
+  it("enforces a strict maximum lifetime and exact no-skew boundaries", () => {
+    const fixture = createFixture();
+    expectCode(
+      () => issueToken(fixture, { lifetimeSeconds: 61 }),
+      "assertion_lifetime_invalid"
+    );
+
+    const token = issueToken(fixture, { lifetimeSeconds: 10 });
+    fixture.clock.set(BASE_TIME - 1);
+    expectCode(() => verifyToken(fixture, token), "assertion_from_future");
+
+    fixture.clock.set(BASE_TIME + 9);
+    expect(verifyToken(fixture, token).exp).toBe(BASE_TIME + 10);
+
+    fixture.clock.set(BASE_TIME + 10);
+    expectCode(() => verifyToken(fixture, token), "assertion_expired");
+  });
+
+  it("rejects signed assertions whose encoded lifetime exceeds the limit", () => {
+    const fixture = createFixture();
+    const token = issueToken(fixture);
+    const oversized = resignToken(token, fixture.current.signing, (claims) => {
+      claims.exp = BASE_TIME + 61;
+    });
+
+    expectCode(
+      () => verifyToken(fixture, oversized),
+      "assertion_lifetime_invalid"
+    );
+  });
+
+  it("rejects a correctly signed assertion from another protocol version", () => {
+    const fixture = createFixture();
+    const token = resignToken(
+      issueToken(fixture),
+      fixture.current.signing,
+      (claims) => {
+        claims.version = 2;
+      }
+    );
+
+    expectCode(
+      () => verifyToken(fixture, token),
+      "unsupported_assertion_version"
+    );
+  });
+
+  it.each([
+    ["issuer", "issuer_mismatch", { issuer: "unexpected-issuer" }],
+    ["audience", "audience_mismatch", { audience: "unexpected-audience" }],
+    ["subject", "subject_mismatch", { subject: "user_owner_b" }],
+    ["connection", "connection_mismatch", { connectionId: "connection_b" }],
+    ["operation", "operation_mismatch", { operation: "node-editing" }],
+  ] as const)(
+    "rejects a wrong expected %s and consumes the signed assertion",
+    (_label, code, expectedOverride) => {
+      const fixture = createFixture();
+      const replayDefense = new BoundedReplayCache(4);
+      const token = issueToken(fixture);
+      const wrongExpected = {
+        ...fixture.expected,
+        ...expectedOverride,
+      } as ExpectedAssertionContext;
+
+      expectCode(
+        () =>
+          verifyToken(fixture, token, {
+            expected: wrongExpected,
+            replayDefense,
+          }),
+        code
+      );
+      expectCode(
+        () => verifyToken(fixture, token, { replayDefense }),
+        "replay_detected"
+      );
+    }
+  );
+
+  it("rejects a signed non-Codex provider and still consumes it", () => {
+    const fixture = createFixture();
+    const replayDefense = new BoundedReplayCache(4);
+    const token = resignToken(
+      issueToken(fixture),
+      fixture.current.signing,
+      (claims) => {
+        claims.provider = "claude";
+      }
+    );
+
+    expectCode(
+      () => verifyToken(fixture, token, { replayDefense }),
+      "provider_mismatch"
+    );
+    expectCode(
+      () => verifyToken(fixture, token, { replayDefense }),
+      "replay_detected"
+    );
+  });
+
+  it("detects request identifier and nonce reuse independently", () => {
+    const fixture = createFixture();
+    const replayDefense = new BoundedReplayCache(4);
+    verifyToken(fixture, issueToken(fixture), { replayDefense });
+
+    expectCode(
+      () =>
+        verifyToken(fixture, issueToken(fixture, { nonce: "nonce_2" }), {
+          replayDefense,
+        }),
+      "replay_detected"
+    );
+    expectCode(
+      () =>
+        verifyToken(fixture, issueToken(fixture, { requestId: "request_2" }), {
+          replayDefense,
+        }),
+      "replay_detected"
+    );
+  });
+
+  it("fails closed through the validity of a token rejected at capacity", () => {
+    const fixture = createFixture();
+    const replayDefense = new BoundedReplayCache(1);
+    verifyToken(fixture, issueToken(fixture, { lifetimeSeconds: 2 }), {
+      replayDefense,
+    });
+
+    expectCode(
+      () =>
+        verifyToken(
+          fixture,
+          issueToken(fixture, {
+            requestId: "request_2",
+            nonce: "nonce_2",
+          }),
+          { replayDefense }
+        ),
+      "replay_defense_unavailable"
+    );
+
+    fixture.clock.set(BASE_TIME + 2);
+    expectCode(
+      () =>
+        verifyToken(
+          fixture,
+          issueToken(fixture, {
+            requestId: "request_3",
+            nonce: "nonce_3",
+          }),
+          { replayDefense }
+        ),
+      "replay_defense_unavailable"
+    );
+
+    fixture.clock.set(BASE_TIME + 62);
+    expect(
+      verifyToken(
+        fixture,
+        issueToken(fixture, {
+          requestId: "request_4",
+          nonce: "nonce_4",
+        }),
+        { replayDefense }
+      ).requestId
+    ).toBe("request_4");
+  });
+
+  it("normalizes unavailable replay state into a fail-closed error", () => {
+    const fixture = createFixture();
+    const unavailable: ReplayDefense = {
+      consume() {
+        throw new Error("state backend disconnected");
+      },
+    };
+
+    expectCode(
+      () =>
+        verifyToken(fixture, issueToken(fixture), {
+          replayDefense: unavailable,
+        }),
+      "replay_defense_unavailable"
+    );
+  });
+
+  it("accepts the explicit previous key only during token validity", () => {
+    const fixture = createFixture();
+    const token = issueToken(
+      fixture,
+      { lifetimeSeconds: 5 },
+      fixture.previous.signing
+    );
+    expect(verifyToken(fixture, token).kid).toBe("key-previous");
+
+    const currentOnly: VerificationKeys = {
+      current: fixture.verificationKeys.current,
+    };
+    expectCode(
+      () => verifyToken(fixture, token, { verificationKeys: currentOnly }),
+      "invalid_signature"
+    );
+
+    fixture.clock.set(BASE_TIME + 5);
+    expectCode(() => verifyToken(fixture, token), "assertion_expired");
+  });
+
+  it("rejects unknown key identifiers and ambiguous rotation configuration", () => {
+    const fixture = createFixture();
+    const unknown = createKeyPair("key-unknown");
+    const token = issueToken(fixture, {}, unknown.signing);
+    expectCode(() => verifyToken(fixture, token), "invalid_signature");
+
+    expectCode(
+      () =>
+        verifyToken(fixture, issueToken(fixture), {
+          verificationKeys: {
+            current: fixture.current.verification,
+            previous: {
+              keyId: fixture.current.verification.keyId,
+              publicKey: fixture.previous.verification.publicKey,
+            },
+          },
+        }),
+      "internal_auth_configuration_invalid"
+    );
+  });
+
+  it("keeps replay state isolated from unrelated unique assertions", () => {
+    const fixture = createFixture();
+    const replayDefense = new BoundedReplayCache(3);
+    const ownerAMismatch = {
+      ...fixture.expected,
+      subject: "user_owner_b",
+    };
+    expectCode(
+      () =>
+        verifyToken(fixture, issueToken(fixture), {
+          expected: ownerAMismatch,
+          replayDefense,
+        }),
+      "subject_mismatch"
+    );
+
+    const unrelated = issueToken(fixture, {
+      requestId: "request_unrelated",
+      nonce: "nonce_unrelated",
+    });
+    expect(verifyToken(fixture, unrelated, { replayDefense }).subject).toBe(
+      "user_owner_a"
+    );
+  });
+});

--- a/services/agent-gateway/internal-auth.ts
+++ b/services/agent-gateway/internal-auth.ts
@@ -1,0 +1,644 @@
+import {
+  type KeyObject,
+  sign as signBytes,
+  verify as verifyBytes,
+} from "node:crypto";
+
+const ASSERTION_ALGORITHM = "EdDSA";
+const ASSERTION_TYPE = "sprig-internal-assertion";
+const ASSERTION_VERSION = 1;
+const MAX_ASSERTION_LIFETIME_SECONDS = 60;
+const MAX_ASSERTION_LENGTH = 8_192;
+const MAX_CLAIM_LENGTH = 256;
+
+const GATEWAY_OPERATIONS = [
+  "chat",
+  "mind-map-generation",
+  "node-editing",
+] as const;
+
+type GatewayOperation = (typeof GATEWAY_OPERATIONS)[number];
+
+type AssertionErrorCode =
+  | "assertion_expired"
+  | "assertion_from_future"
+  | "assertion_lifetime_invalid"
+  | "audience_mismatch"
+  | "connection_mismatch"
+  | "internal_auth_configuration_invalid"
+  | "invalid_assertion"
+  | "invalid_signature"
+  | "issuer_mismatch"
+  | "missing_assertion"
+  | "operation_mismatch"
+  | "provider_mismatch"
+  | "replay_defense_unavailable"
+  | "replay_detected"
+  | "subject_mismatch"
+  | "unsupported_assertion_version";
+
+type InternalAssertionClaims = Readonly<{
+  version: typeof ASSERTION_VERSION;
+  issuer: string;
+  audience: string;
+  subject: string;
+  connectionId: string;
+  provider: "codex";
+  operation: GatewayOperation;
+  requestId: string;
+  iat: number;
+  exp: number;
+  nonce: string;
+  kid: string;
+}>;
+
+type AssertionHeader = Readonly<{
+  algorithm: typeof ASSERTION_ALGORITHM;
+  type: typeof ASSERTION_TYPE;
+  version: typeof ASSERTION_VERSION;
+  kid: string;
+}>;
+
+type Clock = Readonly<{
+  nowSeconds: () => number;
+}>;
+
+type SigningKey = Readonly<{
+  keyId: string;
+  privateKey: KeyObject;
+}>;
+
+type VerificationKey = Readonly<{
+  keyId: string;
+  publicKey: KeyObject;
+}>;
+
+type VerificationKeys = Readonly<{
+  current: VerificationKey;
+  previous?: VerificationKey;
+}>;
+
+type IssueAssertionInput = Readonly<{
+  issuer: string;
+  audience: string;
+  subject: string;
+  connectionId: string;
+  operation: GatewayOperation;
+  requestId: string;
+  nonce: string;
+  lifetimeSeconds?: number;
+}>;
+
+type ExpectedAssertionContext = Readonly<{
+  issuer: string;
+  audience: string;
+  subject: string;
+  connectionId: string;
+  provider: "codex";
+  operation: GatewayOperation;
+}>;
+
+type VerifyAssertionOptions = Readonly<{
+  clock: Clock;
+  expected: ExpectedAssertionContext;
+  replayDefense: ReplayDefense;
+  verificationKeys: VerificationKeys;
+}>;
+
+type ReplayEntry = Readonly<{
+  requestId: string;
+  nonce: string;
+  expiresAt: number;
+}>;
+
+interface ReplayDefense {
+  consume(entry: ReplayEntry, nowSeconds: number): void;
+}
+
+/** Stable internal-auth failure that callers may map to secret-free responses. */
+class InternalAssertionError extends Error {
+  readonly code: AssertionErrorCode;
+
+  constructor(code: AssertionErrorCode, message: string) {
+    super(message);
+    this.name = "InternalAssertionError";
+    this.code = code;
+  }
+}
+
+/**
+ * In-memory replay defense for one gateway process.
+ *
+ * Live entries are never evicted to make room: capacity exhaustion fails closed.
+ * A durable/distributed implementation can replace this through ReplayDefense once
+ * the persistent host and state topology are approved.
+ */
+class BoundedReplayCache implements ReplayDefense {
+  private readonly entries: ReplayEntry[] = [];
+  private unavailableUntil = 0;
+
+  constructor(private readonly capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new InternalAssertionError(
+        "internal_auth_configuration_invalid",
+        "Replay capacity must be a positive safe integer"
+      );
+    }
+  }
+
+  /** Atomically rejects a duplicate or retains both identifiers until expiry. */
+  consume(entry: ReplayEntry, nowSeconds: number): void {
+    if (!Number.isSafeInteger(nowSeconds)) {
+      throw new InternalAssertionError(
+        "replay_defense_unavailable",
+        "Replay defense received an invalid clock value"
+      );
+    }
+
+    // Expiry is exclusive, matching assertion verification at expiresAt.
+    for (let index = this.entries.length - 1; index >= 0; index -= 1) {
+      if (this.entries[index].expiresAt <= nowSeconds) {
+        this.entries.splice(index, 1);
+      }
+    }
+
+    if (this.unavailableUntil > nowSeconds) {
+      // A token rejected while full could otherwise become usable if an older
+      // entry expired first. Keep the cache closed through every such token's
+      // validity without retaining an unbounded list of identifiers.
+      this.unavailableUntil = Math.max(this.unavailableUntil, entry.expiresAt);
+      throw new InternalAssertionError(
+        "replay_defense_unavailable",
+        "Replay defense is recovering from capacity exhaustion"
+      );
+    }
+
+    if (
+      this.entries.some(
+        (existing) =>
+          existing.requestId === entry.requestId ||
+          existing.nonce === entry.nonce
+      )
+    ) {
+      throw new InternalAssertionError(
+        "replay_detected",
+        "The assertion request identifier or nonce was already consumed"
+      );
+    }
+
+    if (this.entries.length >= this.capacity) {
+      this.unavailableUntil = entry.expiresAt;
+      throw new InternalAssertionError(
+        "replay_defense_unavailable",
+        "Replay defense capacity is exhausted"
+      );
+    }
+
+    this.entries.push(entry);
+  }
+}
+
+/** Issues one short-lived, Codex-only internal gateway assertion. */
+function issueInternalAssertion(
+  input: IssueAssertionInput,
+  signingKey: SigningKey,
+  clock: Clock
+): string {
+  assertKeyObject(signingKey.privateKey, "private", "signing key");
+  const issuedAt = readClock(clock);
+  const lifetimeSeconds =
+    input.lifetimeSeconds ?? MAX_ASSERTION_LIFETIME_SECONDS;
+
+  if (
+    !Number.isSafeInteger(lifetimeSeconds) ||
+    lifetimeSeconds <= 0 ||
+    lifetimeSeconds > MAX_ASSERTION_LIFETIME_SECONDS
+  ) {
+    throw new InternalAssertionError(
+      "assertion_lifetime_invalid",
+      "Assertion lifetime must be between 1 and 60 seconds"
+    );
+  }
+
+  const header: AssertionHeader = {
+    algorithm: ASSERTION_ALGORITHM,
+    type: ASSERTION_TYPE,
+    version: ASSERTION_VERSION,
+    kid: assertClaimString(signingKey.keyId, "kid"),
+  };
+  const claims: InternalAssertionClaims = {
+    version: ASSERTION_VERSION,
+    issuer: assertClaimString(input.issuer, "issuer"),
+    audience: assertClaimString(input.audience, "audience"),
+    subject: assertClaimString(input.subject, "subject"),
+    connectionId: assertClaimString(input.connectionId, "connectionId"),
+    provider: "codex",
+    operation: input.operation,
+    requestId: assertClaimString(input.requestId, "requestId"),
+    iat: issuedAt,
+    exp: issuedAt + lifetimeSeconds,
+    nonce: assertClaimString(input.nonce, "nonce"),
+    kid: header.kid,
+  };
+
+  if (!GATEWAY_OPERATIONS.includes(input.operation)) {
+    throw new InternalAssertionError(
+      "invalid_assertion",
+      "Assertion operation is not supported"
+    );
+  }
+
+  const signingInput = `${encodeJson(header)}.${encodeJson(claims)}`;
+  const signature = signBytes(
+    null,
+    Buffer.from(signingInput),
+    signingKey.privateKey
+  );
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+/**
+ * Verifies signature, time, and replay before matching request context.
+ *
+ * Consuming replay identifiers before context checks is intentional: a signed
+ * token presented against the wrong owner or operation must not remain usable.
+ */
+function verifyInternalAssertion(
+  token: string | null | undefined,
+  options: VerifyAssertionOptions
+): InternalAssertionClaims {
+  if (!token) {
+    throw new InternalAssertionError(
+      "missing_assertion",
+      "An internal assertion is required"
+    );
+  }
+  if (token.length > MAX_ASSERTION_LENGTH) {
+    throw invalidAssertion();
+  }
+
+  const segments = token.split(".");
+  if (
+    segments.length !== 3 ||
+    segments.some((segment) => segment.length === 0)
+  ) {
+    throw invalidAssertion();
+  }
+
+  const [encodedHeader, encodedClaims, encodedSignature] = segments;
+  // Only the key identifier is read before authentication; all header semantics
+  // are enforced after the signature succeeds.
+  const routingKeyId = parseRoutingKeyId(encodedHeader);
+  const key = selectVerificationKey(routingKeyId, options.verificationKeys);
+  const signature = decodeBase64Url(encodedSignature);
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+
+  if (!verifyBytes(null, Buffer.from(signingInput), key.publicKey, signature)) {
+    throw new InternalAssertionError(
+      "invalid_signature",
+      "Internal assertion signature is invalid"
+    );
+  }
+
+  const header = parseHeader(encodedHeader);
+  const claims = parseClaims(encodedClaims);
+  if (claims.kid !== header.kid) {
+    throw new InternalAssertionError(
+      "invalid_signature",
+      "Internal assertion key identifiers do not match"
+    );
+  }
+
+  const nowSeconds = readClock(options.clock);
+  assertTemporalValidity(claims, nowSeconds);
+
+  // State errors are normalized so unavailable custom stores cannot accidentally
+  // degrade into accepting a request without replay protection.
+  try {
+    options.replayDefense.consume(
+      {
+        requestId: claims.requestId,
+        nonce: claims.nonce,
+        expiresAt: claims.exp,
+      },
+      nowSeconds
+    );
+  } catch (error) {
+    if (
+      error instanceof InternalAssertionError &&
+      (error.code === "replay_detected" ||
+        error.code === "replay_defense_unavailable")
+    ) {
+      throw error;
+    }
+    throw new InternalAssertionError(
+      "replay_defense_unavailable",
+      "Replay defense could not enforce single use"
+    );
+  }
+
+  assertExpectedContext(claims, options.expected);
+  return claims;
+}
+
+/** Extracts only the bounded key identifier needed to route verification. */
+function parseRoutingKeyId(segment: string): string {
+  const value = parseJsonObject(segment);
+  return assertClaimString(value.kid, "kid");
+}
+
+/** Validates exact expected context without revealing any alternate owner state. */
+function assertExpectedContext(
+  claims: InternalAssertionClaims,
+  expected: ExpectedAssertionContext
+): void {
+  const comparisons: ReadonlyArray<
+    readonly [boolean, AssertionErrorCode, string]
+  > = [
+    [claims.issuer === expected.issuer, "issuer_mismatch", "issuer"],
+    [claims.audience === expected.audience, "audience_mismatch", "audience"],
+    [claims.subject === expected.subject, "subject_mismatch", "subject"],
+    [
+      claims.connectionId === expected.connectionId,
+      "connection_mismatch",
+      "connection",
+    ],
+    [claims.provider === expected.provider, "provider_mismatch", "provider"],
+    [
+      claims.operation === expected.operation,
+      "operation_mismatch",
+      "operation",
+    ],
+  ];
+
+  for (const [matches, code, field] of comparisons) {
+    if (!matches) {
+      throw new InternalAssertionError(
+        code,
+        `Internal assertion ${field} does not match the request context`
+      );
+    }
+  }
+}
+
+/** Enforces the strict, no-skew 60-second validity contract. */
+function assertTemporalValidity(
+  claims: InternalAssertionClaims,
+  nowSeconds: number
+): void {
+  const lifetime = claims.exp - claims.iat;
+  if (lifetime <= 0 || lifetime > MAX_ASSERTION_LIFETIME_SECONDS) {
+    throw new InternalAssertionError(
+      "assertion_lifetime_invalid",
+      "Internal assertion lifetime is invalid"
+    );
+  }
+  if (claims.iat > nowSeconds) {
+    throw new InternalAssertionError(
+      "assertion_from_future",
+      "Internal assertion was issued in the future"
+    );
+  }
+  if (claims.exp <= nowSeconds) {
+    throw new InternalAssertionError(
+      "assertion_expired",
+      "Internal assertion has expired"
+    );
+  }
+}
+
+/** Chooses only the explicit current or previous key without widening time. */
+function selectVerificationKey(
+  keyId: string,
+  keys: VerificationKeys
+): VerificationKey {
+  assertKeyObject(keys.current.publicKey, "public", "current verification key");
+  if (keys.previous) {
+    assertKeyObject(
+      keys.previous.publicKey,
+      "public",
+      "previous verification key"
+    );
+    if (keys.previous.keyId === keys.current.keyId) {
+      throw new InternalAssertionError(
+        "internal_auth_configuration_invalid",
+        "Current and previous verification key identifiers must differ"
+      );
+    }
+  }
+
+  const selected =
+    keys.current.keyId === keyId
+      ? keys.current
+      : keys.previous?.keyId === keyId
+        ? keys.previous
+        : undefined;
+  if (!selected) {
+    // Treat an unrecognized key as a signature failure to avoid a key oracle.
+    throw new InternalAssertionError(
+      "invalid_signature",
+      "Internal assertion signature is invalid"
+    );
+  }
+  return selected;
+}
+
+/** Parses and strictly validates the signed assertion header. */
+function parseHeader(segment: string): AssertionHeader {
+  const value = parseJsonObject(segment);
+  assertExactKeys(value, ["algorithm", "kid", "type", "version"]);
+
+  if (value.version !== ASSERTION_VERSION) {
+    throw new InternalAssertionError(
+      "unsupported_assertion_version",
+      "Internal assertion version is unsupported"
+    );
+  }
+  if (
+    value.algorithm !== ASSERTION_ALGORITHM ||
+    value.type !== ASSERTION_TYPE
+  ) {
+    throw invalidAssertion();
+  }
+
+  return {
+    algorithm: ASSERTION_ALGORITHM,
+    type: ASSERTION_TYPE,
+    version: ASSERTION_VERSION,
+    kid: assertClaimString(value.kid, "kid"),
+  };
+}
+
+/** Parses the exact v1 claim set after signature verification. */
+function parseClaims(segment: string): InternalAssertionClaims {
+  const value = parseJsonObject(segment);
+  assertExactKeys(value, [
+    "audience",
+    "connectionId",
+    "exp",
+    "iat",
+    "issuer",
+    "kid",
+    "nonce",
+    "operation",
+    "provider",
+    "requestId",
+    "subject",
+    "version",
+  ]);
+
+  if (value.version !== ASSERTION_VERSION) {
+    throw new InternalAssertionError(
+      "unsupported_assertion_version",
+      "Internal assertion version is unsupported"
+    );
+  }
+  if (!Number.isSafeInteger(value.iat) || !Number.isSafeInteger(value.exp)) {
+    throw invalidAssertion();
+  }
+
+  return {
+    version: ASSERTION_VERSION,
+    issuer: assertClaimString(value.issuer, "issuer"),
+    audience: assertClaimString(value.audience, "audience"),
+    subject: assertClaimString(value.subject, "subject"),
+    connectionId: assertClaimString(value.connectionId, "connectionId"),
+    // Provider and operation remain strings until expected-context matching so
+    // a correctly signed mismatch consumes its replay identifiers first.
+    provider: assertClaimString(value.provider, "provider") as "codex",
+    operation: assertClaimString(
+      value.operation,
+      "operation"
+    ) as GatewayOperation,
+    requestId: assertClaimString(value.requestId, "requestId"),
+    iat: value.iat as number,
+    exp: value.exp as number,
+    nonce: assertClaimString(value.nonce, "nonce"),
+    kid: assertClaimString(value.kid, "kid"),
+  };
+}
+
+/** Reads a second-resolution injected clock and refuses ambiguous values. */
+function readClock(clock: Clock): number {
+  const nowSeconds = clock.nowSeconds();
+  if (!Number.isSafeInteger(nowSeconds) || nowSeconds < 0) {
+    throw new InternalAssertionError(
+      "internal_auth_configuration_invalid",
+      "Clock must return a non-negative integer epoch second"
+    );
+  }
+  return nowSeconds;
+}
+
+/** Restricts keys to Ed25519 and to their required signing/verification role. */
+function assertKeyObject(
+  key: KeyObject,
+  expectedType: "private" | "public",
+  label: string
+): void {
+  if (key.type !== expectedType || key.asymmetricKeyType !== "ed25519") {
+    throw new InternalAssertionError(
+      "internal_auth_configuration_invalid",
+      `${label} must be an Ed25519 ${expectedType} key`
+    );
+  }
+}
+
+/** Validates bounded, non-empty string claims. */
+function assertClaimString(value: unknown, field: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_CLAIM_LENGTH
+  ) {
+    throw new InternalAssertionError(
+      "invalid_assertion",
+      `Internal assertion ${field} is invalid`
+    );
+  }
+  return value;
+}
+
+/** Encodes deterministic JSON as an unpadded base64url segment. */
+function encodeJson(value: object): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+/** Decodes only canonical, unpadded base64url text. */
+function decodeBase64Url(segment: string): Buffer {
+  if (!/^[A-Za-z0-9_-]+$/.test(segment)) {
+    throw invalidAssertion();
+  }
+  const decoded = Buffer.from(segment, "base64url");
+  if (decoded.toString("base64url") !== segment) {
+    throw invalidAssertion();
+  }
+  return decoded;
+}
+
+/** Decodes a base64url JSON object without accepting arrays or null. */
+function parseJsonObject(segment: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(
+      decodeBase64Url(segment).toString("utf8")
+    );
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw invalidAssertion();
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof InternalAssertionError) {
+      throw error;
+    }
+    throw invalidAssertion();
+  }
+}
+
+/** Rejects omitted and extension fields so v1 has one unambiguous contract. */
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[]
+): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...expectedKeys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    throw invalidAssertion();
+  }
+}
+
+/** Creates a fresh generic invalid-assertion error. */
+function invalidAssertion(): InternalAssertionError {
+  return new InternalAssertionError(
+    "invalid_assertion",
+    "Internal assertion is invalid"
+  );
+}
+
+export {
+  ASSERTION_VERSION,
+  type AssertionErrorCode,
+  BoundedReplayCache,
+  type Clock,
+  type ExpectedAssertionContext,
+  GATEWAY_OPERATIONS,
+  type GatewayOperation,
+  type InternalAssertionClaims,
+  InternalAssertionError,
+  type IssueAssertionInput,
+  issueInternalAssertion,
+  MAX_ASSERTION_LIFETIME_SECONDS,
+  type ReplayDefense,
+  type ReplayEntry,
+  type SigningKey,
+  type VerificationKey,
+  type VerificationKeys,
+  type VerifyAssertionOptions,
+  verifyInternalAssertion,
+};

--- a/services/agent-gateway/internal-auth.ts
+++ b/services/agent-gateway/internal-auth.ts
@@ -30,10 +30,12 @@ type AssertionErrorCode =
   | "invalid_signature"
   | "issuer_mismatch"
   | "missing_assertion"
+  | "noncanonical_assertion"
   | "operation_mismatch"
   | "provider_mismatch"
   | "replay_defense_unavailable"
   | "replay_detected"
+  | "request_id_mismatch"
   | "subject_mismatch"
   | "unsupported_assertion_version";
 
@@ -96,6 +98,7 @@ type ExpectedAssertionContext = Readonly<{
   connectionId: string;
   provider: "codex";
   operation: GatewayOperation;
+  requestId: string;
 }>;
 
 type VerifyAssertionOptions = Readonly<{
@@ -286,23 +289,19 @@ function verifyInternalAssertion(
   }
 
   const [encodedHeader, encodedClaims, encodedSignature] = segments;
-  // Only the key identifier is read before authentication; all header semantics
-  // are enforced after the signature succeeds.
-  const routingKeyId = parseRoutingKeyId(encodedHeader);
-  const key = selectVerificationKey(routingKeyId, options.verificationKeys);
   const signature = decodeBase64Url(encodedSignature);
   const signingInput = `${encodedHeader}.${encodedClaims}`;
-
-  if (!verifyBytes(null, Buffer.from(signingInput), key.publicKey, signature)) {
-    throw new InternalAssertionError(
-      "invalid_signature",
-      "Internal assertion signature is invalid"
-    );
-  }
+  const authenticatedKeyIds = authenticateSignature(
+    signingInput,
+    signature,
+    options.verificationKeys
+  );
 
   const header = parseHeader(encodedHeader);
   const claims = parseClaims(encodedClaims);
-  if (claims.kid !== header.kid) {
+  assertCanonicalSegment(encodedHeader, header);
+  assertCanonicalSegment(encodedClaims, claims);
+  if (claims.kid !== header.kid || !authenticatedKeyIds.includes(header.kid)) {
     throw new InternalAssertionError(
       "invalid_signature",
       "Internal assertion key identifiers do not match"
@@ -341,12 +340,6 @@ function verifyInternalAssertion(
   return claims;
 }
 
-/** Extracts only the bounded key identifier needed to route verification. */
-function parseRoutingKeyId(segment: string): string {
-  const value = parseJsonObject(segment);
-  return assertClaimString(value.kid, "kid");
-}
-
 /** Validates exact expected context without revealing any alternate owner state. */
 function assertExpectedContext(
   claims: InternalAssertionClaims,
@@ -368,6 +361,11 @@ function assertExpectedContext(
       claims.operation === expected.operation,
       "operation_mismatch",
       "operation",
+    ],
+    [
+      claims.requestId === expected.requestId,
+      "request_id_mismatch",
+      "request identifier",
     ],
   ];
 
@@ -407,11 +405,12 @@ function assertTemporalValidity(
   }
 }
 
-/** Chooses only the explicit current or previous key without widening time. */
-function selectVerificationKey(
-  keyId: string,
+/** Authenticates against only the explicit current/previous verification keys. */
+function authenticateSignature(
+  signingInput: string,
+  signature: Buffer,
   keys: VerificationKeys
-): VerificationKey {
+): readonly string[] {
   assertKeyObject(keys.current.publicKey, "public", "current verification key");
   if (keys.previous) {
     assertKeyObject(
@@ -427,20 +426,21 @@ function selectVerificationKey(
     }
   }
 
-  const selected =
-    keys.current.keyId === keyId
-      ? keys.current
-      : keys.previous?.keyId === keyId
-        ? keys.previous
-        : undefined;
-  if (!selected) {
-    // Treat an unrecognized key as a signature failure to avoid a key oracle.
+  const candidates = keys.previous
+    ? [keys.current, keys.previous]
+    : [keys.current];
+  const authenticatedKeyIds = candidates
+    .filter((key) =>
+      verifyBytes(null, Buffer.from(signingInput), key.publicKey, signature)
+    )
+    .map((key) => key.keyId);
+  if (authenticatedKeyIds.length === 0) {
     throw new InternalAssertionError(
       "invalid_signature",
       "Internal assertion signature is invalid"
     );
   }
-  return selected;
+  return authenticatedKeyIds;
 }
 
 /** Parses and strictly validates the signed assertion header. */
@@ -564,6 +564,16 @@ function encodeJson(value: object): string {
   return Buffer.from(JSON.stringify(value)).toString("base64url");
 }
 
+/** Rejects any authenticated JSON representation except the fixed v1 order. */
+function assertCanonicalSegment(segment: string, value: object): void {
+  if (segment !== encodeJson(value)) {
+    throw new InternalAssertionError(
+      "noncanonical_assertion",
+      "Internal assertion encoding is not canonical"
+    );
+  }
+}
+
 /** Decodes only canonical, unpadded base64url text. */
 function decodeBase64Url(segment: string): Buffer {
   if (!/^[A-Za-z0-9_-]+$/.test(segment)) {
@@ -579,8 +589,14 @@ function decodeBase64Url(segment: string): Buffer {
 /** Decodes a base64url JSON object without accepting arrays or null. */
 function parseJsonObject(segment: string): Record<string, unknown> {
   try {
+    if (!/^[A-Za-z0-9_-]+={0,2}$/.test(segment)) {
+      throw invalidAssertion();
+    }
+    // JSON segments are decoded after signature authentication. Padding and
+    // other equivalent encodings are parsed here, then rejected by the exact
+    // canonical-segment comparison.
     const parsed: unknown = JSON.parse(
-      decodeBase64Url(segment).toString("utf8")
+      Buffer.from(segment, "base64url").toString("utf8")
     );
     if (
       typeof parsed !== "object" ||

--- a/services/agent-gateway/internal-auth.ts
+++ b/services/agent-gateway/internal-auth.ts
@@ -115,8 +115,10 @@ type ReplayEntry = Readonly<{
 }>;
 
 interface ReplayDefense {
-  consume(entry: ReplayEntry, nowSeconds: number): void;
+  consume(entry: ReplayEntry, nowSeconds: number): void | Promise<void>;
 }
+
+type ReplayDefenseErrorCode = "replay_defense_unavailable" | "replay_detected";
 
 /** Stable internal-auth failure that callers may map to secret-free responses. */
 class InternalAssertionError extends Error {
@@ -125,6 +127,17 @@ class InternalAssertionError extends Error {
   constructor(code: AssertionErrorCode, message: string) {
     super(message);
     this.name = "InternalAssertionError";
+    this.code = code;
+  }
+}
+
+/** Typed store rejection whose backend message never crosses verification. */
+class ReplayDefenseError extends Error {
+  readonly code: ReplayDefenseErrorCode;
+
+  constructor(code: ReplayDefenseErrorCode) {
+    super("Replay defense rejected the assertion");
+    this.name = "ReplayDefenseError";
     this.code = code;
   }
 }
@@ -152,10 +165,7 @@ class BoundedReplayCache implements ReplayDefense {
   /** Atomically rejects a duplicate or retains both identifiers until expiry. */
   consume(entry: ReplayEntry, nowSeconds: number): void {
     if (!Number.isSafeInteger(nowSeconds)) {
-      throw new InternalAssertionError(
-        "replay_defense_unavailable",
-        "Replay defense received an invalid clock value"
-      );
+      throw new ReplayDefenseError("replay_defense_unavailable");
     }
 
     // Expiry is exclusive, matching assertion verification at expiresAt.
@@ -170,10 +180,7 @@ class BoundedReplayCache implements ReplayDefense {
       // entry expired first. Keep the cache closed through every such token's
       // validity without retaining an unbounded list of identifiers.
       this.unavailableUntil = Math.max(this.unavailableUntil, entry.expiresAt);
-      throw new InternalAssertionError(
-        "replay_defense_unavailable",
-        "Replay defense is recovering from capacity exhaustion"
-      );
+      throw new ReplayDefenseError("replay_defense_unavailable");
     }
 
     if (
@@ -183,18 +190,12 @@ class BoundedReplayCache implements ReplayDefense {
           existing.nonce === entry.nonce
       )
     ) {
-      throw new InternalAssertionError(
-        "replay_detected",
-        "The assertion request identifier or nonce was already consumed"
-      );
+      throw new ReplayDefenseError("replay_detected");
     }
 
     if (this.entries.length >= this.capacity) {
       this.unavailableUntil = entry.expiresAt;
-      throw new InternalAssertionError(
-        "replay_defense_unavailable",
-        "Replay defense capacity is exhausted"
-      );
+      throw new ReplayDefenseError("replay_defense_unavailable");
     }
 
     this.entries.push(entry);
@@ -266,10 +267,10 @@ function issueInternalAssertion(
  * Consuming replay identifiers before context checks is intentional: a signed
  * token presented against the wrong owner or operation must not remain usable.
  */
-function verifyInternalAssertion(
+async function verifyInternalAssertion(
   token: string | null | undefined,
   options: VerifyAssertionOptions
-): InternalAssertionClaims {
+): Promise<InternalAssertionClaims> {
   if (!token) {
     throw new InternalAssertionError(
       "missing_assertion",
@@ -314,7 +315,7 @@ function verifyInternalAssertion(
   // State errors are normalized so unavailable custom stores cannot accidentally
   // degrade into accepting a request without replay protection.
   try {
-    options.replayDefense.consume(
+    await options.replayDefense.consume(
       {
         requestId: claims.requestId,
         nonce: claims.nonce,
@@ -323,21 +324,26 @@ function verifyInternalAssertion(
       nowSeconds
     );
   } catch (error) {
-    if (
-      error instanceof InternalAssertionError &&
-      (error.code === "replay_detected" ||
-        error.code === "replay_defense_unavailable")
-    ) {
-      throw error;
-    }
-    throw new InternalAssertionError(
-      "replay_defense_unavailable",
-      "Replay defense could not enforce single use"
-    );
+    const code =
+      error instanceof ReplayDefenseError
+        ? error.code
+        : "replay_defense_unavailable";
+    throw replayEnforcementError(code);
   }
 
   assertExpectedContext(claims, options.expected);
   return claims;
+}
+
+/** Maps store failures to fixed, secret-free verifier errors. */
+function replayEnforcementError(
+  code: ReplayDefenseErrorCode
+): InternalAssertionError {
+  const message =
+    code === "replay_detected"
+      ? "Internal assertion was already consumed"
+      : "Replay defense could not enforce single use";
+  return new InternalAssertionError(code, message);
 }
 
 /** Validates exact expected context without revealing any alternate owner state. */
@@ -651,6 +657,8 @@ export {
   issueInternalAssertion,
   MAX_ASSERTION_LIFETIME_SECONDS,
   type ReplayDefense,
+  ReplayDefenseError,
+  type ReplayDefenseErrorCode,
   type ReplayEntry,
   type SigningKey,
   type VerificationKey,


### PR DESCRIPTION
## Feature

Adds the first Codex-first gateway implementation slice: deployment-neutral internal request authentication primitives under the service boundary defined by ADR 0002.

The slice provides:

- versioned Ed25519 assertions containing issuer, audience, Clerk subject, connection ID, provider (`codex`), allowed operation, request ID, `iat`, `exp`, nonce, and `kid`;
- a strict maximum assertion lifetime of 60 seconds with no implicit clock-skew extension;
- explicit current/previous verification-key overlap without extending token expiry;
- exact issuer, audience, owner, connection, provider, and operation matching; and
- bounded fail-closed replay defense that consumes signed request IDs and nonces before expected-context checks.

## Architecture

The module uses injected Ed25519 keys, clocks, expected request context, and replay defense. It adds no listener or production state and remains independent of hosting and credential storage choices.

```text
Next.js issuer
    |
    | signed v1 assertion (<= 60s)
    v
signature + key-overlap verification
    |
    v
strict time validation
    |
    v
atomic replay consume (requestId + nonce)
    |
    v
issuer/audience/owner/connection/provider/operation match
    |
    v
future gateway request handling
```

The included in-memory bounded cache is intentionally a deterministic test/local primitive. A real gateway must inject atomic replay state whose lifecycle survives process restarts; a multi-process topology requires shared state.

## Security behavior

- Missing, malformed, tampered, expired, future, wrong-audience, wrong-provider, wrong-operation, wrong-owner, and wrong-connection assertions fail closed.
- A correctly signed assertion rejected by later context validation remains consumed for its validity window.
- Capacity exhaustion does not evict live entries. The cache stays unavailable through the validity of a token it could not retain, preventing that token from becoming usable after older entries expire.
- Unknown key IDs are reported as signature failures, and current/previous key IDs must be distinct.

## Human gates intentionally left unresolved

- persistent Node 24 host/provider and deployment topology;
- production signing-key generation, custody, rotation, and recovery;
- durable/shared replay-state backend and restart behavior;
- encrypted credential storage and backup policy; and
- all provider credentials, login ceremonies, database writes, environment changes, and deployment.

## Validation

- `pnpm exec vitest run services/agent-gateway/internal-auth.test.ts` - 17 passed
- `pnpm test` - 55 files, 526 tests passed
- `pnpm typecheck` - passed
- `pnpm lint` - passed with 5 pre-existing warnings outside this slice
- `pnpm format:check` - passed
- `git diff --check` - passed
