### PR TITLE
feat(gateway): add bounded request dispatcher

### DIFF
--- a/docs/GATEWAY_DISPATCH.md
+++ b/docs/GATEWAY_DISPATCH.md
@@ -1,0 +1,78 @@
+# Gateway request dispatch boundary
+
+This slice defines deployment-neutral request-dispatch primitives for the
+Codex-first subscription gateway. It does not open a socket, start a provider
+process, read credentials, choose a host, or write deployment or database
+state.
+
+## Architecture
+
+The embedding HTTP adapter is responsible only for turning its request into the
+bounded byte-stream envelope. It must construct the route and expected context
+from server-owned routing and authorization state; neither value comes from the
+JSON body.
+
+```text
+trusted Next.js assertion       server-owned request context
+             |                              |
+             +---------------+--------------+
+                             v
+HTTP adapter (future) -> exact route/method -> assertion + replay verification
+                                                   |
+                         signed mismatch ----------+----> charge known owner
+                                                   |
+                                                   v
+                              atomic endpoint owner/global rate budget
+                                                   |
+                                                   v
+                              content type -> bounded bytes -> strict JSON
+                                                   |
+                                                   v
+                                  immutable Codex operation registry
+                                                   |
+                                                   v
+                                  abort/timeout-aware async handoff
+```
+
+Authentication occurs before body parsing. Missing, malformed, or
+signature-invalid assertions are not attributed to an owner. Once the internal
+signature has authenticated and a server-resolved owner is known, the endpoint
+budget is consumed even if replay, request context, media type, size, JSON, or
+operation input later rejects the attempt. Authentication failures remain
+`unauthorized` even if charging also fails, so budget state cannot become an
+authentication oracle.
+
+The rate-budget interface receives both the per-owner and global limits in one
+server-owned policy object. A live implementation must consume both dimensions
+atomically. Exhaustion maps to `rate_limited`; unavailable or unknown store
+failures map to `rate_limit_unavailable`. No store message is returned.
+
+Only an exact `{ "input": ... }` body reaches the selected operation parser.
+Provider, operation, model, command, environment, path, and tool policy cannot
+be overridden at the envelope level. Each operation parser remains responsible
+for a strict operation-specific input schema. The handler receives the verified
+claims and a derived abort signal, never raw headers or route policy.
+
+## Stable outcomes
+
+The dispatcher returns fixed JSON error codes and status values. Exception
+messages, assertion details, rate-store errors, abort reasons, and operation
+errors are never reflected. A future HTTP adapter may add correlation headers,
+but it must not add raw provider, credential, body, or exception data.
+
+## Human gates and deferred work
+
+The following remain deliberately outside this slice:
+
+- persistent gateway host and HTTP framework;
+- TLS, network ingress, and service identity deployment;
+- internal signing-key custody and rotation deployment;
+- durable replay and atomic rate-budget stores;
+- concrete rate limits and window tuning;
+- Codex credential homes, login ceremony, process supervision, and tool policy;
+- provider model selection and operation-specific production schemas;
+- any environment, secret, Convex, migration, or production database change;
+- Claude connection support, which remains deferred until separately approved.
+
+Those decisions require the corresponding human and security gates before a
+listener or provider runtime can be enabled.

--- a/docs/GATEWAY_DISPATCH.md
+++ b/docs/GATEWAY_DISPATCH.md
@@ -47,7 +47,23 @@ remains `unauthorized`, so budget state does not become an authentication oracle
 The rate-budget interface receives both the per-owner and global limits in one
 server-owned policy object. A live implementation must consume both dimensions
 atomically. Exhaustion maps to `rate_limited`; unavailable or unknown store
-failures map to `rate_limit_unavailable`. No store message is returned.
+failures and deadline expiry map to `rate_limit_unavailable`. Replay-store
+failure or deadline expiry maps to `replay_defense_unavailable`. Each store call
+has a finite server-owned deadline and receives a reason-free cancellation
+signal plus the absolute deadline for cooperative cancellation. Caller abort
+maps to `request_aborted`. No store message, abort reason, or deadline detail is
+returned.
+
+A deadline is an ambiguous control-plane outcome: the store may have committed
+before its response was lost. The dispatcher therefore fails closed, continues
+bounded replay verification after a rate-budget timeout, and never proceeds to
+body ingestion or execution. A retry with the same valid assertion is rejected
+by replay defense. Durable budget and replay implementations must use the
+request/nonce identifiers atomically and idempotently; they must never interpret
+timeout as proof that no write occurred. Late promise resolution or rejection is
+observed, while request listeners and timers are removed through one settlement
+path. Store methods are trusted adapters and must return without synchronously
+blocking the event loop; only their asynchronous result is deadline-preemptible.
 
 Only an exact `{ "input": ... }` body reaches the selected operation parser.
 Provider, operation, model, command, environment, path, and tool policy cannot
@@ -63,6 +79,13 @@ a finite cleanup grace period, so a hostile `return()` hook cannot hang the
 response. Execution uses a separate timeout and an idempotent terminal-state
 guard: an abort or timeout that wins before the queued handoff prevents the
 operation callback from starting.
+
+The future transport adapter is a trusted boundary and must provide an
+`AsyncIterable` whose iterator construction and `next()` implementation do not
+perform synchronous blocking work. JavaScript can race an asynchronous
+`next()` result against abort and deadline, but it cannot preempt code that
+blocks the event loop synchronously. Raw socket parsing remains the HTTP
+adapter's responsibility.
 
 ## Stable outcomes
 

--- a/docs/GATEWAY_DISPATCH.md
+++ b/docs/GATEWAY_DISPATCH.md
@@ -35,12 +35,14 @@ HTTP adapter (future) -> exact route/method -> assertion + replay verification
 ```
 
 Authentication occurs before body parsing. Missing, malformed, or
-signature-invalid assertions are not attributed to an owner. Once the internal
-signature has authenticated and a server-resolved owner is known, the endpoint
-budget is consumed even if replay, request context, media type, size, JSON, or
-operation input later rejects the attempt. Authentication failures remain
-`unauthorized` even if charging also fails, so budget state cannot become an
-authentication oracle.
+signature-invalid assertions are not attributed to an owner. Signature
+authentication is a narrow first stage that trusts no unparsed assertion claim.
+Once a configured key authenticates the raw bytes and a server-resolved owner is
+known, the endpoint budget is awaited before canonical encoding, claim, replay,
+request context, media type, size, JSON, or operation validation. The remaining
+assertion validation still runs when the budget rejects, preserving replay
+consumption for structurally valid signed attempts. An invalid signed assertion
+remains `unauthorized`, so budget state does not become an authentication oracle.
 
 The rate-budget interface receives both the per-owner and global limits in one
 server-owned policy object. A live implementation must consume both dimensions
@@ -52,6 +54,15 @@ Provider, operation, model, command, environment, path, and tool policy cannot
 be overridden at the envelope level. Each operation parser remains responsible
 for a strict operation-specific input schema. The handler receives the verified
 claims and a derived abort signal, never raw headers or route policy.
+
+Streaming input is bounded independently by total bytes, non-empty chunk count,
+and one wall-clock read deadline. Zero-byte chunks are invalid, exact-limit
+one-byte chunks are accepted, and the next chunk fails closed. Abort and deadline
+can interrupt a stalled iterator read; rejection requests iterator cleanup with
+a finite cleanup grace period, so a hostile `return()` hook cannot hang the
+response. Execution uses a separate timeout and an idempotent terminal-state
+guard: an abort or timeout that wins before the queued handoff prevents the
+operation callback from starting.
 
 ## Stable outcomes
 

--- a/docs/GATEWAY_DISPATCH.md
+++ b/docs/GATEWAY_DISPATCH.md
@@ -50,20 +50,34 @@ atomically. Exhaustion maps to `rate_limited`; unavailable or unknown store
 failures and deadline expiry map to `rate_limit_unavailable`. Replay-store
 failure or deadline expiry maps to `replay_defense_unavailable`. Each store call
 has a finite server-owned deadline and receives a reason-free cancellation
-signal plus the absolute deadline for cooperative cancellation. Caller abort
-maps to `request_aborted`. No store message, abort reason, or deadline detail is
-returned.
+signal plus the absolute deadline for cooperative cancellation. Before signature
+authentication, caller abort returns immediately without attributing work. After
+signature authentication, caller disconnect is recorded separately and cannot
+cancel rate or replay accounting. The dispatcher returns `request_aborted` only
+after both bounded accounting fences succeed. No store message, abort reason, or
+deadline detail is returned.
 
 A deadline is an ambiguous control-plane outcome: the store may have committed
 before its response was lost. The dispatcher therefore fails closed, continues
-bounded replay verification after a rate-budget timeout, and never proceeds to
-body ingestion or execution. A retry with the same valid assertion is rejected
-by replay defense. Durable budget and replay implementations must use the
+replay verification under a separate server-owned deadline after a rate-budget
+timeout, and never proceeds to body ingestion or execution. Caller abort during
+that fence does not cancel it. If replay commits, a retry with the same valid
+assertion is rejected. Durable budget and replay implementations must use the
 request/nonce identifiers atomically and idempotently; they must never interpret
 timeout as proof that no write occurred. Late promise resolution or rejection is
 observed, while request listeners and timers are removed through one settlement
 path. Store methods are trusted adapters and must return without synchronously
 blocking the event loop; only their asynchronous result is deadline-preemptible.
+
+If replay enforcement itself is unavailable or reaches its deadline, the
+dispatcher returns `replay_defense_unavailable`, taking precedence over a prior
+rate failure or caller abort. It cannot truthfully guarantee non-retryability
+without a durable atomic replay store: the first request did not execute, and a
+later retry may be accepted once if no deny record committed. Production
+enablement therefore requires durable replay persistence whose write can finish
+independently of the caller connection and whose recovery path detects a late
+commit. When replay succeeds, error precedence is signed-assertion/replay denial,
+then rate failure, then recorded caller abort.
 
 Only an exact `{ "input": ... }` body reaches the selected operation parser.
 Provider, operation, model, command, environment, path, and tool policy cannot

--- a/services/agent-gateway/control-plane.ts
+++ b/services/agent-gateway/control-plane.ts
@@ -1,0 +1,88 @@
+type ControlPlaneOperationContext = Readonly<{
+  signal: AbortSignal;
+  deadlineAtMilliseconds: number;
+}>;
+
+type ControlPlaneOutcome<T> =
+  | Readonly<{ status: "fulfilled"; value: T }>
+  | Readonly<{ status: "rejected"; error: unknown }>
+  | Readonly<{ status: "aborted" }>
+  | Readonly<{ status: "timed_out" }>;
+
+const SKIPPED_OPERATION = Symbol("skipped control-plane operation");
+
+/**
+ * Awaits one control-plane dependency behind a finite deadline and caller abort.
+ *
+ * The operation always receives a derived, reason-free signal. Late resolution
+ * or rejection remains observed after this function settles, while the caller's
+ * abort listener and deadline timer are removed by one idempotent settle path.
+ */
+function awaitControlPlaneOperation<T>(
+  operation: (context: ControlPlaneOperationContext) => T | PromiseLike<T>,
+  timeoutMs: number,
+  requestSignal?: AbortSignal
+): Promise<ControlPlaneOutcome<T>> {
+  const operationController = new AbortController();
+  const deadlineAtMilliseconds = Date.now() + timeoutMs;
+
+  return new Promise<ControlPlaneOutcome<T>>((resolve) => {
+    let settled = false;
+    const finish = (
+      outcome: ControlPlaneOutcome<T>,
+      cancelOperation: boolean
+    ): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      requestSignal?.removeEventListener("abort", handleRequestAbort);
+      if (cancelOperation) operationController.abort();
+      resolve(outcome);
+    };
+    const handleRequestAbort = (): void => {
+      finish({ status: "aborted" }, true);
+    };
+
+    const timeout = setTimeout(() => {
+      finish({ status: "timed_out" }, true);
+    }, timeoutMs);
+    requestSignal?.addEventListener("abort", handleRequestAbort, {
+      once: true,
+    });
+
+    if (requestSignal?.aborted) {
+      handleRequestAbort();
+    }
+
+    // The state check closes the same queued-microtask race as provider handoff:
+    // an already aborted request never calls the dependency at all.
+    Promise.resolve()
+      .then(() => {
+        if (settled) return SKIPPED_OPERATION;
+        return operation(
+          Object.freeze({
+            signal: operationController.signal,
+            deadlineAtMilliseconds,
+          })
+        );
+      })
+      .then(
+        (value) => {
+          if (value !== SKIPPED_OPERATION) {
+            finish({ status: "fulfilled", value: value as T }, false);
+          }
+        },
+        (error: unknown) => {
+          // This handler remains attached after timeout/abort, so a late store
+          // rejection is observed and cannot become an unhandled rejection.
+          finish({ status: "rejected", error }, false);
+        }
+      );
+  });
+}
+
+export {
+  awaitControlPlaneOperation,
+  type ControlPlaneOperationContext,
+  type ControlPlaneOutcome,
+};

--- a/services/agent-gateway/dispatcher.test.ts
+++ b/services/agent-gateway/dispatcher.test.ts
@@ -6,6 +6,7 @@ import {
 
 import { describe, expect, it, vi } from "vitest";
 
+import { type ControlPlaneOperationContext } from "./control-plane.ts";
 import {
   type CodexOperationDefinition,
   CodexOperationRegistry,
@@ -22,6 +23,7 @@ import {
   type ExpectedAssertionContext,
   type GatewayOperation,
   issueInternalAssertion,
+  type ReplayDefense,
   type SigningKey,
   type VerificationKeys,
 } from "./internal-auth.ts";
@@ -47,9 +49,19 @@ class TestRateBudget implements RateBudget {
   readonly attempts: RateBudgetAttempt[] = [];
   failure?: Error;
 
-  async consume(attempt: RateBudgetAttempt): Promise<void> {
+  constructor(
+    private readonly implementation?: (
+      context: ControlPlaneOperationContext | undefined
+    ) => void | Promise<void>
+  ) {}
+
+  async consume(
+    attempt: RateBudgetAttempt,
+    context?: ControlPlaneOperationContext
+  ): Promise<void> {
     this.attempts.push(attempt);
     if (this.failure) throw this.failure;
+    await this.implementation?.(context);
   }
 }
 
@@ -64,6 +76,12 @@ function createFixture(
     maxBodyBytes: number;
     maxBodyChunks: number;
     bodyReadTimeoutMs: number;
+    rateBudgetTimeoutMs: number;
+    replayDefenseTimeoutMs: number;
+    rateConsume: (
+      context: ControlPlaneOperationContext | undefined
+    ) => void | Promise<void>;
+    replayDefense: ReplayDefense;
   }> = {}
 ) {
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");
@@ -84,7 +102,7 @@ function createFixture(
     operation: "chat",
     requestId: "request_1",
   };
-  const rateBudget = new TestRateBudget();
+  const rateBudget = new TestRateBudget(options.rateConsume);
   const execute =
     options.execute ??
     (async (input: unknown) => ({ echoed: input, source: "server-registry" }));
@@ -117,13 +135,15 @@ function createFixture(
     route,
     expected,
     clock,
-    replayDefense: new BoundedReplayCache(32),
+    replayDefense: options.replayDefense ?? new BoundedReplayCache(32),
     verificationKeys,
     rateBudget,
     operationRegistry: registry,
     maxBodyBytes: options.maxBodyBytes ?? 64,
     maxBodyChunks: options.maxBodyChunks ?? 32,
     bodyReadTimeoutMs: options.bodyReadTimeoutMs ?? 1_000,
+    rateBudgetTimeoutMs: options.rateBudgetTimeoutMs ?? 1_000,
+    replayDefenseTimeoutMs: options.replayDefenseTimeoutMs ?? 1_000,
     executionTimeoutMs: options.timeoutMs ?? 1_000,
   });
 
@@ -263,6 +283,40 @@ function createStalledBody(): Readonly<{
     },
     cleanupCalls: () => cleanupCount,
     started,
+  };
+}
+
+/** Creates a manually settled promise for late control-plane result tests. */
+function createDeferred(): Readonly<{
+  promise: Promise<void>;
+  reject: (error: unknown) => void;
+  resolve: () => void;
+}> {
+  let rejectPromise: ((error: unknown) => void) | undefined;
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    promise,
+    reject: (error) => rejectPromise?.(error),
+    resolve: () => resolvePromise?.(),
+  };
+}
+
+/** Creates a valid body that records whether ingestion ever began. */
+function createObservedBody(): Readonly<{
+  body: AsyncIterable<Uint8Array>;
+  wasRead: () => boolean;
+}> {
+  let read = false;
+  return {
+    body: (async function* () {
+      read = true;
+      yield Buffer.from(JSON.stringify({ input: "hello" }));
+    })(),
+    wasRead: () => read,
   };
 }
 
@@ -535,6 +589,176 @@ describe("gateway dispatcher", () => {
       expect(JSON.stringify(response)).not.toContain(SECRET_CANARY);
     }
   );
+
+  it("times out a stalled rate store, cancels it, and observes a late rejection", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred();
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    let storeContext: ControlPlaneOperationContext | undefined;
+    const execute = vi.fn();
+    const body = createObservedBody();
+    try {
+      const fixture = createFixture({
+        execute,
+        rateBudgetTimeoutMs: 25,
+        rateConsume: (context) => {
+          storeContext = context;
+          return deferred.promise;
+        },
+      });
+      const token = issueToken(fixture);
+      const pending = fixture.dispatch(
+        createRequest(fixture, { body: body.body, token })
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(storeContext?.deadlineAtMilliseconds).toBeGreaterThanOrEqual(
+        Date.now()
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      const response = await pending;
+      expect([response.status, responseCode(response)]).toEqual([
+        503,
+        "rate_limit_unavailable",
+      ]);
+      expect(storeContext?.signal.aborted).toBe(true);
+      expect(body.wasRead()).toBe(false);
+      expect(execute).not.toHaveBeenCalled();
+
+      deferred.reject(new Error(SECRET_CANARY));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(unhandled).not.toHaveBeenCalled();
+
+      const retryBody = createObservedBody();
+      const retry = await fixture.dispatch(
+        createRequest(fixture, { body: retryBody.body, token })
+      );
+      expect([retry.status, responseCode(retry)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+      expect(retryBody.wasRead()).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      process.removeListener("unhandledRejection", unhandled);
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts a stalled rate store through its cooperative signal", async () => {
+    vi.useFakeTimers();
+    let storeContext: ControlPlaneOperationContext | undefined;
+    const execute = vi.fn();
+    const body = createObservedBody();
+    try {
+      const fixture = createFixture({
+        execute,
+        rateConsume: (context) => {
+          storeContext = context;
+          return new Promise<void>(() => undefined);
+        },
+      });
+      const controller = new AbortController();
+      const pending = fixture.dispatch(
+        createRequest(fixture, { body: body.body, signal: controller.signal })
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(storeContext).toBeDefined();
+      controller.abort(SECRET_CANARY);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const response = await pending;
+      expect([response.status, responseCode(response)]).toEqual([
+        499,
+        "request_aborted",
+      ]);
+      expect(storeContext?.signal.aborted).toBe(true);
+      expect(body.wasRead()).toBe(false);
+      expect(execute).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a stalled replay store, cancels it, and observes a late resolve", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred();
+    let replayContext: ControlPlaneOperationContext | undefined;
+    const replayDefense: ReplayDefense = {
+      consume(_entry, _nowSeconds, context) {
+        replayContext = context;
+        return deferred.promise;
+      },
+    };
+    const execute = vi.fn();
+    const body = createObservedBody();
+    try {
+      const fixture = createFixture({
+        execute,
+        replayDefense,
+        replayDefenseTimeoutMs: 25,
+      });
+      const pending = fixture.dispatch(
+        createRequest(fixture, { body: body.body })
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(replayContext).toBeDefined();
+
+      await vi.advanceTimersByTimeAsync(25);
+      const response = await pending;
+      expect([response.status, responseCode(response)]).toEqual([
+        503,
+        "replay_defense_unavailable",
+      ]);
+      expect(replayContext?.signal.aborted).toBe(true);
+      expect(body.wasRead()).toBe(false);
+      expect(execute).not.toHaveBeenCalled();
+
+      deferred.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts a stalled replay store through its cooperative signal", async () => {
+    vi.useFakeTimers();
+    let replayContext: ControlPlaneOperationContext | undefined;
+    const replayDefense: ReplayDefense = {
+      consume(_entry, _nowSeconds, context) {
+        replayContext = context;
+        return new Promise<void>(() => undefined);
+      },
+    };
+    const execute = vi.fn();
+    const body = createObservedBody();
+    try {
+      const fixture = createFixture({ execute, replayDefense });
+      const controller = new AbortController();
+      const pending = fixture.dispatch(
+        createRequest(fixture, { body: body.body, signal: controller.signal })
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(replayContext).toBeDefined();
+      controller.abort(SECRET_CANARY);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const response = await pending;
+      expect([response.status, responseCode(response)]).toEqual([
+        499,
+        "request_aborted",
+      ]);
+      expect(replayContext?.signal.aborted).toBe(true);
+      expect(body.wasRead()).toBe(false);
+      expect(execute).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("charges valid owners before content, length, JSON, and operation validation", async () => {
     const scenarios: Array<(fixture: Fixture) => GatewayRequestEnvelope> = [
@@ -879,6 +1103,13 @@ describe("gateway dispatcher", () => {
   });
 
   it("rejects invalid or incomplete server registries during startup", () => {
+    expect(() => createFixture({ rateBudgetTimeoutMs: 0 })).toThrowError(
+      "Gateway request was rejected"
+    );
+    expect(() =>
+      createFixture({ replayDefenseTimeoutMs: 10_001 })
+    ).toThrowError("Gateway request was rejected");
+
     const fixture = createFixture();
     expect(
       () =>

--- a/services/agent-gateway/dispatcher.test.ts
+++ b/services/agent-gateway/dispatcher.test.ts
@@ -1,0 +1,681 @@
+import {
+  generateKeyPairSync,
+  type KeyObject,
+  sign as signBytes,
+} from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type CodexOperationDefinition,
+  CodexOperationRegistry,
+  createGatewayDispatcher,
+  type GatewayDispatcher,
+  type GatewayRequestEnvelope,
+  type RateBudget,
+  type RateBudgetAttempt,
+  RateBudgetError,
+} from "./dispatcher.ts";
+import {
+  BoundedReplayCache,
+  type Clock,
+  type ExpectedAssertionContext,
+  type GatewayOperation,
+  issueInternalAssertion,
+  type SigningKey,
+  type VerificationKeys,
+} from "./internal-auth.ts";
+
+const BASE_TIME = 1_800_000_000;
+const SECRET_CANARY = "sk-secret-do-not-reflect";
+
+/** Deterministic clock used by signed dispatcher fixtures. */
+class TestClock implements Clock {
+  constructor(private current = BASE_TIME) {}
+
+  nowSeconds(): number {
+    return this.current;
+  }
+
+  set(nowSeconds: number): void {
+    this.current = nowSeconds;
+  }
+}
+
+/** Observable async budget implementation with controllable failure behavior. */
+class TestRateBudget implements RateBudget {
+  readonly attempts: RateBudgetAttempt[] = [];
+  failure?: Error;
+
+  async consume(attempt: RateBudgetAttempt): Promise<void> {
+    this.attempts.push(attempt);
+    if (this.failure) throw this.failure;
+  }
+}
+
+type Fixture = ReturnType<typeof createFixture>;
+
+/** Creates a complete dispatcher fixture with no ambient key or replay state. */
+function createFixture(
+  options: Partial<{
+    execute: CodexOperationDefinition["execute"];
+    parseInput: CodexOperationDefinition["parseInput"];
+    timeoutMs: number;
+    maxBodyBytes: number;
+  }> = {}
+) {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const clock = new TestClock();
+  const signingKey: SigningKey = {
+    keyId: "dispatcher-current",
+    privateKey,
+  };
+  const verificationKeys: VerificationKeys = {
+    current: { keyId: signingKey.keyId, publicKey },
+  };
+  const expected: ExpectedAssertionContext = {
+    issuer: "sprig-nextjs",
+    audience: "sprig-agent-gateway",
+    subject: "owner_a",
+    connectionId: "connection_a",
+    provider: "codex",
+    operation: "chat",
+    requestId: "request_1",
+  };
+  const rateBudget = new TestRateBudget();
+  const execute =
+    options.execute ??
+    (async (input: unknown) => ({ echoed: input, source: "server-registry" }));
+  const registry = new CodexOperationRegistry([
+    {
+      operation: "chat",
+      parseInput:
+        options.parseInput ??
+        ((input) => {
+          if (typeof input !== "string" || input.length > 128) {
+            throw new Error("invalid chat input");
+          }
+          return input;
+        }),
+      execute,
+    },
+  ]);
+  const route = {
+    method: "POST" as const,
+    path: "/internal/v1/codex/chat" as const,
+    operation: "chat" as const,
+    rateBudget: {
+      endpoint: "codex.chat",
+      ownerLimit: 4,
+      globalLimit: 40,
+      windowSeconds: 60,
+    },
+  };
+  const dispatch = createGatewayDispatcher({
+    route,
+    expected,
+    clock,
+    replayDefense: new BoundedReplayCache(32),
+    verificationKeys,
+    rateBudget,
+    operationRegistry: registry,
+    maxBodyBytes: options.maxBodyBytes ?? 64,
+    executionTimeoutMs: options.timeoutMs ?? 1_000,
+  });
+
+  return {
+    clock,
+    dispatch,
+    expected,
+    privateKey,
+    rateBudget,
+    route,
+    signingKey,
+    verificationKeys,
+  };
+}
+
+/** Issues one signed request token, optionally targeting a different context. */
+function issueToken(
+  fixture: Fixture,
+  overrides: Partial<{
+    connectionId: string;
+    nonce: string;
+    operation: GatewayOperation;
+    requestId: string;
+    subject: string;
+  }> = {}
+): string {
+  return issueInternalAssertion(
+    {
+      issuer: fixture.expected.issuer,
+      audience: fixture.expected.audience,
+      subject: overrides.subject ?? fixture.expected.subject,
+      connectionId: overrides.connectionId ?? fixture.expected.connectionId,
+      operation: overrides.operation ?? fixture.expected.operation,
+      requestId: overrides.requestId ?? fixture.expected.requestId,
+      nonce: overrides.nonce ?? "nonce_1",
+    },
+    fixture.signingKey,
+    fixture.clock
+  );
+}
+
+/** Re-signs one controlled token so provider mismatch reaches context checks. */
+function rewriteSignedProvider(
+  token: string,
+  privateKey: KeyObject,
+  provider: string
+): string {
+  const [header, encodedClaims] = token.split(".");
+  const claims = JSON.parse(
+    Buffer.from(encodedClaims, "base64url").toString("utf8")
+  ) as Record<string, unknown>;
+  claims.provider = provider;
+  const nextClaims = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signingInput = `${header}.${nextClaims}`;
+  const signature = signBytes(
+    null,
+    Buffer.from(signingInput),
+    privateKey
+  ).toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+/** Produces a byte-stream request with strict defaults and overridable fields. */
+function createRequest(
+  fixture: Fixture,
+  options: Partial<{
+    body: AsyncIterable<Uint8Array>;
+    contentLength: string;
+    contentType: string;
+    headers: Readonly<Record<string, string | readonly string[] | undefined>>;
+    method: string;
+    path: string;
+    signal: AbortSignal;
+    token: string;
+  }> = {}
+): GatewayRequestEnvelope {
+  const json = JSON.stringify({ input: "hello" });
+  const token = options.token ?? issueToken(fixture);
+  return {
+    method: options.method ?? "POST",
+    path: options.path ?? "/internal/v1/codex/chat",
+    headers: options.headers ?? {
+      authorization: `Bearer ${token}`,
+      "content-type": options.contentType ?? "application/json",
+      ...(options.contentLength === undefined
+        ? {}
+        : { "content-length": options.contentLength }),
+    },
+    body: options.body ?? chunks(json),
+    signal: options.signal,
+  };
+}
+
+/** Converts text chunks into a transport-neutral async byte stream. */
+async function* chunks(...values: string[]): AsyncIterable<Uint8Array> {
+  for (const value of values) yield Buffer.from(value);
+}
+
+/** Reads the stable error code without relying on implementation messages. */
+function responseCode(
+  response: Awaited<ReturnType<GatewayDispatcher>>
+): string | undefined {
+  return response.body.ok ? undefined : response.body.error.code;
+}
+
+describe("gateway dispatcher", () => {
+  it("dispatches an exact authenticated Codex operation through server policy", async () => {
+    const fixture = createFixture();
+    const response = await fixture.dispatch(createRequest(fixture));
+
+    expect(response).toEqual({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: {
+        ok: true,
+        data: { echoed: "hello", source: "server-registry" },
+      },
+    });
+    expect(fixture.rateBudget.attempts).toEqual([
+      {
+        ownerSubject: "owner_a",
+        connectionId: "connection_a",
+        requestId: "request_1",
+        policy: {
+          endpoint: "codex.chat",
+          ownerLimit: 4,
+          globalLimit: 40,
+          windowSeconds: 60,
+        },
+      },
+    ]);
+  });
+
+  it("snapshots server route, context, and rate policy at creation", async () => {
+    const fixture = createFixture();
+    const token = issueToken(fixture);
+    (fixture.expected as { subject: string }).subject = "owner_mutated";
+    (fixture.route as { path: string }).path = "/mutated";
+    (fixture.route.rateBudget as { ownerLimit: number }).ownerLimit = 999;
+
+    const response = await fixture.dispatch(createRequest(fixture, { token }));
+    expect(response.status).toBe(200);
+    expect(fixture.rateBudget.attempts[0]).toMatchObject({
+      ownerSubject: "owner_a",
+      policy: { ownerLimit: 4 },
+    });
+  });
+
+  it("rejects unknown routes and wrong methods before auth, replay, or budgets", async () => {
+    const fixture = createFixture();
+    const token = issueToken(fixture);
+
+    const unknown = await fixture.dispatch(
+      createRequest(fixture, { path: "/internal/v1/codex/unknown", token })
+    );
+    const wrongMethod = await fixture.dispatch(
+      createRequest(fixture, { method: "GET", token })
+    );
+    const accepted = await fixture.dispatch(createRequest(fixture, { token }));
+
+    expect([unknown.status, responseCode(unknown)]).toEqual([404, "not_found"]);
+    expect([wrongMethod.status, responseCode(wrongMethod)]).toEqual([
+      405,
+      "method_not_allowed",
+    ]);
+    expect(accepted.status).toBe(200);
+    expect(fixture.rateBudget.attempts).toHaveLength(1);
+  });
+
+  it.each([
+    ["missing", {}],
+    ["wrong scheme", { authorization: "Basic abc" }],
+    ["duplicate", { authorization: ["Bearer one", "Bearer two"] }],
+    [
+      "case-duplicate",
+      { authorization: "Bearer one", Authorization: "Bearer two" },
+    ],
+    ["malformed token", { authorization: "Bearer not.a.valid.token" }],
+  ] as const)(
+    "rejects a %s assertion header without charging",
+    async (_label, headers) => {
+      const fixture = createFixture();
+      const response = await fixture.dispatch(
+        createRequest(fixture, {
+          headers: { ...headers, "content-type": "application/json" },
+        })
+      );
+
+      expect([response.status, responseCode(response)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+      expect(fixture.rateBudget.attempts).toHaveLength(0);
+    }
+  );
+
+  it.each(["subject", "connection", "operation", "provider"] as const)(
+    "charges an authentically signed %s mismatch before denying it",
+    async (kind) => {
+      const fixture = createFixture();
+      let token = issueToken(fixture, {
+        ...(kind === "subject" ? { subject: "owner_b" } : {}),
+        ...(kind === "connection" ? { connectionId: "connection_b" } : {}),
+        ...(kind === "operation" ? { operation: "node-editing" } : {}),
+      });
+      if (kind === "provider") {
+        token = rewriteSignedProvider(token, fixture.privateKey, "claude");
+      }
+
+      const response = await fixture.dispatch(
+        createRequest(fixture, { token })
+      );
+      expect([response.status, responseCode(response)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+      expect(fixture.rateBudget.attempts).toHaveLength(1);
+    }
+  );
+
+  it("keeps a signed context rejection unauthorized when charging is unavailable", async () => {
+    const fixture = createFixture();
+    fixture.rateBudget.failure = new Error(SECRET_CANARY);
+    const token = issueToken(fixture, { subject: "owner_b" });
+
+    const response = await fixture.dispatch(createRequest(fixture, { token }));
+    expect([response.status, responseCode(response)]).toEqual([
+      401,
+      "unauthorized",
+    ]);
+    expect(fixture.rateBudget.attempts).toHaveLength(1);
+    expect(JSON.stringify(response)).not.toContain(SECRET_CANARY);
+  });
+
+  it("charges replayed assertions while preserving an unauthorized response", async () => {
+    const fixture = createFixture();
+    const token = issueToken(fixture);
+    expect(
+      (await fixture.dispatch(createRequest(fixture, { token }))).status
+    ).toBe(200);
+
+    const replay = await fixture.dispatch(createRequest(fixture, { token }));
+    expect([replay.status, responseCode(replay)]).toEqual([
+      401,
+      "unauthorized",
+    ]);
+    expect(fixture.rateBudget.attempts).toHaveLength(2);
+  });
+
+  it.each([
+    [new RateBudgetError("exhausted"), 429, "rate_limited"],
+    [new RateBudgetError("unavailable"), 503, "rate_limit_unavailable"],
+    [
+      new Error(`redis://${SECRET_CANARY}@private`),
+      503,
+      "rate_limit_unavailable",
+    ],
+  ] as const)(
+    "fails closed when the budget rejects",
+    async (failure, status, code) => {
+      const fixture = createFixture();
+      fixture.rateBudget.failure = failure;
+      const response = await fixture.dispatch(createRequest(fixture));
+
+      expect([response.status, responseCode(response)]).toEqual([status, code]);
+      expect(JSON.stringify(response)).not.toContain(SECRET_CANARY);
+    }
+  );
+
+  it("charges valid owners before content, length, JSON, and operation validation", async () => {
+    const scenarios: Array<(fixture: Fixture) => GatewayRequestEnvelope> = [
+      (fixture) =>
+        createRequest(fixture, {
+          contentType: "application/json; charset=utf-8",
+        }),
+      (fixture) => createRequest(fixture, { contentLength: "999" }),
+      (fixture) => createRequest(fixture, { body: chunks("{not-json") }),
+      (fixture) =>
+        createRequest(fixture, { body: chunks(JSON.stringify({ input: 42 })) }),
+      (fixture) =>
+        createRequest(fixture, {
+          body: chunks(
+            JSON.stringify({
+              input: "hello",
+              operation: "node-editing",
+              provider: "claude",
+              command: "arbitrary",
+              env: { CODEX_HOME: "/attacker" },
+              model: "attacker-model",
+              cwd: "/private",
+            })
+          ),
+        }),
+    ];
+
+    for (const scenario of scenarios) {
+      const fixture = createFixture();
+      const response = await fixture.dispatch(scenario(fixture));
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(fixture.rateBudget.attempts).toHaveLength(1);
+    }
+  });
+
+  it("rejects an oversized declared body before iterating its stream", async () => {
+    const fixture = createFixture({ maxBodyBytes: 16 });
+    let iterated = false;
+    async function* untouchedBody(): AsyncIterable<Uint8Array> {
+      iterated = true;
+      yield Buffer.from("{}");
+    }
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, { body: untouchedBody(), contentLength: "17" })
+    );
+    expect([response.status, responseCode(response), iterated]).toEqual([
+      413,
+      "payload_too_large",
+      false,
+    ]);
+    expect(fixture.rateBudget.attempts).toHaveLength(1);
+  });
+
+  it("bounds decoded chunked bodies and closes the source on overflow", async () => {
+    const fixture = createFixture({ maxBodyBytes: 24 });
+    let closed = false;
+    async function* chunkedBody(): AsyncIterable<Uint8Array> {
+      try {
+        yield Buffer.from('{"input":"');
+        yield Buffer.from("x".repeat(24));
+        yield Buffer.from('"}');
+      } finally {
+        closed = true;
+      }
+    }
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, { body: chunkedBody() })
+    );
+    expect([response.status, responseCode(response), closed]).toEqual([
+      413,
+      "payload_too_large",
+      true,
+    ]);
+  });
+
+  it("rejects malformed lengths, invalid UTF-8, and byte-count mismatch", async () => {
+    const requests = [
+      (fixture: Fixture) => createRequest(fixture, { contentLength: "+2" }),
+      (fixture: Fixture) =>
+        createRequest(fixture, {
+          headers: {
+            authorization: `Bearer ${issueToken(fixture)}`,
+            "content-type": "application/json",
+            "content-length": "17",
+            "Content-Length": "17",
+          },
+        }),
+      (fixture: Fixture) =>
+        createRequest(fixture, {
+          body: chunks(JSON.stringify({ input: "hello" })),
+          contentLength: "1",
+        }),
+      (fixture: Fixture) =>
+        createRequest(fixture, {
+          body: (async function* () {
+            yield Uint8Array.from([0xc3, 0x28]);
+          })(),
+        }),
+      (fixture: Fixture) =>
+        createRequest(fixture, {
+          body: (async function* (emitChunk: boolean) {
+            if (emitChunk) yield new Uint8Array();
+            throw new Error(SECRET_CANARY);
+          })(false),
+        }),
+    ];
+
+    for (const createScenario of requests) {
+      const fixture = createFixture();
+      const response = await fixture.dispatch(createScenario(fixture));
+      expect([response.status, responseCode(response)]).toEqual([
+        400,
+        "invalid_request",
+      ]);
+      expect(fixture.rateBudget.attempts).toHaveLength(1);
+    }
+  });
+
+  it("does not invoke the operation when aborted before the handoff", async () => {
+    const execute = vi.fn();
+    const fixture = createFixture({ execute });
+    const controller = new AbortController();
+    controller.abort();
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, { signal: controller.signal })
+    );
+    expect([response.status, responseCode(response)]).toEqual([
+      499,
+      "request_aborted",
+    ]);
+    expect(execute).not.toHaveBeenCalled();
+    expect(fixture.rateBudget.attempts).toHaveLength(0);
+  });
+
+  it("honors an abort that arrives after validation but before execution", async () => {
+    const controller = new AbortController();
+    const execute = vi.fn();
+    const fixture = createFixture({
+      execute,
+      parseInput: (input) => {
+        controller.abort();
+        return input;
+      },
+    });
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, { signal: controller.signal })
+    );
+    expect([response.status, responseCode(response)]).toEqual([
+      499,
+      "request_aborted",
+    ]);
+    expect(execute).not.toHaveBeenCalled();
+    expect(fixture.rateBudget.attempts).toHaveLength(1);
+  });
+
+  it("aborts an active operation without reflecting its eventual error", async () => {
+    let operationSignal: AbortSignal | undefined;
+    const fixture = createFixture({
+      execute: async (_input, context) => {
+        operationSignal = context.signal;
+        await new Promise<void>((_resolve, reject) => {
+          context.signal.addEventListener(
+            "abort",
+            () => reject(new Error(SECRET_CANARY)),
+            { once: true }
+          );
+        });
+      },
+    });
+    const controller = new AbortController();
+    const pending = fixture.dispatch(
+      createRequest(fixture, { signal: controller.signal })
+    );
+    await vi.waitFor(() => expect(operationSignal).toBeDefined());
+    controller.abort(SECRET_CANARY);
+
+    const response = await pending;
+    expect([
+      response.status,
+      responseCode(response),
+      operationSignal?.aborted,
+    ]).toEqual([499, "request_aborted", true]);
+    expect(JSON.stringify(response)).not.toContain(SECRET_CANARY);
+  });
+
+  it("times out an operation, signals cancellation, and returns a fixed error", async () => {
+    let operationSignal: AbortSignal | undefined;
+    const fixture = createFixture({
+      timeoutMs: 10,
+      execute: async (_input, context) => {
+        operationSignal = context.signal;
+        await new Promise<void>(() => undefined);
+      },
+    });
+
+    const response = await fixture.dispatch(createRequest(fixture));
+    expect([
+      response.status,
+      responseCode(response),
+      operationSignal?.aborted,
+    ]).toEqual([504, "request_timeout", true]);
+  });
+
+  it("normalizes parser and operation errors without leaking secret canaries", async () => {
+    const parserFailure = createFixture({
+      parseInput: () => {
+        throw new Error(SECRET_CANARY);
+      },
+    });
+    const operationFailure = createFixture({
+      execute: () => {
+        throw new Error(SECRET_CANARY);
+      },
+    });
+
+    const responses = await Promise.all([
+      parserFailure.dispatch(createRequest(parserFailure)),
+      operationFailure.dispatch(createRequest(operationFailure)),
+    ]);
+    expect(responses.map((response) => responseCode(response))).toEqual([
+      "invalid_request",
+      "operation_failed",
+    ]);
+    expect(JSON.stringify(responses)).not.toContain(SECRET_CANARY);
+  });
+
+  it("maps verifier configuration failure to a stable unavailable response", async () => {
+    const fixture = createFixture();
+    const token = issueToken(fixture);
+    fixture.clock.set(-1);
+
+    const response = await fixture.dispatch(createRequest(fixture, { token }));
+    expect([response.status, responseCode(response)]).toEqual([
+      503,
+      "gateway_configuration_unavailable",
+    ]);
+    expect(fixture.rateBudget.attempts).toHaveLength(0);
+  });
+
+  it("rejects invalid or incomplete server registries during startup", () => {
+    const fixture = createFixture();
+    expect(
+      () =>
+        new CodexOperationRegistry([
+          {
+            operation: "chat",
+            parseInput: (input) => input,
+            execute: () => undefined,
+          },
+          {
+            operation: "chat",
+            parseInput: (input) => input,
+            execute: () => undefined,
+          },
+        ])
+    ).toThrowError("Gateway request was rejected");
+
+    const missingChat = new CodexOperationRegistry([
+      {
+        operation: "node-editing",
+        parseInput: (input) => input,
+        execute: () => undefined,
+      },
+    ]);
+    expect(() =>
+      createGatewayDispatcher({
+        route: {
+          method: "POST",
+          path: "/internal/v1/codex/chat",
+          operation: "chat",
+          rateBudget: {
+            endpoint: "codex.chat",
+            ownerLimit: 1,
+            globalLimit: 1,
+            windowSeconds: 1,
+          },
+        },
+        expected: fixture.expected,
+        clock: fixture.clock,
+        replayDefense: new BoundedReplayCache(1),
+        verificationKeys: fixture.verificationKeys,
+        rateBudget: fixture.rateBudget,
+        operationRegistry: missingChat,
+      })
+    ).toThrowError("Gateway request was rejected");
+  });
+});

--- a/services/agent-gateway/dispatcher.test.ts
+++ b/services/agent-gateway/dispatcher.test.ts
@@ -62,6 +62,8 @@ function createFixture(
     parseInput: CodexOperationDefinition["parseInput"];
     timeoutMs: number;
     maxBodyBytes: number;
+    maxBodyChunks: number;
+    bodyReadTimeoutMs: number;
   }> = {}
 ) {
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");
@@ -120,6 +122,8 @@ function createFixture(
     rateBudget,
     operationRegistry: registry,
     maxBodyBytes: options.maxBodyBytes ?? 64,
+    maxBodyChunks: options.maxBodyChunks ?? 32,
+    bodyReadTimeoutMs: options.bodyReadTimeoutMs ?? 1_000,
     executionTimeoutMs: options.timeoutMs ?? 1_000,
   });
 
@@ -161,19 +165,33 @@ function issueToken(
   );
 }
 
-/** Re-signs one controlled token so provider mismatch reaches context checks. */
-function rewriteSignedProvider(
+/** Re-signs controlled raw JSON so authenticated-invalid cases reach validation. */
+function rewriteSignedToken(
   token: string,
   privateKey: KeyObject,
-  provider: string
+  mutate: Readonly<{
+    header?: (value: Record<string, unknown>) => void;
+    claims?: (value: Record<string, unknown>) => void;
+    prettyHeader?: boolean;
+    prettyClaims?: boolean;
+  }>
 ): string {
-  const [header, encodedClaims] = token.split(".");
+  const [encodedHeader, encodedClaims] = token.split(".");
+  const header = JSON.parse(
+    Buffer.from(encodedHeader, "base64url").toString("utf8")
+  ) as Record<string, unknown>;
   const claims = JSON.parse(
     Buffer.from(encodedClaims, "base64url").toString("utf8")
   ) as Record<string, unknown>;
-  claims.provider = provider;
-  const nextClaims = Buffer.from(JSON.stringify(claims)).toString("base64url");
-  const signingInput = `${header}.${nextClaims}`;
+  mutate.header?.(header);
+  mutate.claims?.(claims);
+  const nextHeader = Buffer.from(
+    JSON.stringify(header, null, mutate.prettyHeader ? 2 : undefined)
+  ).toString("base64url");
+  const nextClaims = Buffer.from(
+    JSON.stringify(claims, null, mutate.prettyClaims ? 2 : undefined)
+  ).toString("base64url");
+  const signingInput = `${nextHeader}.${nextClaims}`;
   const signature = signBytes(
     null,
     Buffer.from(signingInput),
@@ -216,6 +234,36 @@ function createRequest(
 /** Converts text chunks into a transport-neutral async byte stream. */
 async function* chunks(...values: string[]): AsyncIterable<Uint8Array> {
   for (const value of values) yield Buffer.from(value);
+}
+
+/** Creates a body whose first read stalls until dispatcher cancellation. */
+function createStalledBody(): Readonly<{
+  body: AsyncIterable<Uint8Array>;
+  cleanupCalls: () => number;
+  started: Promise<void>;
+}> {
+  let cleanupCount = 0;
+  let markStarted: (() => void) | undefined;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const iterator: AsyncIterator<Uint8Array> = {
+    next() {
+      markStarted?.();
+      return new Promise<IteratorResult<Uint8Array>>(() => undefined);
+    },
+    async return() {
+      cleanupCount += 1;
+      return { done: true, value: undefined };
+    },
+  };
+  return {
+    body: {
+      [Symbol.asyncIterator]: () => iterator,
+    },
+    cleanupCalls: () => cleanupCount,
+    started,
+  };
 }
 
 /** Reads the stable error code without relying on implementation messages. */
@@ -326,7 +374,11 @@ describe("gateway dispatcher", () => {
         ...(kind === "operation" ? { operation: "node-editing" } : {}),
       });
       if (kind === "provider") {
-        token = rewriteSignedProvider(token, fixture.privateKey, "claude");
+        token = rewriteSignedToken(token, fixture.privateKey, {
+          claims: (claims) => {
+            claims.provider = "claude";
+          },
+        });
       }
 
       const response = await fixture.dispatch(
@@ -340,6 +392,82 @@ describe("gateway dispatcher", () => {
     }
   );
 
+  it.each(["noncanonical", "header", "claim", "kid"] as const)(
+    "charges a configured-key signature before rejecting invalid %s data",
+    async (kind) => {
+      const fixture = createFixture();
+      const token = rewriteSignedToken(
+        issueToken(fixture),
+        fixture.privateKey,
+        {
+          ...(kind === "noncanonical" ? { prettyClaims: true } : {}),
+          ...(kind === "header"
+            ? {
+                header: (header: Record<string, unknown>) => {
+                  header.algorithm = "not-EdDSA";
+                },
+              }
+            : {}),
+          ...(kind === "claim"
+            ? {
+                claims: (claims: Record<string, unknown>) => {
+                  claims.subject = "";
+                },
+              }
+            : {}),
+          ...(kind === "kid"
+            ? {
+                header: (header: Record<string, unknown>) => {
+                  header.kid = "configured-key-alias-mismatch";
+                },
+                claims: (claims: Record<string, unknown>) => {
+                  claims.kid = "configured-key-alias-mismatch";
+                },
+              }
+            : {}),
+        }
+      );
+
+      const response = await fixture.dispatch(
+        createRequest(fixture, { token })
+      );
+      expect([response.status, responseCode(response)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+      expect(fixture.rateBudget.attempts).toHaveLength(1);
+    }
+  );
+
+  it("does not charge unknown-key or signature-tampered assertions", async () => {
+    const fixture = createFixture();
+    const unknownKeys = generateKeyPairSync("ed25519");
+    const unknownToken = issueInternalAssertion(
+      {
+        ...fixture.expected,
+        nonce: "unknown_nonce",
+      },
+      { keyId: "unknown-key", privateKey: unknownKeys.privateKey },
+      fixture.clock
+    );
+    const validToken = issueToken(fixture, { nonce: "tampered_nonce" });
+    const [header, claims, signature] = validToken.split(".");
+    const signatureBytes = Buffer.from(signature, "base64url");
+    signatureBytes[0] ^= 0x01;
+    const tamperedToken = `${header}.${claims}.${signatureBytes.toString("base64url")}`;
+
+    for (const token of [unknownToken, tamperedToken]) {
+      const response = await fixture.dispatch(
+        createRequest(fixture, { token })
+      );
+      expect([response.status, responseCode(response)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+    }
+    expect(fixture.rateBudget.attempts).toHaveLength(0);
+  });
+
   it("keeps a signed context rejection unauthorized when charging is unavailable", async () => {
     const fixture = createFixture();
     fixture.rateBudget.failure = new Error(SECRET_CANARY);
@@ -352,6 +480,25 @@ describe("gateway dispatcher", () => {
     ]);
     expect(fixture.rateBudget.attempts).toHaveLength(1);
     expect(JSON.stringify(response)).not.toContain(SECRET_CANARY);
+  });
+
+  it("consumes replay state for a valid assertion rejected by the rate budget", async () => {
+    const fixture = createFixture();
+    fixture.rateBudget.failure = new RateBudgetError("exhausted");
+    const token = issueToken(fixture);
+    const limited = await fixture.dispatch(createRequest(fixture, { token }));
+    fixture.rateBudget.failure = undefined;
+    const replay = await fixture.dispatch(createRequest(fixture, { token }));
+
+    expect([limited.status, responseCode(limited)]).toEqual([
+      429,
+      "rate_limited",
+    ]);
+    expect([replay.status, responseCode(replay)]).toEqual([
+      401,
+      "unauthorized",
+    ]);
+    expect(fixture.rateBudget.attempts).toHaveLength(2);
   });
 
   it("charges replayed assertions while preserving an unauthorized response", async () => {
@@ -465,6 +612,83 @@ describe("gateway dispatcher", () => {
     ]);
   });
 
+  it("rejects zero-byte chunk floods and requests iterator cleanup", async () => {
+    const fixture = createFixture();
+    let closed = false;
+    async function* zeroByteFlood(): AsyncIterable<Uint8Array> {
+      try {
+        while (true) yield new Uint8Array();
+      } finally {
+        closed = true;
+      }
+    }
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, { body: zeroByteFlood() })
+    );
+    expect([response.status, responseCode(response), closed]).toEqual([
+      400,
+      "invalid_request",
+      true,
+    ]);
+  });
+
+  it("accepts at most the configured number of one-byte chunks", async () => {
+    const json = JSON.stringify({ input: "hello" });
+    const exactFixture = createFixture({ maxBodyChunks: json.length });
+    const overflowFixture = createFixture({ maxBodyChunks: json.length });
+    const oneByteChunks = (value: string): AsyncIterable<Uint8Array> =>
+      chunks(...value.split(""));
+
+    const accepted = await exactFixture.dispatch(
+      createRequest(exactFixture, { body: oneByteChunks(json) })
+    );
+    const rejected = await overflowFixture.dispatch(
+      createRequest(overflowFixture, { body: oneByteChunks(`${json} `) })
+    );
+    expect(accepted.status).toBe(200);
+    expect([rejected.status, responseCode(rejected)]).toEqual([
+      413,
+      "payload_too_large",
+    ]);
+  });
+
+  it("aborts a stalled body read and requests iterator cleanup", async () => {
+    const execute = vi.fn();
+    const fixture = createFixture({ execute });
+    const controller = new AbortController();
+    const stalled = createStalledBody();
+    const pending = fixture.dispatch(
+      createRequest(fixture, { body: stalled.body, signal: controller.signal })
+    );
+    await stalled.started;
+    controller.abort(SECRET_CANARY);
+
+    const response = await pending;
+    expect([response.status, responseCode(response)]).toEqual([
+      499,
+      "request_aborted",
+    ]);
+    expect(stalled.cleanupCalls()).toBe(1);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("times out a stalled body read and requests iterator cleanup", async () => {
+    const execute = vi.fn();
+    const fixture = createFixture({ bodyReadTimeoutMs: 10, execute });
+    const stalled = createStalledBody();
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, { body: stalled.body })
+    );
+    expect([response.status, responseCode(response)]).toEqual([
+      504,
+      "request_timeout",
+    ]);
+    expect(stalled.cleanupCalls()).toBe(1);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed lengths, invalid UTF-8, and byte-count mismatch", async () => {
     const requests = [
       (fixture: Fixture) => createRequest(fixture, { contentLength: "+2" }),
@@ -547,6 +771,29 @@ describe("gateway dispatcher", () => {
     expect(fixture.rateBudget.attempts).toHaveLength(1);
   });
 
+  it("never executes when an abort settles ahead of the queued handoff", async () => {
+    const controller = new AbortController();
+    const execute = vi.fn();
+    const fixture = createFixture({
+      execute,
+      parseInput: (input) => {
+        // This abort microtask is queued before executeWithCancellation queues
+        // its operation microtask, deterministically exercising the prior race.
+        queueMicrotask(() => controller.abort());
+        return input;
+      },
+    });
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, { signal: controller.signal })
+    );
+    expect([response.status, responseCode(response)]).toEqual([
+      499,
+      "request_aborted",
+    ]);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("aborts an active operation without reflecting its eventual error", async () => {
     let operationSignal: AbortSignal | undefined;
     const fixture = createFixture({
@@ -618,7 +865,7 @@ describe("gateway dispatcher", () => {
     expect(JSON.stringify(responses)).not.toContain(SECRET_CANARY);
   });
 
-  it("maps verifier configuration failure to a stable unavailable response", async () => {
+  it("charges authenticated bytes before mapping later verifier configuration failure", async () => {
     const fixture = createFixture();
     const token = issueToken(fixture);
     fixture.clock.set(-1);
@@ -628,7 +875,7 @@ describe("gateway dispatcher", () => {
       503,
       "gateway_configuration_unavailable",
     ]);
-    expect(fixture.rateBudget.attempts).toHaveLength(0);
+    expect(fixture.rateBudget.attempts).toHaveLength(1);
   });
 
   it("rejects invalid or incomplete server registries during startup", () => {

--- a/services/agent-gateway/dispatcher.test.ts
+++ b/services/agent-gateway/dispatcher.test.ts
@@ -24,6 +24,7 @@ import {
   type GatewayOperation,
   issueInternalAssertion,
   type ReplayDefense,
+  ReplayDefenseError,
   type SigningKey,
   type VerificationKeys,
 } from "./internal-auth.ts";
@@ -646,8 +647,42 @@ describe("gateway dispatcher", () => {
     }
   });
 
-  it("aborts a stalled rate store through its cooperative signal", async () => {
+  it("fences a same-tick post-auth abort before returning 499", async () => {
+    const execute = vi.fn();
+    const body = createObservedBody();
+    const fixture = createFixture({ execute });
+    const token = issueToken(fixture);
+    const controller = new AbortController();
+
+    // Dispatch authenticates synchronously before its first awaited store call.
+    const pending = fixture.dispatch(
+      createRequest(fixture, {
+        body: body.body,
+        signal: controller.signal,
+        token,
+      })
+    );
+    controller.abort(SECRET_CANARY);
+
+    const response = await pending;
+    const retryBody = createObservedBody();
+    const retry = await fixture.dispatch(
+      createRequest(fixture, { body: retryBody.body, token })
+    );
+    expect([response.status, responseCode(response)]).toEqual([
+      499,
+      "request_aborted",
+    ]);
+    expect([retry.status, responseCode(retry)]).toEqual([401, "unauthorized"]);
+    expect(fixture.rateBudget.attempts).toHaveLength(2);
+    expect(body.wasRead()).toBe(false);
+    expect(retryBody.wasRead()).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("allows rate accounting to commit after caller abort before returning 499", async () => {
     vi.useFakeTimers();
+    const deferred = createDeferred();
     let storeContext: ControlPlaneOperationContext | undefined;
     const execute = vi.fn();
     const body = createObservedBody();
@@ -656,16 +691,24 @@ describe("gateway dispatcher", () => {
         execute,
         rateConsume: (context) => {
           storeContext = context;
-          return new Promise<void>(() => undefined);
+          return deferred.promise;
         },
       });
+      const token = issueToken(fixture);
       const controller = new AbortController();
       const pending = fixture.dispatch(
-        createRequest(fixture, { body: body.body, signal: controller.signal })
+        createRequest(fixture, {
+          body: body.body,
+          signal: controller.signal,
+          token,
+        })
       );
       await vi.advanceTimersByTimeAsync(0);
       expect(storeContext).toBeDefined();
       controller.abort(SECRET_CANARY);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(storeContext?.signal.aborted).toBe(false);
+      deferred.resolve();
       await vi.advanceTimersByTimeAsync(0);
 
       const response = await pending;
@@ -673,8 +716,16 @@ describe("gateway dispatcher", () => {
         499,
         "request_aborted",
       ]);
-      expect(storeContext?.signal.aborted).toBe(true);
+      const retryBody = createObservedBody();
+      const retry = await fixture.dispatch(
+        createRequest(fixture, { body: retryBody.body, token })
+      );
+      expect([retry.status, responseCode(retry)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
       expect(body.wasRead()).toBe(false);
+      expect(retryBody.wasRead()).toBe(false);
       expect(execute).not.toHaveBeenCalled();
       expect(vi.getTimerCount()).toBe(0);
     } finally {
@@ -724,26 +775,39 @@ describe("gateway dispatcher", () => {
     }
   });
 
-  it("aborts a stalled replay store through its cooperative signal", async () => {
+  it("allows replay accounting to commit after caller abort before returning 499", async () => {
     vi.useFakeTimers();
+    const deferred = createDeferred();
     let replayContext: ControlPlaneOperationContext | undefined;
+    let consumed = false;
     const replayDefense: ReplayDefense = {
       consume(_entry, _nowSeconds, context) {
         replayContext = context;
-        return new Promise<void>(() => undefined);
+        if (consumed) throw new ReplayDefenseError("replay_detected");
+        return deferred.promise.then(() => {
+          consumed = true;
+        });
       },
     };
     const execute = vi.fn();
     const body = createObservedBody();
     try {
       const fixture = createFixture({ execute, replayDefense });
+      const token = issueToken(fixture);
       const controller = new AbortController();
       const pending = fixture.dispatch(
-        createRequest(fixture, { body: body.body, signal: controller.signal })
+        createRequest(fixture, {
+          body: body.body,
+          signal: controller.signal,
+          token,
+        })
       );
       await vi.advanceTimersByTimeAsync(0);
       expect(replayContext).toBeDefined();
       controller.abort(SECRET_CANARY);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(replayContext?.signal.aborted).toBe(false);
+      deferred.resolve();
       await vi.advanceTimersByTimeAsync(0);
 
       const response = await pending;
@@ -751,9 +815,154 @@ describe("gateway dispatcher", () => {
         499,
         "request_aborted",
       ]);
+      const retryBody = createObservedBody();
+      const retry = await fixture.dispatch(
+        createRequest(fixture, { body: retryBody.body, token })
+      );
+      expect([retry.status, responseCode(retry)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+      expect(body.wasRead()).toBe(false);
+      expect(retryBody.wasRead()).toBe(false);
+      expect(execute).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("completes replay after an ambiguous rate timeout despite caller abort", async () => {
+    vi.useFakeTimers();
+    const replayCommit = createDeferred();
+    let replayContext: ControlPlaneOperationContext | undefined;
+    let consumed = false;
+    const replayDefense: ReplayDefense = {
+      consume(_entry, _nowSeconds, context) {
+        replayContext = context;
+        if (consumed) throw new ReplayDefenseError("replay_detected");
+        return replayCommit.promise.then(() => {
+          consumed = true;
+        });
+      },
+    };
+    const execute = vi.fn();
+    const body = createObservedBody();
+    try {
+      const fixture = createFixture({
+        execute,
+        rateBudgetTimeoutMs: 25,
+        rateConsume: () => new Promise<void>(() => undefined),
+        replayDefense,
+        replayDefenseTimeoutMs: 100,
+      });
+      const token = issueToken(fixture);
+      const controller = new AbortController();
+      const pending = fixture.dispatch(
+        createRequest(fixture, {
+          body: body.body,
+          signal: controller.signal,
+          token,
+        })
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(replayContext).toBeDefined();
+      controller.abort(SECRET_CANARY);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(replayContext?.signal.aborted).toBe(false);
+      replayCommit.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const response = await pending;
+      expect([response.status, responseCode(response)]).toEqual([
+        503,
+        "rate_limit_unavailable",
+      ]);
+      expect(body.wasRead()).toBe(false);
+      expect(execute).not.toHaveBeenCalled();
+
+      const retryBody = createObservedBody();
+      const retryPending = fixture.dispatch(
+        createRequest(fixture, { body: retryBody.body, token })
+      );
+      await vi.advanceTimersByTimeAsync(25);
+      const retry = await retryPending;
+      expect([retry.status, responseCode(retry)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+      expect(retryBody.wasRead()).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives replay unavailability precedence and honors a durable late commit", async () => {
+    vi.useFakeTimers();
+    const replayCommit = createDeferred();
+    let replayContext: ControlPlaneOperationContext | undefined;
+    let consumed = false;
+    const replayDefense: ReplayDefense = {
+      consume(_entry, _nowSeconds, context) {
+        replayContext = context;
+        if (consumed) throw new ReplayDefenseError("replay_detected");
+        return replayCommit.promise.then(() => {
+          consumed = true;
+        });
+      },
+    };
+    const execute = vi.fn();
+    const body = createObservedBody();
+    try {
+      const fixture = createFixture({
+        execute,
+        rateBudgetTimeoutMs: 25,
+        rateConsume: () => new Promise<void>(() => undefined),
+        replayDefense,
+        replayDefenseTimeoutMs: 25,
+      });
+      const token = issueToken(fixture);
+      const controller = new AbortController();
+      const pending = fixture.dispatch(
+        createRequest(fixture, {
+          body: body.body,
+          signal: controller.signal,
+          token,
+        })
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(replayContext).toBeDefined();
+      controller.abort(SECRET_CANARY);
+      expect(replayContext?.signal.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(25);
+
+      const response = await pending;
+      expect([response.status, responseCode(response)]).toEqual([
+        503,
+        "replay_defense_unavailable",
+      ]);
       expect(replayContext?.signal.aborted).toBe(true);
       expect(body.wasRead()).toBe(false);
       expect(execute).not.toHaveBeenCalled();
+
+      // A durable store may commit after its response deadline. The attached
+      // observer records that completion, and recovery rejects the exact token.
+      replayCommit.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      const retryBody = createObservedBody();
+      const retryPending = fixture.dispatch(
+        createRequest(fixture, { body: retryBody.body, token })
+      );
+      await vi.advanceTimersByTimeAsync(25);
+      const retry = await retryPending;
+      expect([retry.status, responseCode(retry)]).toEqual([
+        401,
+        "unauthorized",
+      ]);
+      expect(retryBody.wasRead()).toBe(false);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();

--- a/services/agent-gateway/dispatcher.ts
+++ b/services/agent-gateway/dispatcher.ts
@@ -1,12 +1,18 @@
 import {
+  awaitControlPlaneOperation,
+  type ControlPlaneOperationContext,
+} from "./control-plane.ts";
+import {
   type AuthenticatedInternalAssertion,
   authenticateInternalAssertion,
   type Clock,
+  DEFAULT_REPLAY_DEFENSE_TIMEOUT_MS,
   type ExpectedAssertionContext,
   GATEWAY_OPERATIONS,
   type GatewayOperation,
   type InternalAssertionClaims,
   InternalAssertionError,
+  MAX_REPLAY_DEFENSE_TIMEOUT_MS,
   type ReplayDefense,
   type VerificationKeys,
   verifyAuthenticatedInternalAssertion,
@@ -15,10 +21,12 @@ import {
 const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
 const DEFAULT_MAX_BODY_CHUNKS = 256;
 const DEFAULT_BODY_READ_TIMEOUT_MS = 5_000;
+const DEFAULT_RATE_BUDGET_TIMEOUT_MS = 1_000;
 const DEFAULT_EXECUTION_TIMEOUT_MS = 30_000;
 const MAX_BODY_BYTES = 1024 * 1_024;
 const MAX_BODY_CHUNKS = 4_096;
 const MAX_BODY_READ_TIMEOUT_MS = 30_000;
+const MAX_CONTROL_PLANE_TIMEOUT_MS = 10_000;
 const MAX_EXECUTION_TIMEOUT_MS = 5 * 60_000;
 const BODY_CLEANUP_GRACE_MS = 25;
 
@@ -41,6 +49,7 @@ type GatewayErrorCode =
   | "payload_too_large"
   | "rate_limit_unavailable"
   | "rate_limited"
+  | "replay_defense_unavailable"
   | "request_aborted"
   | "request_timeout"
   | "unauthorized"
@@ -77,7 +86,10 @@ type RateBudgetAttempt = Readonly<{
 }>;
 
 interface RateBudget {
-  consume(attempt: RateBudgetAttempt): void | Promise<void>;
+  consume(
+    attempt: RateBudgetAttempt,
+    context?: ControlPlaneOperationContext
+  ): void | Promise<void>;
 }
 
 type RateBudgetErrorCode = "exhausted" | "unavailable";
@@ -157,6 +169,8 @@ type GatewayDispatcherOptions = Readonly<{
   maxBodyChunks?: number;
   bodyReadTimeoutMs?: number;
   executionTimeoutMs?: number;
+  rateBudgetTimeoutMs?: number;
+  replayDefenseTimeoutMs?: number;
 }>;
 
 type GatewayDispatcher = (
@@ -185,6 +199,10 @@ function createGatewayDispatcher(
   const maxBodyChunks = options.maxBodyChunks ?? DEFAULT_MAX_BODY_CHUNKS;
   const bodyReadTimeoutMs =
     options.bodyReadTimeoutMs ?? DEFAULT_BODY_READ_TIMEOUT_MS;
+  const rateBudgetTimeoutMs =
+    options.rateBudgetTimeoutMs ?? DEFAULT_RATE_BUDGET_TIMEOUT_MS;
+  const replayDefenseTimeoutMs =
+    options.replayDefenseTimeoutMs ?? DEFAULT_REPLAY_DEFENSE_TIMEOUT_MS;
   const executionTimeoutMs =
     options.executionTimeoutMs ?? DEFAULT_EXECUTION_TIMEOUT_MS;
   assertDispatcherConfiguration(
@@ -192,6 +210,8 @@ function createGatewayDispatcher(
     maxBodyBytes,
     maxBodyChunks,
     bodyReadTimeoutMs,
+    rateBudgetTimeoutMs,
+    replayDefenseTimeoutMs,
     executionTimeoutMs
   );
   const configuredOptions = snapshotDispatcherOptions(options);
@@ -224,7 +244,11 @@ function createGatewayDispatcher(
       return errorResponse("unauthorized");
     }
 
-    const rateFailure = await consumeRateBudget(configuredOptions);
+    const rateFailure = await consumeRateBudget(
+      configuredOptions,
+      rateBudgetTimeoutMs,
+      request.signal
+    );
 
     let claims: InternalAssertionClaims;
     try {
@@ -234,8 +258,22 @@ function createGatewayDispatcher(
         clock: configuredOptions.clock,
         expected: configuredOptions.expected,
         replayDefense: configuredOptions.replayDefense,
+        replayDefenseTimeoutMs,
+        signal: request.signal,
       });
     } catch (error) {
+      if (
+        error instanceof InternalAssertionError &&
+        error.code === "assertion_verification_aborted"
+      ) {
+        return errorResponse("request_aborted");
+      }
+      if (
+        error instanceof InternalAssertionError &&
+        error.code === "replay_defense_unavailable"
+      ) {
+        return errorResponse("replay_defense_unavailable");
+      }
       if (
         error instanceof InternalAssertionError &&
         error.code === "internal_auth_configuration_invalid"
@@ -311,6 +349,8 @@ function assertDispatcherConfiguration(
   maxBodyBytes: number,
   maxBodyChunks: number,
   bodyReadTimeoutMs: number,
+  rateBudgetTimeoutMs: number,
+  replayDefenseTimeoutMs: number,
   executionTimeoutMs: number
 ): void {
   if (
@@ -325,6 +365,10 @@ function assertDispatcherConfiguration(
     maxBodyChunks > MAX_BODY_CHUNKS ||
     !isPositiveSafeInteger(bodyReadTimeoutMs) ||
     bodyReadTimeoutMs > MAX_BODY_READ_TIMEOUT_MS ||
+    !isPositiveSafeInteger(rateBudgetTimeoutMs) ||
+    rateBudgetTimeoutMs > MAX_CONTROL_PLANE_TIMEOUT_MS ||
+    !isPositiveSafeInteger(replayDefenseTimeoutMs) ||
+    replayDefenseTimeoutMs > MAX_REPLAY_DEFENSE_TIMEOUT_MS ||
     !isPositiveSafeInteger(executionTimeoutMs) ||
     executionTimeoutMs > MAX_EXECUTION_TIMEOUT_MS
   ) {
@@ -561,16 +605,26 @@ function readOperationInput(body: unknown): unknown {
 
 /** Attempts the endpoint's atomic owner/global budget and fails closed. */
 async function consumeRateBudget(
-  options: GatewayDispatcherOptions
-): Promise<"rate_limited" | "rate_limit_unavailable" | undefined> {
-  try {
-    await options.rateBudget.consume(rateAttempt(options));
-    return undefined;
-  } catch (error) {
-    return error instanceof RateBudgetError && error.code === "exhausted"
+  options: GatewayDispatcherOptions,
+  timeoutMs: number,
+  requestSignal: AbortSignal | undefined
+): Promise<
+  "rate_limited" | "rate_limit_unavailable" | "request_aborted" | undefined
+> {
+  const outcome = await awaitControlPlaneOperation(
+    (context) => options.rateBudget.consume(rateAttempt(options), context),
+    timeoutMs,
+    requestSignal
+  );
+  if (outcome.status === "aborted") return "request_aborted";
+  if (outcome.status === "timed_out") return "rate_limit_unavailable";
+  if (outcome.status === "rejected") {
+    return outcome.error instanceof RateBudgetError &&
+      outcome.error.code === "exhausted"
       ? "rate_limited"
       : "rate_limit_unavailable";
   }
+  return undefined;
 }
 
 /** Builds the immutable budget key exclusively from server-authenticated data. */
@@ -655,6 +709,7 @@ function errorResponse(code: GatewayErrorCode): GatewayResponse {
     payload_too_large: 413,
     rate_limit_unavailable: 503,
     rate_limited: 429,
+    replay_defense_unavailable: 503,
     request_aborted: 499,
     request_timeout: 504,
     unauthorized: 401,
@@ -694,6 +749,8 @@ export {
   DEFAULT_EXECUTION_TIMEOUT_MS,
   DEFAULT_MAX_BODY_BYTES,
   DEFAULT_MAX_BODY_CHUNKS,
+  DEFAULT_RATE_BUDGET_TIMEOUT_MS,
+  DEFAULT_REPLAY_DEFENSE_TIMEOUT_MS,
   type GatewayDispatcher,
   type GatewayDispatcherOptions,
   type GatewayErrorBody,
@@ -707,6 +764,7 @@ export {
   MAX_BODY_BYTES,
   MAX_BODY_CHUNKS,
   MAX_BODY_READ_TIMEOUT_MS,
+  MAX_CONTROL_PLANE_TIMEOUT_MS,
   MAX_EXECUTION_TIMEOUT_MS,
   type OperationExecutionContext,
   type RateBudget,

--- a/services/agent-gateway/dispatcher.ts
+++ b/services/agent-gateway/dispatcher.ts
@@ -244,10 +244,12 @@ function createGatewayDispatcher(
       return errorResponse("unauthorized");
     }
 
+    // Signature authentication is the point of no cancellation for accounting.
+    // Caller disconnect is recorded on the request signal and checked only after
+    // independent bounded rate and replay mutations finish.
     const rateFailure = await consumeRateBudget(
       configuredOptions,
-      rateBudgetTimeoutMs,
-      request.signal
+      rateBudgetTimeoutMs
     );
 
     let claims: InternalAssertionClaims;
@@ -259,15 +261,8 @@ function createGatewayDispatcher(
         expected: configuredOptions.expected,
         replayDefense: configuredOptions.replayDefense,
         replayDefenseTimeoutMs,
-        signal: request.signal,
       });
     } catch (error) {
-      if (
-        error instanceof InternalAssertionError &&
-        error.code === "assertion_verification_aborted"
-      ) {
-        return errorResponse("request_aborted");
-      }
       if (
         error instanceof InternalAssertionError &&
         error.code === "replay_defense_unavailable"
@@ -284,6 +279,9 @@ function createGatewayDispatcher(
     }
     if (rateFailure) {
       return errorResponse(rateFailure);
+    }
+    if (request.signal?.aborted) {
+      return errorResponse("request_aborted");
     }
 
     try {
@@ -606,17 +604,13 @@ function readOperationInput(body: unknown): unknown {
 /** Attempts the endpoint's atomic owner/global budget and fails closed. */
 async function consumeRateBudget(
   options: GatewayDispatcherOptions,
-  timeoutMs: number,
-  requestSignal: AbortSignal | undefined
-): Promise<
-  "rate_limited" | "rate_limit_unavailable" | "request_aborted" | undefined
-> {
+  timeoutMs: number
+): Promise<"rate_limited" | "rate_limit_unavailable" | undefined> {
   const outcome = await awaitControlPlaneOperation(
     (context) => options.rateBudget.consume(rateAttempt(options), context),
-    timeoutMs,
-    requestSignal
+    timeoutMs
   );
-  if (outcome.status === "aborted") return "request_aborted";
+  if (outcome.status === "aborted") return "rate_limit_unavailable";
   if (outcome.status === "timed_out") return "rate_limit_unavailable";
   if (outcome.status === "rejected") {
     return outcome.error instanceof RateBudgetError &&

--- a/services/agent-gateway/dispatcher.ts
+++ b/services/agent-gateway/dispatcher.ts
@@ -1,0 +1,608 @@
+import {
+  type AssertionErrorCode,
+  type Clock,
+  type ExpectedAssertionContext,
+  GATEWAY_OPERATIONS,
+  type GatewayOperation,
+  type InternalAssertionClaims,
+  InternalAssertionError,
+  type ReplayDefense,
+  type VerificationKeys,
+  verifyInternalAssertion,
+} from "./internal-auth.ts";
+
+const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
+const DEFAULT_EXECUTION_TIMEOUT_MS = 30_000;
+const MAX_BODY_BYTES = 1024 * 1_024;
+const MAX_EXECUTION_TIMEOUT_MS = 5 * 60_000;
+
+const AUTHENTICATED_ASSERTION_FAILURES = new Set<AssertionErrorCode>([
+  "assertion_expired",
+  "assertion_from_future",
+  "assertion_lifetime_invalid",
+  "audience_mismatch",
+  "connection_mismatch",
+  "issuer_mismatch",
+  "noncanonical_assertion",
+  "operation_mismatch",
+  "provider_mismatch",
+  "replay_defense_unavailable",
+  "replay_detected",
+  "request_id_mismatch",
+  "subject_mismatch",
+  "unsupported_assertion_version",
+]);
+
+type GatewayHeaderValue = string | readonly string[] | undefined;
+
+type GatewayRequestEnvelope = Readonly<{
+  method: string;
+  path: string;
+  headers: Readonly<Record<string, GatewayHeaderValue>>;
+  body: AsyncIterable<Uint8Array>;
+  signal?: AbortSignal;
+}>;
+
+type GatewayErrorCode =
+  | "gateway_configuration_unavailable"
+  | "invalid_request"
+  | "method_not_allowed"
+  | "not_found"
+  | "operation_failed"
+  | "payload_too_large"
+  | "rate_limit_unavailable"
+  | "rate_limited"
+  | "request_aborted"
+  | "request_timeout"
+  | "unauthorized"
+  | "unsupported_media_type";
+
+type GatewayErrorBody = Readonly<{
+  ok: false;
+  error: Readonly<{ code: GatewayErrorCode }>;
+}>;
+
+type GatewaySuccessBody = Readonly<{
+  ok: true;
+  data: unknown;
+}>;
+
+type GatewayResponse = Readonly<{
+  status: number;
+  headers: Readonly<Record<string, string>>;
+  body: GatewayErrorBody | GatewaySuccessBody;
+}>;
+
+type RateBudgetPolicy = Readonly<{
+  endpoint: string;
+  ownerLimit: number;
+  globalLimit: number;
+  windowSeconds: number;
+}>;
+
+type RateBudgetAttempt = Readonly<{
+  ownerSubject: string;
+  connectionId: string;
+  requestId: string;
+  policy: RateBudgetPolicy;
+}>;
+
+interface RateBudget {
+  consume(attempt: RateBudgetAttempt): void | Promise<void>;
+}
+
+type RateBudgetErrorCode = "exhausted" | "unavailable";
+
+/** Typed rate-store rejection whose implementation details never reach clients. */
+class RateBudgetError extends Error {
+  readonly code: RateBudgetErrorCode;
+
+  constructor(code: RateBudgetErrorCode) {
+    super("Gateway rate budget rejected the request");
+    this.name = "RateBudgetError";
+    this.code = code;
+  }
+}
+
+type OperationExecutionContext = Readonly<{
+  claims: InternalAssertionClaims;
+  signal: AbortSignal;
+}>;
+
+type CodexOperationDefinition = Readonly<{
+  operation: GatewayOperation;
+  parseInput: (input: unknown) => unknown;
+  execute: (
+    input: unknown,
+    context: OperationExecutionContext
+  ) => unknown | Promise<unknown>;
+}>;
+
+/** Immutable server-owned operation lookup; transport input cannot mutate it. */
+class CodexOperationRegistry {
+  private readonly definitions: ReadonlyMap<
+    GatewayOperation,
+    CodexOperationDefinition
+  >;
+
+  constructor(definitions: readonly CodexOperationDefinition[]) {
+    const entries = new Map<GatewayOperation, CodexOperationDefinition>();
+    for (const definition of definitions) {
+      if (!GATEWAY_OPERATIONS.includes(definition.operation)) {
+        throw configurationError();
+      }
+      if (entries.has(definition.operation)) {
+        throw configurationError();
+      }
+      entries.set(definition.operation, Object.freeze({ ...definition }));
+    }
+    if (entries.size === 0) {
+      throw configurationError();
+    }
+    this.definitions = entries;
+    Object.freeze(this);
+  }
+
+  /** Resolves only a compile-time gateway operation selected by server policy. */
+  get(operation: GatewayOperation): CodexOperationDefinition | undefined {
+    return this.definitions.get(operation);
+  }
+}
+
+type GatewayRoute = Readonly<{
+  method: "POST";
+  path: `/${string}`;
+  operation: GatewayOperation;
+  rateBudget: RateBudgetPolicy;
+}>;
+
+type GatewayDispatcherOptions = Readonly<{
+  route: GatewayRoute;
+  expected: ExpectedAssertionContext;
+  clock: Clock;
+  replayDefense: ReplayDefense;
+  verificationKeys: VerificationKeys;
+  rateBudget: RateBudget;
+  operationRegistry: CodexOperationRegistry;
+  maxBodyBytes?: number;
+  executionTimeoutMs?: number;
+}>;
+
+type GatewayDispatcher = (
+  request: GatewayRequestEnvelope
+) => Promise<GatewayResponse>;
+
+/** Internal control-flow failure that is always rendered from a fixed code map. */
+class GatewayRequestError extends Error {
+  readonly code: GatewayErrorCode;
+
+  constructor(code: GatewayErrorCode) {
+    super("Gateway request was rejected");
+    this.name = "GatewayRequestError";
+    this.code = code;
+  }
+}
+
+/**
+ * Creates one deployment-neutral dispatcher for an exact server-owned route and
+ * authorization context. The returned function never throws request failures.
+ */
+function createGatewayDispatcher(
+  options: GatewayDispatcherOptions
+): GatewayDispatcher {
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  const executionTimeoutMs =
+    options.executionTimeoutMs ?? DEFAULT_EXECUTION_TIMEOUT_MS;
+  assertDispatcherConfiguration(options, maxBodyBytes, executionTimeoutMs);
+  const configuredOptions = snapshotDispatcherOptions(options);
+
+  return async (request: GatewayRequestEnvelope): Promise<GatewayResponse> => {
+    if (request.path !== configuredOptions.route.path) {
+      return errorResponse("not_found");
+    }
+    if (request.method !== configuredOptions.route.method) {
+      return errorResponse("method_not_allowed");
+    }
+    if (request.signal?.aborted) {
+      return errorResponse("request_aborted");
+    }
+
+    const assertion = readBearerAssertion(request.headers);
+    let claims: InternalAssertionClaims;
+    try {
+      claims = await verifyInternalAssertion(assertion, {
+        clock: configuredOptions.clock,
+        expected: configuredOptions.expected,
+        replayDefense: configuredOptions.replayDefense,
+        verificationKeys: configuredOptions.verificationKeys,
+      });
+    } catch (error) {
+      // The verifier reaches these codes only after signature authentication.
+      // Charge the trusted, server-resolved owner without revealing whether the
+      // signed context or the budget was the reason for denial.
+      if (
+        error instanceof InternalAssertionError &&
+        AUTHENTICATED_ASSERTION_FAILURES.has(error.code)
+      ) {
+        await consumeRejectedAttempt(configuredOptions);
+      }
+      if (
+        error instanceof InternalAssertionError &&
+        error.code === "internal_auth_configuration_invalid"
+      ) {
+        return errorResponse("gateway_configuration_unavailable");
+      }
+      return errorResponse("unauthorized");
+    }
+
+    const rateFailure = await consumeRateBudget(configuredOptions);
+    if (rateFailure) {
+      return errorResponse(rateFailure);
+    }
+
+    try {
+      assertJsonContentType(request.headers);
+      const body = await readJsonBody(
+        request.body,
+        request.headers,
+        maxBodyBytes
+      );
+      const operationInput = readOperationInput(body);
+      const definition = configuredOptions.operationRegistry.get(
+        configuredOptions.route.operation
+      );
+      if (!definition) {
+        throw new GatewayRequestError("gateway_configuration_unavailable");
+      }
+
+      let parsedInput: unknown;
+      try {
+        parsedInput = definition.parseInput(operationInput);
+      } catch {
+        throw new GatewayRequestError("invalid_request");
+      }
+
+      const data = await executeWithCancellation(
+        definition,
+        parsedInput,
+        claims,
+        request.signal,
+        executionTimeoutMs
+      );
+      return successResponse(data);
+    } catch (error) {
+      if (error instanceof GatewayRequestError) {
+        return errorResponse(error.code);
+      }
+      return errorResponse("operation_failed");
+    }
+  };
+}
+
+/** Snapshots caller-owned policy objects so later mutation cannot alter routing. */
+function snapshotDispatcherOptions(
+  options: GatewayDispatcherOptions
+): GatewayDispatcherOptions {
+  return Object.freeze({
+    ...options,
+    expected: Object.freeze({ ...options.expected }),
+    route: Object.freeze({
+      ...options.route,
+      rateBudget: Object.freeze({ ...options.route.rateBudget }),
+    }),
+    verificationKeys: Object.freeze({ ...options.verificationKeys }),
+  });
+}
+
+/** Validates all startup policy before accepting a request. */
+function assertDispatcherConfiguration(
+  options: GatewayDispatcherOptions,
+  maxBodyBytes: number,
+  executionTimeoutMs: number
+): void {
+  if (
+    options.route.path.length < 2 ||
+    options.route.path.includes("?") ||
+    options.route.operation !== options.expected.operation ||
+    options.expected.provider !== "codex" ||
+    !options.operationRegistry.get(options.route.operation) ||
+    !isPositiveSafeInteger(maxBodyBytes) ||
+    maxBodyBytes > MAX_BODY_BYTES ||
+    !isPositiveSafeInteger(executionTimeoutMs) ||
+    executionTimeoutMs > MAX_EXECUTION_TIMEOUT_MS
+  ) {
+    throw configurationError();
+  }
+
+  const policy = options.route.rateBudget;
+  if (
+    policy.endpoint.length === 0 ||
+    policy.endpoint.length > 128 ||
+    !isPositiveSafeInteger(policy.ownerLimit) ||
+    !isPositiveSafeInteger(policy.globalLimit) ||
+    !isPositiveSafeInteger(policy.windowSeconds)
+  ) {
+    throw configurationError();
+  }
+}
+
+/** Reads exactly one canonical Bearer credential without accepting duplicates. */
+function readBearerAssertion(
+  headers: Readonly<Record<string, GatewayHeaderValue>>
+): string | undefined {
+  const authorization = readSingletonHeader(headers, "authorization");
+  if (!authorization) {
+    return undefined;
+  }
+  const match = /^Bearer ([A-Za-z0-9._-]+)$/.exec(authorization);
+  return match?.[1];
+}
+
+/** Requires the one media type supported by this JSON-only dispatcher. */
+function assertJsonContentType(
+  headers: Readonly<Record<string, GatewayHeaderValue>>
+): void {
+  if (readSingletonHeader(headers, "content-type") !== "application/json") {
+    throw new GatewayRequestError("unsupported_media_type");
+  }
+}
+
+/** Returns one case-insensitive scalar header and rejects ambiguous values. */
+function readSingletonHeader(
+  headers: Readonly<Record<string, GatewayHeaderValue>>,
+  requestedName: string
+): string | undefined {
+  const matches = Object.entries(headers).filter(
+    ([name]) => name.toLowerCase() === requestedName
+  );
+  if (matches.length !== 1) {
+    return undefined;
+  }
+  const value = matches[0][1];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Reads a bounded byte stream completely before decoding or parsing JSON. */
+async function readJsonBody(
+  body: AsyncIterable<Uint8Array>,
+  headers: Readonly<Record<string, GatewayHeaderValue>>,
+  maxBodyBytes: number
+): Promise<unknown> {
+  const declaredLength = readContentLength(headers);
+  if (declaredLength !== undefined && declaredLength > maxBodyBytes) {
+    throw new GatewayRequestError("payload_too_large");
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    for await (const chunk of body) {
+      if (!(chunk instanceof Uint8Array)) {
+        throw new GatewayRequestError("invalid_request");
+      }
+      if (chunk.byteLength > maxBodyBytes - totalBytes) {
+        throw new GatewayRequestError("payload_too_large");
+      }
+      totalBytes += chunk.byteLength;
+      chunks.push(chunk);
+    }
+  } catch (error) {
+    if (error instanceof GatewayRequestError) throw error;
+    throw new GatewayRequestError("invalid_request");
+  }
+  if (declaredLength !== undefined && declaredLength !== totalBytes) {
+    throw new GatewayRequestError("invalid_request");
+  }
+
+  try {
+    const bytes = Buffer.concat(
+      chunks.map((chunk) =>
+        Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+      ),
+      totalBytes
+    );
+    const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return JSON.parse(json) as unknown;
+  } catch {
+    throw new GatewayRequestError("invalid_request");
+  }
+}
+
+/** Parses an optional, exact decimal content length without coercion. */
+function readContentLength(
+  headers: Readonly<Record<string, GatewayHeaderValue>>
+): number | undefined {
+  const matchingNames = Object.keys(headers).filter(
+    (name) => name.toLowerCase() === "content-length"
+  );
+  const value = readSingletonHeader(headers, "content-length");
+  if (value === undefined) {
+    if (matchingNames.length > 0) {
+      throw new GatewayRequestError("invalid_request");
+    }
+    return undefined;
+  }
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw new GatewayRequestError("invalid_request");
+  }
+  const length = Number(value);
+  if (!Number.isSafeInteger(length)) {
+    throw new GatewayRequestError("invalid_request");
+  }
+  return length;
+}
+
+/** Accepts only `{ input }`, preventing body-level policy or registry override. */
+function readOperationInput(body: unknown): unknown {
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    Array.isArray(body) ||
+    Object.getPrototypeOf(body) !== Object.prototype
+  ) {
+    throw new GatewayRequestError("invalid_request");
+  }
+  const record = body as Record<string, unknown>;
+  if (Object.keys(record).length !== 1 || !("input" in record)) {
+    throw new GatewayRequestError("invalid_request");
+  }
+  return record.input;
+}
+
+/** Attempts the endpoint's atomic owner/global budget and fails closed. */
+async function consumeRateBudget(
+  options: GatewayDispatcherOptions
+): Promise<"rate_limited" | "rate_limit_unavailable" | undefined> {
+  try {
+    await options.rateBudget.consume(rateAttempt(options));
+    return undefined;
+  } catch (error) {
+    return error instanceof RateBudgetError && error.code === "exhausted"
+      ? "rate_limited"
+      : "rate_limit_unavailable";
+  }
+}
+
+/** Charges a signed rejected attempt while preserving its unauthorized result. */
+async function consumeRejectedAttempt(
+  options: GatewayDispatcherOptions
+): Promise<void> {
+  try {
+    await options.rateBudget.consume(rateAttempt(options));
+  } catch {
+    // The request already fails closed as unauthorized. Suppress store details
+    // and avoid turning rate state into an authentication oracle.
+  }
+}
+
+/** Builds the immutable budget key exclusively from server-authenticated data. */
+function rateAttempt(options: GatewayDispatcherOptions): RateBudgetAttempt {
+  return {
+    ownerSubject: options.expected.subject,
+    connectionId: options.expected.connectionId,
+    requestId: options.expected.requestId,
+    policy: options.route.rateBudget,
+  };
+}
+
+/** Hands execution an abort signal and bounds how long dispatch awaits it. */
+async function executeWithCancellation(
+  definition: CodexOperationDefinition,
+  input: unknown,
+  claims: InternalAssertionClaims,
+  requestSignal: AbortSignal | undefined,
+  timeoutMs: number
+): Promise<unknown> {
+  if (requestSignal?.aborted) {
+    throw new GatewayRequestError("request_aborted");
+  }
+
+  const executionController = new AbortController();
+  return new Promise<unknown>((resolve, reject) => {
+    let settled = false;
+    const finish = (action: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      requestSignal?.removeEventListener("abort", handleRequestAbort);
+      action();
+    };
+    const handleRequestAbort = (): void => {
+      executionController.abort();
+      finish(() => reject(new GatewayRequestError("request_aborted")));
+    };
+    const timeout = setTimeout(() => {
+      executionController.abort();
+      finish(() => reject(new GatewayRequestError("request_timeout")));
+    }, timeoutMs);
+    requestSignal?.addEventListener("abort", handleRequestAbort, {
+      once: true,
+    });
+    // Abort may race the initial check and listener registration. Recheck after
+    // attachment so the operation never starts with a missed caller abort.
+    if (requestSignal?.aborted) {
+      handleRequestAbort();
+      return;
+    }
+
+    Promise.resolve()
+      .then(() =>
+        definition.execute(input, {
+          claims,
+          signal: executionController.signal,
+        })
+      )
+      .then(
+        (result) => finish(() => resolve(result)),
+        () => finish(() => reject(new GatewayRequestError("operation_failed")))
+      );
+  });
+}
+
+/** Maps one stable code to a fixed status without reflecting exception text. */
+function errorResponse(code: GatewayErrorCode): GatewayResponse {
+  const statusByCode: Readonly<Record<GatewayErrorCode, number>> = {
+    gateway_configuration_unavailable: 503,
+    invalid_request: 400,
+    method_not_allowed: 405,
+    not_found: 404,
+    operation_failed: 502,
+    payload_too_large: 413,
+    rate_limit_unavailable: 503,
+    rate_limited: 429,
+    request_aborted: 499,
+    request_timeout: 504,
+    unauthorized: 401,
+    unsupported_media_type: 415,
+  };
+  return {
+    status: statusByCode[code],
+    headers: { "content-type": "application/json" },
+    body: { ok: false, error: { code } },
+  };
+}
+
+/** Creates the single successful response shape used by the transport adapter. */
+function successResponse(data: unknown): GatewayResponse {
+  return {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    body: { ok: true, data },
+  };
+}
+
+/** Produces a stable startup error without embedding policy values. */
+function configurationError(): GatewayRequestError {
+  return new GatewayRequestError("gateway_configuration_unavailable");
+}
+
+/** Recognizes positive bounded integer configuration values. */
+function isPositiveSafeInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+export {
+  type CodexOperationDefinition,
+  CodexOperationRegistry,
+  createGatewayDispatcher,
+  DEFAULT_EXECUTION_TIMEOUT_MS,
+  DEFAULT_MAX_BODY_BYTES,
+  type GatewayDispatcher,
+  type GatewayDispatcherOptions,
+  type GatewayErrorBody,
+  type GatewayErrorCode,
+  type GatewayHeaderValue,
+  type GatewayRequestEnvelope,
+  GatewayRequestError,
+  type GatewayResponse,
+  type GatewayRoute,
+  type GatewaySuccessBody,
+  MAX_BODY_BYTES,
+  MAX_EXECUTION_TIMEOUT_MS,
+  type OperationExecutionContext,
+  type RateBudget,
+  type RateBudgetAttempt,
+  RateBudgetError,
+  type RateBudgetErrorCode,
+  type RateBudgetPolicy,
+};

--- a/services/agent-gateway/dispatcher.ts
+++ b/services/agent-gateway/dispatcher.ts
@@ -1,5 +1,6 @@
 import {
-  type AssertionErrorCode,
+  type AuthenticatedInternalAssertion,
+  authenticateInternalAssertion,
   type Clock,
   type ExpectedAssertionContext,
   GATEWAY_OPERATIONS,
@@ -8,30 +9,18 @@ import {
   InternalAssertionError,
   type ReplayDefense,
   type VerificationKeys,
-  verifyInternalAssertion,
+  verifyAuthenticatedInternalAssertion,
 } from "./internal-auth.ts";
 
 const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
+const DEFAULT_MAX_BODY_CHUNKS = 256;
+const DEFAULT_BODY_READ_TIMEOUT_MS = 5_000;
 const DEFAULT_EXECUTION_TIMEOUT_MS = 30_000;
 const MAX_BODY_BYTES = 1024 * 1_024;
+const MAX_BODY_CHUNKS = 4_096;
+const MAX_BODY_READ_TIMEOUT_MS = 30_000;
 const MAX_EXECUTION_TIMEOUT_MS = 5 * 60_000;
-
-const AUTHENTICATED_ASSERTION_FAILURES = new Set<AssertionErrorCode>([
-  "assertion_expired",
-  "assertion_from_future",
-  "assertion_lifetime_invalid",
-  "audience_mismatch",
-  "connection_mismatch",
-  "issuer_mismatch",
-  "noncanonical_assertion",
-  "operation_mismatch",
-  "provider_mismatch",
-  "replay_defense_unavailable",
-  "replay_detected",
-  "request_id_mismatch",
-  "subject_mismatch",
-  "unsupported_assertion_version",
-]);
+const BODY_CLEANUP_GRACE_MS = 25;
 
 type GatewayHeaderValue = string | readonly string[] | undefined;
 
@@ -165,6 +154,8 @@ type GatewayDispatcherOptions = Readonly<{
   rateBudget: RateBudget;
   operationRegistry: CodexOperationRegistry;
   maxBodyBytes?: number;
+  maxBodyChunks?: number;
+  bodyReadTimeoutMs?: number;
   executionTimeoutMs?: number;
 }>;
 
@@ -191,9 +182,18 @@ function createGatewayDispatcher(
   options: GatewayDispatcherOptions
 ): GatewayDispatcher {
   const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  const maxBodyChunks = options.maxBodyChunks ?? DEFAULT_MAX_BODY_CHUNKS;
+  const bodyReadTimeoutMs =
+    options.bodyReadTimeoutMs ?? DEFAULT_BODY_READ_TIMEOUT_MS;
   const executionTimeoutMs =
     options.executionTimeoutMs ?? DEFAULT_EXECUTION_TIMEOUT_MS;
-  assertDispatcherConfiguration(options, maxBodyBytes, executionTimeoutMs);
+  assertDispatcherConfiguration(
+    options,
+    maxBodyBytes,
+    maxBodyChunks,
+    bodyReadTimeoutMs,
+    executionTimeoutMs
+  );
   const configuredOptions = snapshotDispatcherOptions(options);
 
   return async (request: GatewayRequestEnvelope): Promise<GatewayResponse> => {
@@ -208,24 +208,13 @@ function createGatewayDispatcher(
     }
 
     const assertion = readBearerAssertion(request.headers);
-    let claims: InternalAssertionClaims;
+    let authenticated: AuthenticatedInternalAssertion;
     try {
-      claims = await verifyInternalAssertion(assertion, {
-        clock: configuredOptions.clock,
-        expected: configuredOptions.expected,
-        replayDefense: configuredOptions.replayDefense,
-        verificationKeys: configuredOptions.verificationKeys,
-      });
+      authenticated = authenticateInternalAssertion(
+        assertion,
+        configuredOptions.verificationKeys
+      );
     } catch (error) {
-      // The verifier reaches these codes only after signature authentication.
-      // Charge the trusted, server-resolved owner without revealing whether the
-      // signed context or the budget was the reason for denial.
-      if (
-        error instanceof InternalAssertionError &&
-        AUTHENTICATED_ASSERTION_FAILURES.has(error.code)
-      ) {
-        await consumeRejectedAttempt(configuredOptions);
-      }
       if (
         error instanceof InternalAssertionError &&
         error.code === "internal_auth_configuration_invalid"
@@ -236,6 +225,25 @@ function createGatewayDispatcher(
     }
 
     const rateFailure = await consumeRateBudget(configuredOptions);
+
+    let claims: InternalAssertionClaims;
+    try {
+      // Budget charging is intentionally between signature authentication and
+      // all parsing, canonical, temporal, replay, and context validation.
+      claims = await verifyAuthenticatedInternalAssertion(authenticated, {
+        clock: configuredOptions.clock,
+        expected: configuredOptions.expected,
+        replayDefense: configuredOptions.replayDefense,
+      });
+    } catch (error) {
+      if (
+        error instanceof InternalAssertionError &&
+        error.code === "internal_auth_configuration_invalid"
+      ) {
+        return errorResponse("gateway_configuration_unavailable");
+      }
+      return errorResponse("unauthorized");
+    }
     if (rateFailure) {
       return errorResponse(rateFailure);
     }
@@ -245,7 +253,10 @@ function createGatewayDispatcher(
       const body = await readJsonBody(
         request.body,
         request.headers,
-        maxBodyBytes
+        maxBodyBytes,
+        maxBodyChunks,
+        bodyReadTimeoutMs,
+        request.signal
       );
       const operationInput = readOperationInput(body);
       const definition = configuredOptions.operationRegistry.get(
@@ -298,6 +309,8 @@ function snapshotDispatcherOptions(
 function assertDispatcherConfiguration(
   options: GatewayDispatcherOptions,
   maxBodyBytes: number,
+  maxBodyChunks: number,
+  bodyReadTimeoutMs: number,
   executionTimeoutMs: number
 ): void {
   if (
@@ -308,6 +321,10 @@ function assertDispatcherConfiguration(
     !options.operationRegistry.get(options.route.operation) ||
     !isPositiveSafeInteger(maxBodyBytes) ||
     maxBodyBytes > MAX_BODY_BYTES ||
+    !isPositiveSafeInteger(maxBodyChunks) ||
+    maxBodyChunks > MAX_BODY_CHUNKS ||
+    !isPositiveSafeInteger(bodyReadTimeoutMs) ||
+    bodyReadTimeoutMs > MAX_BODY_READ_TIMEOUT_MS ||
     !isPositiveSafeInteger(executionTimeoutMs) ||
     executionTimeoutMs > MAX_EXECUTION_TIMEOUT_MS
   ) {
@@ -366,19 +383,78 @@ function readSingletonHeader(
 async function readJsonBody(
   body: AsyncIterable<Uint8Array>,
   headers: Readonly<Record<string, GatewayHeaderValue>>,
-  maxBodyBytes: number
+  maxBodyBytes: number,
+  maxBodyChunks: number,
+  bodyReadTimeoutMs: number,
+  requestSignal: AbortSignal | undefined
 ): Promise<unknown> {
   const declaredLength = readContentLength(headers);
   if (declaredLength !== undefined && declaredLength > maxBodyBytes) {
     throw new GatewayRequestError("payload_too_large");
   }
 
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
+  if (requestSignal?.aborted) {
+    throw new GatewayRequestError("request_aborted");
+  }
+
+  let iterator: AsyncIterator<Uint8Array>;
   try {
-    for await (const chunk of body) {
+    iterator = body[Symbol.asyncIterator]();
+    if (typeof iterator.next !== "function") {
+      throw new GatewayRequestError("invalid_request");
+    }
+  } catch (error) {
+    if (error instanceof GatewayRequestError) throw error;
+    throw new GatewayRequestError("invalid_request");
+  }
+
+  const chunks: Uint8Array[] = [];
+  let chunkCount = 0;
+  let completed = false;
+  let totalBytes = 0;
+  let rejectCancellation: ((error: GatewayRequestError) => void) | undefined;
+  const cancellation = new Promise<never>((_resolve, reject) => {
+    rejectCancellation = reject;
+  });
+  const handleAbort = (): void => {
+    rejectCancellation?.(new GatewayRequestError("request_aborted"));
+  };
+  requestSignal?.addEventListener("abort", handleAbort, { once: true });
+  const timeout = setTimeout(() => {
+    rejectCancellation?.(new GatewayRequestError("request_timeout"));
+  }, bodyReadTimeoutMs);
+
+  try {
+    if (requestSignal?.aborted) handleAbort();
+    while (true) {
+      let result: IteratorResult<Uint8Array>;
+      try {
+        result = await Promise.race([
+          Promise.resolve().then(() => iterator.next()),
+          cancellation,
+        ]);
+      } catch (error) {
+        if (error instanceof GatewayRequestError) throw error;
+        throw new GatewayRequestError("invalid_request");
+      }
+      if (typeof result !== "object" || result === null) {
+        throw new GatewayRequestError("invalid_request");
+      }
+      if (result.done) {
+        completed = true;
+        break;
+      }
+
+      const chunk = result.value;
       if (!(chunk instanceof Uint8Array)) {
         throw new GatewayRequestError("invalid_request");
+      }
+      if (chunk.byteLength === 0) {
+        throw new GatewayRequestError("invalid_request");
+      }
+      chunkCount += 1;
+      if (chunkCount > maxBodyChunks) {
+        throw new GatewayRequestError("payload_too_large");
       }
       if (chunk.byteLength > maxBodyBytes - totalBytes) {
         throw new GatewayRequestError("payload_too_large");
@@ -389,6 +465,10 @@ async function readJsonBody(
   } catch (error) {
     if (error instanceof GatewayRequestError) throw error;
     throw new GatewayRequestError("invalid_request");
+  } finally {
+    clearTimeout(timeout);
+    requestSignal?.removeEventListener("abort", handleAbort);
+    if (!completed) await closeBodyIterator(iterator);
   }
   if (declaredLength !== undefined && declaredLength !== totalBytes) {
     throw new GatewayRequestError("invalid_request");
@@ -405,6 +485,36 @@ async function readJsonBody(
     return JSON.parse(json) as unknown;
   } catch {
     throw new GatewayRequestError("invalid_request");
+  }
+}
+
+/** Requests iterator cleanup without allowing a hostile return hook to hang. */
+async function closeBodyIterator(
+  iterator: AsyncIterator<Uint8Array>
+): Promise<void> {
+  let returnMethod: AsyncIterator<Uint8Array>["return"];
+  try {
+    returnMethod = iterator.return;
+  } catch {
+    return;
+  }
+  if (typeof returnMethod !== "function") return;
+  let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const cleanup = Promise.resolve()
+      .then(() => returnMethod.call(iterator))
+      .then(
+        () => undefined,
+        () => undefined
+      );
+    await Promise.race([
+      cleanup,
+      new Promise<void>((resolve) => {
+        cleanupTimer = setTimeout(resolve, BODY_CLEANUP_GRACE_MS);
+      }),
+    ]);
+  } finally {
+    if (cleanupTimer !== undefined) clearTimeout(cleanupTimer);
   }
 }
 
@@ -463,18 +573,6 @@ async function consumeRateBudget(
   }
 }
 
-/** Charges a signed rejected attempt while preserving its unauthorized result. */
-async function consumeRejectedAttempt(
-  options: GatewayDispatcherOptions
-): Promise<void> {
-  try {
-    await options.rateBudget.consume(rateAttempt(options));
-  } catch {
-    // The request already fails closed as unauthorized. Suppress store details
-    // and avoid turning rate state into an authentication oracle.
-  }
-}
-
 /** Builds the immutable budget key exclusively from server-authenticated data. */
 function rateAttempt(options: GatewayDispatcherOptions): RateBudgetAttempt {
   return {
@@ -508,12 +606,16 @@ async function executeWithCancellation(
       action();
     };
     const handleRequestAbort = (): void => {
-      executionController.abort();
-      finish(() => reject(new GatewayRequestError("request_aborted")));
+      finish(() => {
+        executionController.abort();
+        reject(new GatewayRequestError("request_aborted"));
+      });
     };
     const timeout = setTimeout(() => {
-      executionController.abort();
-      finish(() => reject(new GatewayRequestError("request_timeout")));
+      finish(() => {
+        executionController.abort();
+        reject(new GatewayRequestError("request_timeout"));
+      });
     }, timeoutMs);
     requestSignal?.addEventListener("abort", handleRequestAbort, {
       once: true,
@@ -526,12 +628,15 @@ async function executeWithCancellation(
     }
 
     Promise.resolve()
-      .then(() =>
-        definition.execute(input, {
+      .then(() => {
+        // Abort and timeout may settle while this microtask is queued. Never
+        // cross the execution boundary after either terminal outcome.
+        if (settled) return;
+        return definition.execute(input, {
           claims,
           signal: executionController.signal,
-        })
-      )
+        });
+      })
       .then(
         (result) => finish(() => resolve(result)),
         () => finish(() => reject(new GatewayRequestError("operation_failed")))
@@ -585,8 +690,10 @@ export {
   type CodexOperationDefinition,
   CodexOperationRegistry,
   createGatewayDispatcher,
+  DEFAULT_BODY_READ_TIMEOUT_MS,
   DEFAULT_EXECUTION_TIMEOUT_MS,
   DEFAULT_MAX_BODY_BYTES,
+  DEFAULT_MAX_BODY_CHUNKS,
   type GatewayDispatcher,
   type GatewayDispatcherOptions,
   type GatewayErrorBody,
@@ -598,6 +705,8 @@ export {
   type GatewayRoute,
   type GatewaySuccessBody,
   MAX_BODY_BYTES,
+  MAX_BODY_CHUNKS,
+  MAX_BODY_READ_TIMEOUT_MS,
   MAX_EXECUTION_TIMEOUT_MS,
   type OperationExecutionContext,
   type RateBudget,

--- a/services/agent-gateway/internal-auth.test.ts
+++ b/services/agent-gateway/internal-auth.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync, sign as signBytes } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
 import {
+  authenticateInternalAssertion,
   BoundedReplayCache,
   type Clock,
   type ExpectedAssertionContext,
@@ -12,6 +13,7 @@ import {
   type ReplayDefense,
   type SigningKey,
   type VerificationKeys,
+  verifyAuthenticatedInternalAssertion,
   verifyInternalAssertion,
 } from "./internal-auth.ts";
 
@@ -164,6 +166,74 @@ async function captureAssertionError(
 }
 
 describe("internal gateway assertions", () => {
+  it("stages configured-key authentication before strict payload validation", async () => {
+    const fixture = createFixture();
+    const token = issueToken(fixture);
+    const [encodedHeader, encodedClaims] = token.split(".");
+    const claims = JSON.parse(
+      Buffer.from(encodedClaims, "base64url").toString("utf8")
+    ) as Record<string, unknown>;
+    const noncanonicalClaims = Buffer.from(
+      JSON.stringify(claims, null, 2)
+    ).toString("base64url");
+    const signedNoncanonical = signEncodedAssertion(
+      encodedHeader,
+      noncanonicalClaims,
+      fixture.current.signing
+    );
+
+    const authenticated = authenticateInternalAssertion(
+      signedNoncanonical,
+      fixture.verificationKeys
+    );
+    await expectCode(
+      () =>
+        verifyAuthenticatedInternalAssertion(authenticated, {
+          clock: fixture.clock,
+          expected: fixture.expected,
+          replayDefense: new BoundedReplayCache(4),
+        }),
+      "noncanonical_assertion"
+    );
+
+    // Even copying every enumerable field and hidden symbol from a real stage
+    // cannot mint another signature-authenticated object identity.
+    const forged = { ...authenticated };
+    await expectCode(
+      () =>
+        verifyAuthenticatedInternalAssertion(forged, {
+          clock: fixture.clock,
+          expected: fixture.expected,
+          replayDefense: new BoundedReplayCache(4),
+        }),
+      "invalid_assertion"
+    );
+  });
+
+  it("does not create an authenticated stage for unknown or tampered signatures", async () => {
+    const fixture = createFixture();
+    const unknown = createKeyPair("unknown-key");
+    const unknownToken = issueToken(fixture, {}, unknown.signing);
+    await expectCode(
+      () =>
+        authenticateInternalAssertion(unknownToken, fixture.verificationKeys),
+      "invalid_signature"
+    );
+
+    const token = issueToken(fixture);
+    const [header, claims, signature] = token.split(".");
+    const bytes = Buffer.from(signature, "base64url");
+    bytes[0] ^= 0x01;
+    await expectCode(
+      () =>
+        authenticateInternalAssertion(
+          `${header}.${claims}.${bytes.toString("base64url")}`,
+          fixture.verificationKeys
+        ),
+      "invalid_signature"
+    );
+  });
+
   it("issues and verifies the exact Codex-only v1 context", async () => {
     const fixture = createFixture();
     const claims = await verifyToken(fixture, issueToken(fixture));

--- a/services/agent-gateway/internal-auth.ts
+++ b/services/agent-gateway/internal-auth.ts
@@ -108,6 +108,21 @@ type VerifyAssertionOptions = Readonly<{
   verificationKeys: VerificationKeys;
 }>;
 
+type VerifyAuthenticatedAssertionOptions = Omit<
+  VerifyAssertionOptions,
+  "verificationKeys"
+>;
+
+const AUTHENTICATED_ASSERTION_BRAND = Symbol("authenticated assertion");
+const AUTHENTICATED_ASSERTIONS = new WeakSet<object>();
+
+type AuthenticatedInternalAssertion = Readonly<{
+  [AUTHENTICATED_ASSERTION_BRAND]: true;
+  encodedHeader: string;
+  encodedClaims: string;
+  authenticatedKeyIds: readonly string[];
+}>;
+
 type ReplayEntry = Readonly<{
   requestId: string;
   nonce: string;
@@ -271,6 +286,23 @@ async function verifyInternalAssertion(
   token: string | null | undefined,
   options: VerifyAssertionOptions
 ): Promise<InternalAssertionClaims> {
+  const authenticated = authenticateInternalAssertion(
+    token,
+    options.verificationKeys
+  );
+  return verifyAuthenticatedInternalAssertion(authenticated, options);
+}
+
+/**
+ * Proves that the raw assertion bytes were signed by a configured key.
+ *
+ * Parsing is deliberately deferred. A trusted dispatcher may charge its
+ * server-resolved owner after this stage without trusting any unparsed claim.
+ */
+function authenticateInternalAssertion(
+  token: string | null | undefined,
+  verificationKeys: VerificationKeys
+): AuthenticatedInternalAssertion {
   if (!token) {
     throw new InternalAssertionError(
       "missing_assertion",
@@ -295,8 +327,34 @@ async function verifyInternalAssertion(
   const authenticatedKeyIds = authenticateSignature(
     signingInput,
     signature,
-    options.verificationKeys
+    verificationKeys
   );
+
+  const authenticated = Object.freeze({
+    [AUTHENTICATED_ASSERTION_BRAND]: true as const,
+    encodedHeader,
+    encodedClaims,
+    authenticatedKeyIds: Object.freeze([...authenticatedKeyIds]),
+  });
+  AUTHENTICATED_ASSERTIONS.add(authenticated);
+  return authenticated;
+}
+
+/**
+ * Validates authenticated bytes, consumes replay state, then matches context.
+ * Replay consumption remains before every expected-context comparison.
+ */
+async function verifyAuthenticatedInternalAssertion(
+  authenticated: AuthenticatedInternalAssertion,
+  options: VerifyAuthenticatedAssertionOptions
+): Promise<InternalAssertionClaims> {
+  if (
+    authenticated[AUTHENTICATED_ASSERTION_BRAND] !== true ||
+    !AUTHENTICATED_ASSERTIONS.has(authenticated)
+  ) {
+    throw invalidAssertion();
+  }
+  const { authenticatedKeyIds, encodedClaims, encodedHeader } = authenticated;
 
   const header = parseHeader(encodedHeader);
   const claims = parseClaims(encodedClaims);
@@ -646,6 +704,8 @@ function invalidAssertion(): InternalAssertionError {
 export {
   ASSERTION_VERSION,
   type AssertionErrorCode,
+  type AuthenticatedInternalAssertion,
+  authenticateInternalAssertion,
   BoundedReplayCache,
   type Clock,
   type ExpectedAssertionContext,
@@ -664,5 +724,7 @@ export {
   type VerificationKey,
   type VerificationKeys,
   type VerifyAssertionOptions,
+  type VerifyAuthenticatedAssertionOptions,
+  verifyAuthenticatedInternalAssertion,
   verifyInternalAssertion,
 };

--- a/services/agent-gateway/internal-auth.ts
+++ b/services/agent-gateway/internal-auth.ts
@@ -30,7 +30,6 @@ type AssertionErrorCode =
   | "assertion_expired"
   | "assertion_from_future"
   | "assertion_lifetime_invalid"
-  | "assertion_verification_aborted"
   | "audience_mismatch"
   | "connection_mismatch"
   | "internal_auth_configuration_invalid"
@@ -115,7 +114,6 @@ type VerifyAssertionOptions = Readonly<{
   replayDefense: ReplayDefense;
   verificationKeys: VerificationKeys;
   replayDefenseTimeoutMs?: number;
-  signal?: AbortSignal;
 }>;
 
 type VerifyAuthenticatedAssertionOptions = Omit<
@@ -410,14 +408,10 @@ async function verifyAuthenticatedInternalAssertion(
         nowSeconds,
         context
       ),
-    replayDefenseTimeoutMs,
-    options.signal
+    replayDefenseTimeoutMs
   );
   if (replayOutcome.status === "aborted") {
-    throw new InternalAssertionError(
-      "assertion_verification_aborted",
-      "Internal assertion verification was aborted"
-    );
+    throw replayEnforcementError("replay_defense_unavailable");
   }
   if (replayOutcome.status === "timed_out") {
     throw replayEnforcementError("replay_defense_unavailable");

--- a/services/agent-gateway/internal-auth.ts
+++ b/services/agent-gateway/internal-auth.ts
@@ -4,12 +4,19 @@ import {
   verify as verifyBytes,
 } from "node:crypto";
 
+import {
+  awaitControlPlaneOperation,
+  type ControlPlaneOperationContext,
+} from "./control-plane.ts";
+
 const ASSERTION_ALGORITHM = "EdDSA";
 const ASSERTION_TYPE = "sprig-internal-assertion";
 const ASSERTION_VERSION = 1;
 const MAX_ASSERTION_LIFETIME_SECONDS = 60;
 const MAX_ASSERTION_LENGTH = 8_192;
 const MAX_CLAIM_LENGTH = 256;
+const DEFAULT_REPLAY_DEFENSE_TIMEOUT_MS = 1_000;
+const MAX_REPLAY_DEFENSE_TIMEOUT_MS = 10_000;
 
 const GATEWAY_OPERATIONS = [
   "chat",
@@ -23,6 +30,7 @@ type AssertionErrorCode =
   | "assertion_expired"
   | "assertion_from_future"
   | "assertion_lifetime_invalid"
+  | "assertion_verification_aborted"
   | "audience_mismatch"
   | "connection_mismatch"
   | "internal_auth_configuration_invalid"
@@ -106,6 +114,8 @@ type VerifyAssertionOptions = Readonly<{
   expected: ExpectedAssertionContext;
   replayDefense: ReplayDefense;
   verificationKeys: VerificationKeys;
+  replayDefenseTimeoutMs?: number;
+  signal?: AbortSignal;
 }>;
 
 type VerifyAuthenticatedAssertionOptions = Omit<
@@ -130,7 +140,11 @@ type ReplayEntry = Readonly<{
 }>;
 
 interface ReplayDefense {
-  consume(entry: ReplayEntry, nowSeconds: number): void | Promise<void>;
+  consume(
+    entry: ReplayEntry,
+    nowSeconds: number,
+    context?: ControlPlaneOperationContext
+  ): void | Promise<void>;
 }
 
 type ReplayDefenseErrorCode = "replay_defense_unavailable" | "replay_detected";
@@ -370,21 +384,48 @@ async function verifyAuthenticatedInternalAssertion(
   const nowSeconds = readClock(options.clock);
   assertTemporalValidity(claims, nowSeconds);
 
+  const replayDefenseTimeoutMs =
+    options.replayDefenseTimeoutMs ?? DEFAULT_REPLAY_DEFENSE_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(replayDefenseTimeoutMs) ||
+    replayDefenseTimeoutMs <= 0 ||
+    replayDefenseTimeoutMs > MAX_REPLAY_DEFENSE_TIMEOUT_MS
+  ) {
+    throw new InternalAssertionError(
+      "internal_auth_configuration_invalid",
+      "Replay defense timeout is invalid"
+    );
+  }
+
   // State errors are normalized so unavailable custom stores cannot accidentally
   // degrade into accepting a request without replay protection.
-  try {
-    await options.replayDefense.consume(
-      {
-        requestId: claims.requestId,
-        nonce: claims.nonce,
-        expiresAt: claims.exp,
-      },
-      nowSeconds
+  const replayOutcome = await awaitControlPlaneOperation(
+    (context) =>
+      options.replayDefense.consume(
+        {
+          requestId: claims.requestId,
+          nonce: claims.nonce,
+          expiresAt: claims.exp,
+        },
+        nowSeconds,
+        context
+      ),
+    replayDefenseTimeoutMs,
+    options.signal
+  );
+  if (replayOutcome.status === "aborted") {
+    throw new InternalAssertionError(
+      "assertion_verification_aborted",
+      "Internal assertion verification was aborted"
     );
-  } catch (error) {
+  }
+  if (replayOutcome.status === "timed_out") {
+    throw replayEnforcementError("replay_defense_unavailable");
+  }
+  if (replayOutcome.status === "rejected") {
     const code =
-      error instanceof ReplayDefenseError
-        ? error.code
+      replayOutcome.error instanceof ReplayDefenseError
+        ? replayOutcome.error.code
         : "replay_defense_unavailable";
     throw replayEnforcementError(code);
   }
@@ -708,6 +749,7 @@ export {
   authenticateInternalAssertion,
   BoundedReplayCache,
   type Clock,
+  DEFAULT_REPLAY_DEFENSE_TIMEOUT_MS,
   type ExpectedAssertionContext,
   GATEWAY_OPERATIONS,
   type GatewayOperation,
@@ -716,6 +758,7 @@ export {
   type IssueAssertionInput,
   issueInternalAssertion,
   MAX_ASSERTION_LIFETIME_SECONDS,
+  MAX_REPLAY_DEFENSE_TIMEOUT_MS,
   type ReplayDefense,
   ReplayDefenseError,
   type ReplayDefenseErrorCode,


### PR DESCRIPTION
## Feature

Adds a deployment-neutral Codex-first gateway dispatcher around the merged internal assertion boundary. It validates bounded request envelopes, authenticates the signed server-owned context, charges async owner and global budgets, and dispatches only registered Codex operations with abort and timeout handling.

## Architecture

```text
Next.js request
  -> bounded envelope and JSON validation
  -> signed assertion verification and replay consume
  -> persistent owner and global rate budget
  -> server-owned Codex operation registry
  -> abort and timeout aware handler
  -> stable secret-free response
```

The client cannot provide commands, environment variables, model endpoints, filesystem paths, or arbitrary operations. No provider subprocess or network listener is added in this slice.

## Human gates

Persistent hosting, signing-key custody, durable replay and rate stores, provider credentials, listener deployment, and real Codex execution remain human-gated. This PR performs no environment, database, credential, login, or deployment mutation.

## Validation

- Focused dispatcher tests: 28 passed
- Full suite: 599 passed
- Typecheck and formatting passed
- Lint passed with five unrelated existing warnings
- Diff check passed