### PR TITLE
feat(gateway): add Codex device ceremony flow

### DIFF
--- a/docs/architecture/codex-device-ceremony.md
+++ b/docs/architecture/codex-device-ceremony.md
@@ -1,0 +1,68 @@
+# Codex device authorization ceremony
+
+Status: Phase 1 contract only; not a deployable provider integration.
+
+## Boundary
+
+`services/agent-gateway/codex-device-flow.ts` defines a pure coordinator between
+an injected `CodexDeviceClient` and an injected durable
+`CodexDeviceCeremonyStore`. It does not start Codex, log in, read or write a
+home directory, persist credentials, open a listener, call a network service,
+or deploy infrastructure.
+
+```text
+signed gateway request
+        |
+        v
+ begin / poll / cancel
+        |
+        +---- atomic durable transition ---- ceremony record
+        |                                      (server only)
+        v
+ idempotent CodexDeviceClient call
+        |
+        +---- fenced atomic completion ----> safe browser projection
+```
+
+The browser projection is closed by construction. It contains only a
+server-configured official HTTPS verification URL, a short validated user code
+while pending, finite expiry and poll interval, a stable status, and—only after
+authorization—an account type plus `present: true`. Provider session references,
+tokens, raw output, paths, errors, commands, model choices, environment, and
+credential handles never cross that boundary.
+
+## Durable-store contract
+
+The production store must make each method atomic and durable across process
+restarts:
+
+- `reserve` applies expiry, enforces one active ceremony per connection,
+  conceals cross-owner matches, and binds the ceremony to the begin request;
+- `activate` moves only the matching starting record to pending;
+- `preparePoll` applies expiry and grants at most one revision per poll window;
+- `completePoll` accepts a provider result only if that exact revision is still
+  pending, fencing completion after cancellation or expiry; and
+- `cancel` makes the transition terminal and idempotent before provider cleanup.
+
+Every method validates owner, connection, request, and ceremony ID together.
+An absent or mismatched scope is reported only as `not_found`. Store rejection,
+timeout, and ambiguous settlement fail closed; retries recover from the durable
+record instead of guessing whether a transition committed.
+
+The provider `begin` and `cancel` methods must be idempotent by the
+server-generated ceremony ID. This is required because a dependency can commit
+and settle after the caller's deadline. Provider polling must be safe to repeat,
+and every implementation must honor the supplied abort signal and deadline.
+
+## Deferred integration gates
+
+This contract intentionally leaves the following work gated:
+
+1. PR #39's branded Codex-home authority and ownership rules;
+2. a real Codex app-server adapter and verified device-login protocol;
+3. an encrypted durable store for provider session state and final credentials;
+4. persistent-host selection, key custody, backup, and deployment; and
+5. human-authorized live account and recovery testing.
+
+Claude authorization remains deferred. This slice establishes only the
+Codex-first ceremony semantics needed by later transport and UI work.

--- a/docs/architecture/codex-device-ceremony.md
+++ b/docs/architecture/codex-device-ceremony.md
@@ -24,12 +24,20 @@ signed gateway request
         +---- fenced atomic completion ----> safe browser projection
 ```
 
-The browser projection is closed by construction. It contains only a
-server-configured official HTTPS verification URL, a short validated user code
+The browser projection is closed by construction. It contains only an exact
+server-owned URL from the nonempty Codex verification allowlist, a short validated user code
 while pending, finite expiry and poll interval, a stable status, and—only after
 authorization—an account type plus `present: true`. Provider session references,
 tokens, raw output, paths, errors, commands, model choices, environment, and
 credential handles never cross that boundary.
+
+The current allowlist contains exactly
+`https://auth.openai.com/codex/device`. Normalization is not treated as
+authorization: explicit ports, alternate paths, trailing segments, encoded path
+variants, user information, query redirects, fragments, sibling or suffix
+hosts, and internationalized lookalikes are rejected. The device completion
+accepts only an explicit `chatgpt` subscription presence result. Ambient API
+keys and every other credential type fail closed.
 
 ## Durable-store contract
 
@@ -38,28 +46,47 @@ restarts:
 
 - `reserve` applies expiry, enforces one active ceremony per connection,
   conceals cross-owner matches, and binds the ceremony to the begin request;
-- `activate` moves only the matching starting record to pending;
+- `recordBegin` atomically activates the first result and retains every terminal
+  or distinct race-loser session reference as durable cleanup work;
 - `preparePoll` applies expiry and grants at most one revision per poll window;
 - `completePoll` accepts a provider result only if that exact revision is still
   pending, fencing completion after cancellation or expiry; and
-- `cancel` makes the transition terminal and idempotent before provider cleanup.
+- `cancel` makes the transition terminal and appends any active provider session
+  to cleanup work before returning;
+- `claimCleanup` grants one retained reference without deleting it; and
+- `completeCleanup` removes only the exact granted revision after an idempotent
+  provider cancellation succeeds.
 
 Every method validates owner, connection, request, and ceremony ID together.
 An absent or mismatched scope is reported only as `not_found`. Store rejection,
 timeout, and ambiguous settlement fail closed; retries recover from the durable
 record instead of guessing whether a transition committed.
 
-The provider `begin` and `cancel` methods must be idempotent by the
-server-generated ceremony ID. This is required because a dependency can commit
-and settle after the caller's deadline. Provider polling must be safe to repeat,
-and every implementation must honor the supplied abort signal and deadline.
+`reserve` persists a separate server-generated `providerBeginKey` before any
+provider call. Provider `begin` must be atomically idempotent by ceremony ID plus
+that key across processes and restarts. A retry after provider or store timeout
+must recover the same provider session reference. The coordinator defensively
+retains and cleans a distinct race-loser reference, but such a result proves the
+adapter violated its primary serialization contract. Provider `cancel` must be
+idempotent by the same key and reference. Provider polling must be safe to
+repeat, and every implementation must honor the supplied abort signal and
+deadline.
+
+Caller abort ends only the browser wait. It atomically terminalizes the durable
+ceremony while provider settlement continues under an independent bounded
+server deadline. A late session reference is recorded before cleanup is tried.
+Timeout, rejection, process loss, or ambiguous cleanup completion leaves the
+reference durable so a later `cancel` call or worker using the same store
+contract can resume it. No original request signal controls cleanup.
 
 ## Deferred integration gates
 
 This contract intentionally leaves the following work gated:
 
 1. PR #39's branded Codex-home authority and ownership rules;
-2. a real Codex app-server adapter and verified device-login protocol;
+2. a real Codex app-server adapter and verified device-login protocol, including
+   proof of cross-process atomic idempotency/serialization, restart recovery by
+   `providerBeginKey`, and distinct-reference loser cleanup before enablement;
 3. an encrypted durable store for provider session state and final credentials;
 4. persistent-host selection, key custody, backup, and deployment; and
 5. human-authorized live account and recovery testing.

--- a/docs/architecture/codex-device-ceremony.md
+++ b/docs/architecture/codex-device-ceremony.md
@@ -45,7 +45,11 @@ coordinator reads it. The copy uses property descriptors rather than invoking
 getters and rejects accessors, unexpected prototypes or fields, functions,
 cycles, and malformed nested values. Hostile mutation after validation cannot
 change coordinator decisions, and exceptions at either dependency boundary are
-normalized to stable, secret-free unavailable results.
+normalized to stable, secret-free unavailable results. Server-owned limits cap
+array length, own-key cardinality, nesting depth, string size, and a shared
+budget that charges every value and property or array slot. Array length is
+rejected before key enumeration, so sparse claimed lengths cannot induce work
+proportional to attacker-controlled cardinality.
 
 ## Durable-store contract
 

--- a/docs/architecture/codex-device-ceremony.md
+++ b/docs/architecture/codex-device-ceremony.md
@@ -39,6 +39,14 @@ hosts, and internationalized lookalikes are rejected. The device completion
 accepts only an explicit `chatgpt` subscription presence result. Ambient API
 keys and every other credential type fail closed.
 
+Every injected scope, provider result, and store outcome is copied at the
+boundary into a bounded, closed, deeply frozen plain-data snapshot before the
+coordinator reads it. The copy uses property descriptors rather than invoking
+getters and rejects accessors, unexpected prototypes or fields, functions,
+cycles, and malformed nested values. Hostile mutation after validation cannot
+change coordinator decisions, and exceptions at either dependency boundary are
+normalized to stable, secret-free unavailable results.
+
 ## Durable-store contract
 
 The production store must make each method atomic and durable across process
@@ -72,12 +80,25 @@ idempotent by the same key and reference. Provider polling must be safe to
 repeat, and every implementation must honor the supplied abort signal and
 deadline.
 
+The record also persists whether provider begin authority remains unresolved.
+A response deadline aborts the adapter signal but does not discard a later
+fulfilled result: late settlement still enters the atomic `recordBegin` and
+cleanup path under server-owned deadlines. If reference persistence is
+ambiguous or did not commit, a fresh manager, explicit cancel, or cleanup worker
+can retry begin with the durable idempotency key and recover the same session
+authority rather than orphaning it.
+
 Caller abort ends only the browser wait. It atomically terminalizes the durable
 ceremony while provider settlement continues under an independent bounded
 server deadline. A late session reference is recorded before cleanup is tried.
 Timeout, rejection, process loss, or ambiguous cleanup completion leaves the
 reference durable so a later `cancel` call or worker using the same store
 contract can resume it. No original request signal controls cleanup.
+
+Likewise, once an explicit cancel request is authorized, its terminal store
+transition and cleanup fencing use a server-owned deadline. A pre-aborted or
+mid-flight browser signal may end that caller's response wait, but cannot skip,
+abort, or roll back durable cancellation.
 
 ## Deferred integration gates
 

--- a/services/agent-gateway/codex-device-flow.test.ts
+++ b/services/agent-gateway/codex-device-flow.test.ts
@@ -1,0 +1,771 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type CancelCeremonyOutcome,
+  type CodexDeviceCeremonyRecord,
+  type CodexDeviceCeremonyStore,
+  type CodexDeviceClient,
+  type CodexDeviceClientBeginOutcome,
+  type CodexDevicePollCompletion,
+  type CodexDeviceScope,
+  type CompletePollOutcome,
+  createCodexDeviceFlow,
+  type PreparePollOutcome,
+  type ReserveCeremonyOutcome,
+} from "./codex-device-flow.ts";
+import type { ControlPlaneOperationContext } from "./control-plane.ts";
+
+const OFFICIAL_URL = "https://auth.openai.com/codex/device";
+const SECRET_CANARY = "sk-secret-must-never-cross-browser-boundary";
+const OWNER_A: CodexDeviceScope = {
+  ownerId: "owner_a",
+  connectionId: "connection_a",
+  requestId: "request_a",
+};
+
+/** Mutable clock for exact poll and expiry boundary tests. */
+class TestClock {
+  constructor(public nowMilliseconds = 1_900_000_000_000) {}
+
+  advance(milliseconds: number): void {
+    this.nowMilliseconds += milliseconds;
+  }
+}
+
+/** Minimal atomic store model used to exercise the public store contract. */
+class TestCeremonyStore implements CodexDeviceCeremonyStore {
+  readonly records = new Map<string, CodexDeviceCeremonyRecord>();
+
+  async reserve(
+    input: Parameters<CodexDeviceCeremonyStore["reserve"]>[0],
+    _context: ControlPlaneOperationContext
+  ): Promise<ReserveCeremonyOutcome> {
+    for (const [id, record] of Array.from(this.records.entries())) {
+      if (record.connectionId !== input.scope.connectionId) continue;
+      const current = this.expire(record, input.nowMilliseconds);
+      this.records.set(id, current);
+      if (!isActive(current.status)) continue;
+      if (current.ownerId !== input.scope.ownerId) {
+        return { status: "not_found" };
+      }
+      if (current.requestId === input.scope.requestId) {
+        return { status: "same_request", record: current };
+      }
+      return { status: "active_other_request" };
+    }
+    if (this.records.has(input.ceremonyId)) return { status: "id_collision" };
+    const record: CodexDeviceCeremonyRecord = {
+      ceremonyId: input.ceremonyId,
+      ...input.scope,
+      status: "starting",
+      createdAtMilliseconds: input.nowMilliseconds,
+      expiresAtMilliseconds: input.expiresAtMilliseconds,
+      pollIntervalMilliseconds: input.pollIntervalMilliseconds,
+      nextPollAtMilliseconds:
+        input.nowMilliseconds + input.pollIntervalMilliseconds,
+      revision: 1,
+    };
+    this.records.set(input.ceremonyId, record);
+    return { status: "reserved", record };
+  }
+
+  async activate(
+    input: Parameters<CodexDeviceCeremonyStore["activate"]>[0],
+    _context: ControlPlaneOperationContext
+  ) {
+    const record = this.scoped(input.ceremonyId, input.scope);
+    if (!record) return { status: "not_found" } as const;
+    const current = this.expire(record, input.nowMilliseconds);
+    if (current.status !== "starting") {
+      this.records.set(input.ceremonyId, current);
+      return { status: "current", record: current } as const;
+    }
+    const activated: CodexDeviceCeremonyRecord = {
+      ...current,
+      status: "pending",
+      userCode: input.userCode,
+      providerSessionRef: input.providerSessionRef,
+      revision: current.revision + 1,
+    };
+    this.records.set(input.ceremonyId, activated);
+    return { status: "activated", record: activated } as const;
+  }
+
+  async preparePoll(
+    input: Parameters<CodexDeviceCeremonyStore["preparePoll"]>[0],
+    _context: ControlPlaneOperationContext
+  ): Promise<PreparePollOutcome> {
+    const record = this.scoped(input.ceremonyId, input.scope);
+    if (!record) return { status: "not_found" };
+    const current = this.expire(record, input.nowMilliseconds);
+    this.records.set(input.ceremonyId, current);
+    if (
+      current.status !== "pending" ||
+      input.nowMilliseconds < current.nextPollAtMilliseconds ||
+      !current.providerSessionRef
+    ) {
+      return { status: "current", record: current };
+    }
+    const granted: CodexDeviceCeremonyRecord = {
+      ...current,
+      nextPollAtMilliseconds:
+        input.nowMilliseconds + current.pollIntervalMilliseconds,
+      revision: current.revision + 1,
+    };
+    this.records.set(input.ceremonyId, granted);
+    return {
+      status: "granted",
+      record: granted,
+      pollRevision: granted.revision,
+      providerSessionRef: current.providerSessionRef,
+    };
+  }
+
+  async completePoll(
+    input: Parameters<CodexDeviceCeremonyStore["completePoll"]>[0],
+    _context: ControlPlaneOperationContext
+  ): Promise<CompletePollOutcome> {
+    const record = this.scoped(input.ceremonyId, input.scope);
+    if (!record) return { status: "not_found" };
+    const current = this.expire(record, input.nowMilliseconds);
+    if (
+      current.status !== "pending" ||
+      current.revision !== input.pollRevision
+    ) {
+      this.records.set(input.ceremonyId, current);
+      return { status: "stale", record: current };
+    }
+    const completed = applyCompletion(current, input.completion);
+    this.records.set(input.ceremonyId, completed);
+    return { status: "completed", record: completed };
+  }
+
+  async cancel(
+    input: Parameters<CodexDeviceCeremonyStore["cancel"]>[0],
+    _context: ControlPlaneOperationContext
+  ): Promise<CancelCeremonyOutcome> {
+    const record = this.scoped(input.ceremonyId, input.scope);
+    if (!record) return { status: "not_found" };
+    const current = this.expire(record, input.nowMilliseconds);
+    if (!isActive(current.status)) {
+      this.records.set(input.ceremonyId, current);
+      return {
+        status: "current",
+        record: current,
+        providerSessionRef: current.providerSessionRef,
+      };
+    }
+    const cancelled: CodexDeviceCeremonyRecord = {
+      ...current,
+      status: "cancelled",
+      revision: current.revision + 1,
+    };
+    this.records.set(input.ceremonyId, cancelled);
+    return {
+      status: "cancelled",
+      record: cancelled,
+      providerSessionRef: current.providerSessionRef,
+    };
+  }
+
+  /** Returns a record only when every caller-bound scope component matches. */
+  private scoped(
+    ceremonyId: string,
+    scope: CodexDeviceScope
+  ): CodexDeviceCeremonyRecord | undefined {
+    const record = this.records.get(ceremonyId);
+    return record &&
+      record.ownerId === scope.ownerId &&
+      record.connectionId === scope.connectionId &&
+      record.requestId === scope.requestId
+      ? record
+      : undefined;
+  }
+
+  /** Applies expiry atomically before any other transition. */
+  private expire(
+    record: CodexDeviceCeremonyRecord,
+    nowMilliseconds: number
+  ): CodexDeviceCeremonyRecord {
+    return isActive(record.status) &&
+      nowMilliseconds >= record.expiresAtMilliseconds
+      ? { ...record, status: "expired", revision: record.revision + 1 }
+      : record;
+  }
+}
+
+/** Deterministic injected provider with fully shaped, server-only results. */
+class TestDeviceClient implements CodexDeviceClient {
+  readonly begin = vi.fn<CodexDeviceClient["begin"]>(
+    async (_input, _context): Promise<CodexDeviceClientBeginOutcome> => ({
+      providerSessionRef: `provider-session-${SECRET_CANARY}`,
+      userCode: "ABCD-1234",
+    })
+  );
+  readonly poll = vi.fn<CodexDeviceClient["poll"]>(
+    async (_input, _context): Promise<CodexDevicePollCompletion> => ({
+      status: "pending",
+    })
+  );
+  readonly cancel = vi.fn<CodexDeviceClient["cancel"]>(
+    async (_input, _context): Promise<void> => undefined
+  );
+}
+
+/** Creates one coordinator fixture without ambient provider or durable state. */
+function createFixture(
+  overrides: Partial<{
+    client: TestDeviceClient;
+    store: CodexDeviceCeremonyStore;
+    timeout: number;
+    verificationUrl: string;
+  }> = {}
+) {
+  const clock = new TestClock();
+  const store = overrides.store ?? new TestCeremonyStore();
+  const client = overrides.client ?? new TestDeviceClient();
+  let identifier = 0;
+  const flow = createCodexDeviceFlow({
+    client,
+    store,
+    officialVerificationUrl: overrides.verificationUrl ?? OFFICIAL_URL,
+    ceremonyTtlMilliseconds: 60_000,
+    pollIntervalMilliseconds: 5_000,
+    dependencyTimeoutMilliseconds: overrides.timeout ?? 50,
+    now: () => clock.nowMilliseconds,
+    createCeremonyId: () => (++identifier).toString().padStart(32, "A"),
+  });
+  return { client, clock, flow, store };
+}
+
+/** Begins a valid ceremony and narrows its successful result for later steps. */
+async function beginCeremony(fixture: ReturnType<typeof createFixture>) {
+  const result = await fixture.flow.begin(OWNER_A);
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error("expected ceremony");
+  return result.ceremony;
+}
+
+/** Creates a controllable promise for race and late-settlement tests. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+/** Identifies the two nonterminal durable statuses. */
+function isActive(status: CodexDeviceCeremonyRecord["status"]): boolean {
+  return status === "starting" || status === "pending";
+}
+
+/** Applies one validated provider completion to a pending record. */
+function applyCompletion(
+  record: CodexDeviceCeremonyRecord,
+  completion: CodexDevicePollCompletion
+): CodexDeviceCeremonyRecord {
+  if (completion.status === "pending") return record;
+  if (completion.status === "authorized") {
+    return {
+      ...record,
+      status: "authorized",
+      account: completion.account,
+      revision: record.revision + 1,
+    };
+  }
+  return {
+    ...record,
+    status: completion.status,
+    revision: record.revision + 1,
+  };
+}
+
+describe("Codex device ceremony flow", () => {
+  it("returns only the fixed safe browser projection", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+
+    expect(ceremony).toEqual({
+      ceremonyId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+      status: "pending",
+      verificationUrl: `${OFFICIAL_URL}`,
+      expiresAtMilliseconds: fixture.clock.nowMilliseconds + 60_000,
+      pollIntervalMilliseconds: 5_000,
+      userCode: "ABCD-1234",
+    });
+    expect(JSON.stringify(ceremony)).not.toContain(SECRET_CANARY);
+    expect(JSON.stringify(ceremony)).not.toContain("providerSessionRef");
+  });
+
+  it.each([
+    "http://auth.openai.com/device",
+    "https://user:pass@auth.openai.com/device",
+    "https://auth.openai.com/device?token=secret",
+    "https://auth.openai.com/device#secret",
+    "not a url",
+  ])("rejects unsafe server verification URL %s", (verificationUrl) => {
+    expect(() => createFixture({ verificationUrl })).toThrow(
+      /officialVerificationUrl/
+    );
+  });
+
+  it("rejects malformed or over-shaped provider begin output", async () => {
+    const client = new TestDeviceClient();
+    client.begin.mockResolvedValue({
+      providerSessionRef: "session",
+      userCode: "ABCD-1234",
+      token: SECRET_CANARY,
+    } as never);
+    const { flow } = createFixture({ client });
+
+    await expect(flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "invalid_provider_response",
+    });
+  });
+
+  it.each(["a", "lower-code", "ABCD 1234", "A".repeat(17)])(
+    "rejects unsafe user code %s",
+    async (userCode) => {
+      const client = new TestDeviceClient();
+      client.begin.mockResolvedValue({
+        providerSessionRef: "session",
+        userCode,
+      });
+      const { flow } = createFixture({ client });
+      await expect(flow.begin(OWNER_A)).resolves.toEqual({
+        ok: false,
+        error: "invalid_provider_response",
+      });
+    }
+  );
+
+  it("recovers duplicate same-request begin with one ceremony identity", async () => {
+    const fixture = createFixture();
+    const first = await fixture.flow.begin(OWNER_A);
+    const second = await fixture.flow.begin(OWNER_A);
+
+    expect(first).toEqual(second);
+    expect(fixture.client.begin).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when another request races the active connection", async () => {
+    const fixture = createFixture();
+    await beginCeremony(fixture);
+
+    await expect(
+      fixture.flow.begin({ ...OWNER_A, requestId: "request_b" })
+    ).resolves.toEqual({ ok: false, error: "active_ceremony_exists" });
+    expect(fixture.client.begin).toHaveBeenCalledTimes(1);
+  });
+
+  it("conceals a cross-owner begin against an active connection", async () => {
+    const fixture = createFixture();
+    await beginCeremony(fixture);
+
+    await expect(
+      fixture.flow.begin({ ...OWNER_A, ownerId: "owner_b" })
+    ).resolves.toEqual({ ok: false, error: "not_found" });
+    expect(fixture.client.begin).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows concurrent same-request begin only through idempotent ceremony ID", async () => {
+    const client = new TestDeviceClient();
+    const beginGate = deferred<CodexDeviceClientBeginOutcome>();
+    client.begin.mockImplementation(() => beginGate.promise);
+    const fixture = createFixture({ client });
+
+    const first = fixture.flow.begin(OWNER_A);
+    const second = fixture.flow.begin(OWNER_A);
+    await vi.waitFor(() => expect(client.begin).toHaveBeenCalledTimes(2));
+    expect(client.begin.mock.calls[0]?.[0]).toEqual(
+      client.begin.mock.calls[1]?.[0]
+    );
+    beginGate.resolve({
+      providerSessionRef: "same-session",
+      userCode: "WXYZ-7890",
+    });
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult).toEqual(secondResult);
+  });
+
+  it.each([
+    { ownerId: "owner_b" },
+    { connectionId: "connection_b" },
+    { requestId: "request_b" },
+  ])(
+    "conceals scoped records from $ownerId$connectionId$requestId",
+    async (change) => {
+      const fixture = createFixture();
+      const ceremony = await beginCeremony(fixture);
+      const foreignScope = { ...OWNER_A, ...change };
+
+      await expect(
+        fixture.flow.poll(foreignScope, ceremony.ceremonyId)
+      ).resolves.toEqual({ ok: false, error: "not_found" });
+      await expect(
+        fixture.flow.cancel(foreignScope, ceremony.ceremonyId)
+      ).resolves.toEqual({ ok: false, error: "not_found" });
+      expect(fixture.client.poll).not.toHaveBeenCalled();
+      expect(fixture.client.cancel).not.toHaveBeenCalled();
+    }
+  );
+
+  it("conceals guessed and malformed ceremony IDs", async () => {
+    const fixture = createFixture();
+    await beginCeremony(fixture);
+    for (const id of ["B".repeat(32), "../secret", SECRET_CANARY]) {
+      await expect(fixture.flow.poll(OWNER_A, id)).resolves.toEqual({
+        ok: false,
+        error: "not_found",
+      });
+    }
+  });
+
+  it("throttles provider polls at the durable interval", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+
+    await fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    expect(fixture.client.poll).not.toHaveBeenCalled();
+    fixture.clock.advance(5_000);
+    await fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    await fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    expect(fixture.client.poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("projects only strict account type and presence after authorization", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+    fixture.clock.advance(5_000);
+    fixture.client.poll.mockResolvedValue({
+      status: "authorized",
+      account: { type: "chatgpt", present: true },
+    });
+
+    const result = await fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    expect(result).toEqual({
+      ok: true,
+      ceremony: {
+        ceremonyId: ceremony.ceremonyId,
+        status: "authorized",
+        verificationUrl: `${OFFICIAL_URL}`,
+        expiresAtMilliseconds: ceremony.expiresAtMilliseconds,
+        pollIntervalMilliseconds: 5_000,
+        account: { type: "chatgpt", present: true },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+    expect(JSON.stringify(result)).not.toContain("userCode");
+  });
+
+  it("rejects raw or ambiguous authorized account output", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+    fixture.clock.advance(5_000);
+    fixture.client.poll.mockResolvedValue({
+      status: "authorized",
+      account: { type: "chatgpt", present: true, email: SECRET_CANARY },
+    } as never);
+
+    await expect(
+      fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "invalid_provider_response" });
+  });
+
+  it("fails closed instead of projecting corrupted durable fields", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    const record = store.records.get(ceremony.ceremonyId);
+    if (!record) throw new Error("missing durable record");
+    store.records.set(ceremony.ceremonyId, {
+      ...record,
+      userCode: SECRET_CANARY,
+    });
+
+    const result = await fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    expect(result).toEqual({ ok: false, error: "store_unavailable" });
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it("fences delayed authorization after cancellation", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+    const pollGate = deferred<CodexDevicePollCompletion>();
+    fixture.client.poll.mockImplementation(() => pollGate.promise);
+    fixture.clock.advance(5_000);
+
+    const poll = fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    await vi.waitFor(() => expect(fixture.client.poll).toHaveBeenCalledOnce());
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toMatchObject({ ok: true, ceremony: { status: "cancelled" } });
+    pollGate.resolve({
+      status: "authorized",
+      account: { type: "chatgpt", present: true },
+    });
+    await expect(poll).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "cancelled" },
+    });
+  });
+
+  it("fences and cleans up delayed begin after cancellation", async () => {
+    const client = new TestDeviceClient();
+    const beginGate = deferred<CodexDeviceClientBeginOutcome>();
+    client.begin.mockImplementation(() => beginGate.promise);
+    const fixture = createFixture({ client });
+    const begin = fixture.flow.begin(OWNER_A);
+    await vi.waitFor(() => expect(client.begin).toHaveBeenCalledOnce());
+    const ceremonyId = client.begin.mock.calls[0]?.[0].ceremonyId;
+
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremonyId)
+    ).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "cancelled" },
+    });
+    beginGate.resolve({
+      providerSessionRef: "late-provider-session",
+      userCode: "ABCD-1234",
+    });
+    await expect(begin).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "cancelled" },
+    });
+    expect(client.cancel).toHaveBeenCalledWith(
+      { ceremonyId, providerSessionRef: "late-provider-session" },
+      expect.any(Object)
+    );
+  });
+
+  it("fences delayed authorization at the exact expiry boundary", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+    const pollGate = deferred<CodexDevicePollCompletion>();
+    fixture.client.poll.mockImplementation(() => pollGate.promise);
+    fixture.clock.advance(5_000);
+    const poll = fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    await vi.waitFor(() => expect(fixture.client.poll).toHaveBeenCalledOnce());
+    fixture.clock.advance(55_000);
+    pollGate.resolve({
+      status: "authorized",
+      account: { type: "chatgpt", present: true },
+    });
+    await expect(poll).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "expired" },
+    });
+  });
+
+  it("makes repeated cancellation terminal while retrying provider cleanup", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+    const first = await fixture.flow.cancel(OWNER_A, ceremony.ceremonyId);
+    const second = await fixture.flow.cancel(OWNER_A, ceremony.ceremonyId);
+
+    expect(first).toEqual(second);
+    expect(fixture.client.cancel).toHaveBeenCalledTimes(2);
+    expect(fixture.client.cancel.mock.calls[0]?.[0]).toEqual(
+      fixture.client.cancel.mock.calls[1]?.[0]
+    );
+  });
+
+  it.each([
+    ["store", "store_unavailable"],
+    ["provider", "provider_unavailable"],
+  ] as const)(
+    "maps opaque %s failures to a stable unavailable result",
+    async (kind, code) => {
+      const fixture = createFixture();
+      if (kind === "store") {
+        vi.spyOn(fixture.store, "reserve").mockRejectedValue(
+          new Error(SECRET_CANARY)
+        );
+      } else {
+        fixture.client.begin.mockRejectedValue(new Error(SECRET_CANARY));
+      }
+      const result = await fixture.flow.begin(OWNER_A);
+      expect(result).toEqual({ ok: false, error: code });
+      expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+    }
+  );
+
+  it.each(["store", "provider"] as const)(
+    "bounds and aborts stalled %s operations while observing late rejection",
+    async (kind) => {
+      const fixture = createFixture({ timeout: 5 });
+      const gate = deferred<never>();
+      let context: ControlPlaneOperationContext | undefined;
+      if (kind === "store") {
+        vi.spyOn(fixture.store, "reserve").mockImplementation(
+          (_input, value) => {
+            context = value;
+            return gate.promise;
+          }
+        );
+      } else {
+        fixture.client.begin.mockImplementation((_input, value) => {
+          context = value;
+          return gate.promise;
+        });
+      }
+      await expect(fixture.flow.begin(OWNER_A)).resolves.toEqual({
+        ok: false,
+        error: "timed_out",
+      });
+      expect(context?.signal.aborted).toBe(true);
+      gate.reject(new Error(SECRET_CANARY));
+      await Promise.resolve();
+    }
+  );
+
+  it("aborts before calling an injected dependency", async () => {
+    const fixture = createFixture();
+    const controller = new AbortController();
+    controller.abort(SECRET_CANARY);
+    await expect(
+      fixture.flow.begin(OWNER_A, controller.signal)
+    ).resolves.toEqual({
+      ok: false,
+      error: "aborted",
+    });
+    expect(fixture.client.begin).not.toHaveBeenCalled();
+  });
+
+  it("propagates a reason-free abort to an active provider wait", async () => {
+    const fixture = createFixture();
+    const gate = deferred<CodexDeviceClientBeginOutcome>();
+    let context: ControlPlaneOperationContext | undefined;
+    fixture.client.begin.mockImplementation((_input, value) => {
+      context = value;
+      return gate.promise;
+    });
+    const controller = new AbortController();
+    const begin = fixture.flow.begin(OWNER_A, controller.signal);
+    await vi.waitFor(() => expect(fixture.client.begin).toHaveBeenCalledOnce());
+    controller.abort(SECRET_CANARY);
+
+    await expect(begin).resolves.toEqual({ ok: false, error: "aborted" });
+    expect(context?.signal.aborted).toBe(true);
+    expect(context?.signal.reason).not.toBe(SECRET_CANARY);
+    gate.reject(new Error(SECRET_CANARY));
+    await Promise.resolve();
+  });
+
+  it("recovers an ambiguous late reserve on a same-request retry", async () => {
+    const store = new TestCeremonyStore();
+    const originalReserve = store.reserve.bind(store);
+    const gate = deferred<ReserveCeremonyOutcome>();
+    vi.spyOn(store, "reserve").mockImplementationOnce(
+      async (input, context) => {
+        const committed = await originalReserve(input, context);
+        await gate.promise;
+        return committed;
+      }
+    );
+    const fixture = createFixture({ store, timeout: 5 });
+    await expect(fixture.flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "timed_out",
+    });
+    gate.resolve({ status: "id_collision" });
+    const retry = await fixture.flow.begin(OWNER_A);
+    expect(retry).toMatchObject({ ok: true, ceremony: { status: "pending" } });
+  });
+
+  it("recovers an ambiguous activate commit without another provider begin", async () => {
+    const store = new TestCeremonyStore();
+    const originalActivate = store.activate.bind(store);
+    const gate = deferred<void>();
+    vi.spyOn(store, "activate").mockImplementationOnce(
+      async (input, context) => {
+        const committed = await originalActivate(input, context);
+        await gate.promise;
+        return committed;
+      }
+    );
+    const fixture = createFixture({ store, timeout: 5 });
+    await expect(fixture.flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "timed_out",
+    });
+    gate.resolve();
+
+    const retry = await fixture.flow.begin(OWNER_A);
+    expect(retry).toMatchObject({ ok: true, ceremony: { status: "pending" } });
+    expect(fixture.client.begin).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers an ambiguous poll completion from durable authorized state", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store, timeout: 5 });
+    const ceremony = await beginCeremony(fixture);
+    fixture.clock.advance(5_000);
+    fixture.client.poll.mockResolvedValue({
+      status: "authorized",
+      account: { type: "chatgpt", present: true },
+    });
+    const originalComplete = store.completePoll.bind(store);
+    const gate = deferred<void>();
+    vi.spyOn(store, "completePoll").mockImplementationOnce(
+      async (input, context) => {
+        const committed = await originalComplete(input, context);
+        await gate.promise;
+        return committed;
+      }
+    );
+
+    await expect(
+      fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "timed_out" });
+    gate.resolve();
+    await expect(
+      fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "authorized" },
+    });
+    expect(fixture.client.poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers an ambiguous cancellation commit idempotently", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store, timeout: 5 });
+    const ceremony = await beginCeremony(fixture);
+    const originalCancel = store.cancel.bind(store);
+    const gate = deferred<void>();
+    vi.spyOn(store, "cancel").mockImplementationOnce(async (input, context) => {
+      const committed = await originalCancel(input, context);
+      await gate.promise;
+      return committed;
+    });
+
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "timed_out" });
+    gate.resolve();
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "cancelled" },
+    });
+  });
+
+  it("does not accept caller-selected URLs, commands, models, homes, or env", async () => {
+    const fixture = createFixture();
+    await beginCeremony(fixture);
+    const beginInput = fixture.client.begin.mock.calls[0]?.[0];
+    expect(beginInput).toEqual({
+      ceremonyId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+    });
+    expect(JSON.stringify(beginInput)).not.toMatch(
+      /url|command|model|home|env/i
+    );
+  });
+});

--- a/services/agent-gateway/codex-device-flow.test.ts
+++ b/services/agent-gateway/codex-device-flow.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   type CancelCeremonyOutcome,
+  type ClaimCleanupOutcome,
   type CodexDeviceCeremonyRecord,
   type CodexDeviceCeremonyStore,
   type CodexDeviceClient,
   type CodexDeviceClientBeginOutcome,
   type CodexDevicePollCompletion,
   type CodexDeviceScope,
+  type CompleteCleanupOutcome,
   type CompletePollOutcome,
   createCodexDeviceFlow,
   type PreparePollOutcome,
+  type RecordBeginOutcome,
   type ReserveCeremonyOutcome,
 } from "./codex-device-flow.ts";
 import type { ControlPlaneOperationContext } from "./control-plane.ts";
@@ -64,21 +67,34 @@ class TestCeremonyStore implements CodexDeviceCeremonyStore {
       nextPollAtMilliseconds:
         input.nowMilliseconds + input.pollIntervalMilliseconds,
       revision: 1,
+      providerBeginKey: input.providerBeginKey,
+      cleanupSessionRefs: [],
     };
     this.records.set(input.ceremonyId, record);
     return { status: "reserved", record };
   }
 
-  async activate(
-    input: Parameters<CodexDeviceCeremonyStore["activate"]>[0],
+  async recordBegin(
+    input: Parameters<CodexDeviceCeremonyStore["recordBegin"]>[0],
     _context: ControlPlaneOperationContext
-  ) {
+  ): Promise<RecordBeginOutcome> {
     const record = this.scoped(input.ceremonyId, input.scope);
     if (!record) return { status: "not_found" } as const;
+    if (record.providerBeginKey !== input.providerBeginKey) {
+      return { status: "not_found" };
+    }
     const current = this.expire(record, input.nowMilliseconds);
     if (current.status !== "starting") {
-      this.records.set(input.ceremonyId, current);
-      return { status: "current", record: current } as const;
+      if (
+        current.status === "pending" &&
+        current.providerSessionRef === input.providerSessionRef
+      ) {
+        this.records.set(input.ceremonyId, current);
+        return { status: "current", record: current };
+      }
+      const retained = this.retainCleanup(current, input.providerSessionRef);
+      this.records.set(input.ceremonyId, retained);
+      return { status: "recorded", record: retained };
     }
     const activated: CodexDeviceCeremonyRecord = {
       ...current,
@@ -88,7 +104,7 @@ class TestCeremonyStore implements CodexDeviceCeremonyStore {
       revision: current.revision + 1,
     };
     this.records.set(input.ceremonyId, activated);
-    return { status: "activated", record: activated } as const;
+    return { status: "recorded", record: activated };
   }
 
   async preparePoll(
@@ -152,20 +168,63 @@ class TestCeremonyStore implements CodexDeviceCeremonyStore {
       return {
         status: "current",
         record: current,
-        providerSessionRef: current.providerSessionRef,
       };
     }
     const cancelled: CodexDeviceCeremonyRecord = {
       ...current,
       status: "cancelled",
+      cleanupSessionRefs: current.providerSessionRef
+        ? uniqueRefs(current.cleanupSessionRefs, current.providerSessionRef)
+        : current.cleanupSessionRefs,
       revision: current.revision + 1,
     };
     this.records.set(input.ceremonyId, cancelled);
     return {
       status: "cancelled",
       record: cancelled,
-      providerSessionRef: current.providerSessionRef,
     };
+  }
+
+  async claimCleanup(
+    input: Parameters<CodexDeviceCeremonyStore["claimCleanup"]>[0],
+    _context: ControlPlaneOperationContext
+  ): Promise<ClaimCleanupOutcome> {
+    const record = this.scoped(input.ceremonyId, input.scope);
+    if (!record) return { status: "not_found" };
+    const current = this.expire(record, input.nowMilliseconds);
+    this.records.set(input.ceremonyId, current);
+    const providerSessionRef = current.cleanupSessionRefs[0];
+    if (!providerSessionRef) return { status: "current", record: current };
+    return {
+      status: "granted",
+      record: current,
+      cleanupRevision: current.revision,
+      providerBeginKey: current.providerBeginKey,
+      providerSessionRef,
+    };
+  }
+
+  async completeCleanup(
+    input: Parameters<CodexDeviceCeremonyStore["completeCleanup"]>[0],
+    _context: ControlPlaneOperationContext
+  ): Promise<CompleteCleanupOutcome> {
+    const record = this.scoped(input.ceremonyId, input.scope);
+    if (!record) return { status: "not_found" };
+    if (
+      record.revision !== input.cleanupRevision ||
+      !record.cleanupSessionRefs.includes(input.providerSessionRef)
+    ) {
+      return { status: "current", record };
+    }
+    const completed: CodexDeviceCeremonyRecord = {
+      ...record,
+      cleanupSessionRefs: record.cleanupSessionRefs.filter(
+        (value) => value !== input.providerSessionRef
+      ),
+      revision: record.revision + 1,
+    };
+    this.records.set(input.ceremonyId, completed);
+    return { status: "completed", record: completed };
   }
 
   /** Returns a record only when every caller-bound scope component matches. */
@@ -187,11 +246,40 @@ class TestCeremonyStore implements CodexDeviceCeremonyStore {
     record: CodexDeviceCeremonyRecord,
     nowMilliseconds: number
   ): CodexDeviceCeremonyRecord {
-    return isActive(record.status) &&
-      nowMilliseconds >= record.expiresAtMilliseconds
-      ? { ...record, status: "expired", revision: record.revision + 1 }
-      : record;
+    if (
+      !isActive(record.status) ||
+      nowMilliseconds < record.expiresAtMilliseconds
+    ) {
+      return record;
+    }
+    return {
+      ...record,
+      status: "expired",
+      cleanupSessionRefs: record.providerSessionRef
+        ? uniqueRefs(record.cleanupSessionRefs, record.providerSessionRef)
+        : record.cleanupSessionRefs,
+      revision: record.revision + 1,
+    };
   }
+
+  /** Retains each race-loser or terminal provider ref exactly once. */
+  private retainCleanup(
+    record: CodexDeviceCeremonyRecord,
+    providerSessionRef: string
+  ): CodexDeviceCeremonyRecord {
+    const refs = uniqueRefs(record.cleanupSessionRefs, providerSessionRef);
+    return refs === record.cleanupSessionRefs
+      ? record
+      : { ...record, cleanupSessionRefs: refs, revision: record.revision + 1 };
+  }
+}
+
+/** Appends one cleanup ref without duplicating an idempotent retry. */
+function uniqueRefs(
+  values: readonly string[],
+  value: string
+): readonly string[] {
+  return values.includes(value) ? values : [...values, value];
 }
 
 /** Deterministic injected provider with fully shaped, server-only results. */
@@ -225,6 +313,7 @@ function createFixture(
   const store = overrides.store ?? new TestCeremonyStore();
   const client = overrides.client ?? new TestDeviceClient();
   let identifier = 0;
+  let providerKey = 0;
   const flow = createCodexDeviceFlow({
     client,
     store,
@@ -234,6 +323,7 @@ function createFixture(
     dependencyTimeoutMilliseconds: overrides.timeout ?? 50,
     now: () => clock.nowMilliseconds,
     createCeremonyId: () => (++identifier).toString().padStart(32, "A"),
+    createProviderBeginKey: () => (++providerKey).toString().padStart(32, "K"),
   });
   return { client, clock, flow, store };
 }
@@ -279,6 +369,9 @@ function applyCompletion(
   return {
     ...record,
     status: completion.status,
+    cleanupSessionRefs: record.providerSessionRef
+      ? uniqueRefs(record.cleanupSessionRefs, record.providerSessionRef)
+      : record.cleanupSessionRefs,
     revision: record.revision + 1,
   };
 }
@@ -305,6 +398,21 @@ describe("Codex device ceremony flow", () => {
     "https://user:pass@auth.openai.com/device",
     "https://auth.openai.com/device?token=secret",
     "https://auth.openai.com/device#secret",
+    "https://evil.example/phish",
+    "https://auth.openai.com.evil.example/codex/device",
+    "https://xn--openai-9za.example/codex/device",
+    "https://auth.openаi.com/codex/device",
+    "https://auth.openai.com\\@evil.example/codex/device",
+    "https://auth.openai.com:444/codex/device",
+    "https://auth.openai.com:443/codex/device",
+    "https://auth.openai.com/codex/device/",
+    "https://auth.openai.com/codex/other",
+    "https://auth.openai.com/codex%2Fdevice",
+    "https://auth.openai.com/codex/device%2Fredirect",
+    "https://auth.openai.com/codex/%2e%2e/device",
+    `https://auth.openai.com/codex/device?next=${encodeURIComponent(
+      "https://evil.example"
+    )}`,
     "not a url",
   ])("rejects unsafe server verification URL %s", (verificationUrl) => {
     expect(() => createFixture({ verificationUrl })).toThrow(
@@ -323,9 +431,22 @@ describe("Codex device ceremony flow", () => {
 
     await expect(flow.begin(OWNER_A)).resolves.toEqual({
       ok: false,
-      error: "invalid_provider_response",
+      error: "provider_unavailable",
     });
   });
+
+  it.each([null, undefined, {}, { providerSessionRef: "session" }])(
+    "fails closed for malformed provider begin envelope %#",
+    async (malformed) => {
+      const client = new TestDeviceClient();
+      client.begin.mockResolvedValue(malformed as never);
+      const { flow } = createFixture({ client });
+      await expect(flow.begin(OWNER_A)).resolves.toEqual({
+        ok: false,
+        error: "provider_unavailable",
+      });
+    }
+  );
 
   it.each(["a", "lower-code", "ABCD 1234", "A".repeat(17)])(
     "rejects unsafe user code %s",
@@ -338,7 +459,7 @@ describe("Codex device ceremony flow", () => {
       const { flow } = createFixture({ client });
       await expect(flow.begin(OWNER_A)).resolves.toEqual({
         ok: false,
-        error: "invalid_provider_response",
+        error: "provider_unavailable",
       });
     }
   );
@@ -473,7 +594,54 @@ describe("Codex device ceremony flow", () => {
 
     await expect(
       fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
-    ).resolves.toEqual({ ok: false, error: "invalid_provider_response" });
+    ).resolves.toEqual({ ok: false, error: "provider_unavailable" });
+  });
+
+  it("rejects ambient API-key presence as a subscription authorization", async () => {
+    const fixture = createFixture();
+    const ceremony = await beginCeremony(fixture);
+    fixture.clock.advance(5_000);
+    fixture.client.poll.mockResolvedValue({
+      status: "authorized",
+      account: { type: "api_key", present: true },
+    } as never);
+
+    const result = await fixture.flow.poll(OWNER_A, ceremony.ceremonyId);
+    expect(result).toEqual({ ok: false, error: "provider_unavailable" });
+    expect(JSON.stringify(result)).not.toContain("api_key");
+  });
+
+  it.each([
+    null,
+    undefined,
+    {},
+    { status: "authorized" },
+    { status: "mystery" },
+  ])(
+    "fails closed for malformed provider poll envelope %#",
+    async (malformed) => {
+      const fixture = createFixture();
+      const ceremony = await beginCeremony(fixture);
+      fixture.clock.advance(5_000);
+      fixture.client.poll.mockResolvedValue(malformed as never);
+      await expect(
+        fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
+      ).resolves.toEqual({ ok: false, error: "provider_unavailable" });
+    }
+  );
+
+  it("keeps cleanup pending when provider cancel fulfills with a malformed value", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    fixture.client.cancel.mockResolvedValue({ secret: SECRET_CANARY } as never);
+
+    const result = await fixture.flow.cancel(OWNER_A, ceremony.ceremonyId);
+    expect(result).toEqual({ ok: false, error: "provider_unavailable" });
+    expect(store.records.get(ceremony.ceremonyId)?.cleanupSessionRefs).toEqual([
+      `provider-session-${SECRET_CANARY}`,
+    ]);
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
   });
 
   it("fails closed instead of projecting corrupted durable fields", async () => {
@@ -538,9 +706,118 @@ describe("Codex device ceremony flow", () => {
       ceremony: { status: "cancelled" },
     });
     expect(client.cancel).toHaveBeenCalledWith(
-      { ceremonyId, providerSessionRef: "late-provider-session" },
+      {
+        ceremonyId,
+        providerBeginKey: "KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK1",
+        providerSessionRef: "late-provider-session",
+      },
       expect.any(Object)
     );
+  });
+
+  it("retains and cleans a delayed begin result after exact expiry", async () => {
+    const client = new TestDeviceClient();
+    const beginGate = deferred<CodexDeviceClientBeginOutcome>();
+    client.begin.mockImplementation(() => beginGate.promise);
+    const fixture = createFixture({ client });
+    const begin = fixture.flow.begin(OWNER_A);
+    await vi.waitFor(() => expect(client.begin).toHaveBeenCalledOnce());
+    const ceremonyId = client.begin.mock.calls[0]?.[0].ceremonyId;
+    fixture.clock.advance(60_000);
+
+    await expect(fixture.flow.poll(OWNER_A, ceremonyId)).resolves.toMatchObject(
+      {
+        ok: true,
+        ceremony: { status: "expired" },
+      }
+    );
+    beginGate.resolve({
+      providerSessionRef: "late-expired-session",
+      userCode: "ABCD-1234",
+    });
+    await expect(begin).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "expired" },
+    });
+    expect(client.cancel).toHaveBeenCalledWith(
+      expect.objectContaining({ providerSessionRef: "late-expired-session" }),
+      expect.any(Object)
+    );
+  });
+
+  it.each(["timeout", "rejection"] as const)(
+    "keeps cleanup durable after provider %s and lets a fresh manager retry",
+    async (failureMode) => {
+      const store = new TestCeremonyStore();
+      const client = new TestDeviceClient();
+      const beginGate = deferred<CodexDeviceClientBeginOutcome>();
+      const cleanupGate = deferred<void>();
+      client.begin.mockImplementation(() => beginGate.promise);
+      if (failureMode === "timeout") {
+        client.cancel.mockImplementationOnce(() => cleanupGate.promise);
+      } else {
+        client.cancel.mockRejectedValueOnce(new Error(SECRET_CANARY));
+      }
+      const fixture = createFixture({ client, store, timeout: 20 });
+      const begin = fixture.flow.begin(OWNER_A);
+      await vi.waitFor(() => expect(client.begin).toHaveBeenCalledOnce(), {
+        interval: 1,
+        timeout: 10,
+      });
+      const ceremonyId = client.begin.mock.calls[0]?.[0].ceremonyId;
+      await fixture.flow.cancel(OWNER_A, ceremonyId);
+      beginGate.resolve({
+        providerSessionRef: "durable-cleanup-session",
+        userCode: "ABCD-1234",
+      });
+      await expect(begin).resolves.toMatchObject({
+        ok: false,
+        error: failureMode === "timeout" ? "timed_out" : "provider_unavailable",
+      });
+      expect(store.records.get(ceremonyId)?.cleanupSessionRefs).toContain(
+        "durable-cleanup-session"
+      );
+
+      client.cancel.mockResolvedValue(undefined);
+      const freshManager = createFixture({ client, store });
+      await expect(
+        freshManager.flow.cancel(OWNER_A, ceremonyId)
+      ).resolves.toMatchObject({
+        ok: true,
+        ceremony: { status: "cancelled" },
+      });
+      expect(store.records.get(ceremonyId)?.cleanupSessionRefs).toEqual([]);
+      cleanupGate.resolve();
+    }
+  );
+
+  it("cleans a distinct session ref returned by a broken concurrent begin loser", async () => {
+    const store = new TestCeremonyStore();
+    const client = new TestDeviceClient();
+    client.begin
+      .mockResolvedValueOnce({
+        providerSessionRef: "race-session-a",
+        userCode: "ABCD-1234",
+      })
+      .mockResolvedValueOnce({
+        providerSessionRef: "race-session-b",
+        userCode: "ABCD-1234",
+      });
+    const fixture = createFixture({ client, store });
+    const [first, second] = await Promise.all([
+      fixture.flow.begin(OWNER_A),
+      fixture.flow.begin(OWNER_A),
+    ]);
+    expect(first).toMatchObject({ ok: true, ceremony: { status: "pending" } });
+    expect(second).toMatchObject({ ok: true, ceremony: { status: "pending" } });
+    const record = Array.from(store.records.values())[0];
+    const active = record?.providerSessionRef;
+    const loser =
+      active === "race-session-a" ? "race-session-b" : "race-session-a";
+    expect(
+      client.cancel.mock.calls.map(([input]) => input.providerSessionRef)
+    ).toContain(loser);
+    expect(record?.cleanupSessionRefs).toEqual([]);
   });
 
   it("fences delayed authorization at the exact expiry boundary", async () => {
@@ -562,17 +839,14 @@ describe("Codex device ceremony flow", () => {
     });
   });
 
-  it("makes repeated cancellation terminal while retrying provider cleanup", async () => {
+  it("makes repeated cancellation terminal without repeating completed cleanup", async () => {
     const fixture = createFixture();
     const ceremony = await beginCeremony(fixture);
     const first = await fixture.flow.cancel(OWNER_A, ceremony.ceremonyId);
     const second = await fixture.flow.cancel(OWNER_A, ceremony.ceremonyId);
 
     expect(first).toEqual(second);
-    expect(fixture.client.cancel).toHaveBeenCalledTimes(2);
-    expect(fixture.client.cancel.mock.calls[0]?.[0]).toEqual(
-      fixture.client.cancel.mock.calls[1]?.[0]
-    );
+    expect(fixture.client.cancel).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -594,6 +868,127 @@ describe("Codex device ceremony flow", () => {
       expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
     }
   );
+
+  it.each([
+    null,
+    undefined,
+    { status: "mystery" },
+    { status: "reserved" },
+    { status: "reserved", record: null },
+    { status: "reserved", record: { providerBeginKey: SECRET_CANARY } },
+  ])("fails closed for malformed reserve envelope %#", async (malformed) => {
+    const store = new TestCeremonyStore();
+    vi.spyOn(store, "reserve").mockResolvedValue(malformed as never);
+    const { flow } = createFixture({ store });
+    await expect(flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "store_unavailable",
+    });
+  });
+
+  it("fails closed for hostile store envelope accessors", async () => {
+    const store = new TestCeremonyStore();
+    const hostile = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error(SECRET_CANARY);
+        },
+      }
+    );
+    vi.spyOn(store, "reserve").mockResolvedValue(hostile as never);
+    const { flow } = createFixture({ store });
+    const result = await flow.begin(OWNER_A);
+    expect(result).toEqual({ ok: false, error: "store_unavailable" });
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it("fails closed for null or malformed runtime scope", async () => {
+    const fixture = createFixture();
+    await expect(fixture.flow.begin(null as never)).resolves.toEqual({
+      ok: false,
+      error: "not_found",
+    });
+    await expect(
+      fixture.flow.begin({ ownerId: SECRET_CANARY } as never)
+    ).resolves.toEqual({ ok: false, error: "not_found" });
+    await expect(
+      fixture.flow.begin({
+        ...OWNER_A,
+        verificationUrl: "https://evil.example/phish",
+      } as never)
+    ).resolves.toEqual({ ok: false, error: "not_found" });
+    expect(fixture.client.begin).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for malformed begin-result store envelopes", async () => {
+    const store = new TestCeremonyStore();
+    vi.spyOn(store, "recordBegin").mockResolvedValue({
+      status: "recorded",
+    } as never);
+    const { flow } = createFixture({ store });
+    await expect(flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "store_unavailable",
+    });
+  });
+
+  it("fails closed for malformed prepare-poll store envelopes", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    vi.spyOn(store, "preparePoll").mockResolvedValue(undefined as never);
+    await expect(
+      fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "store_unavailable" });
+  });
+
+  it("fails closed for malformed complete-poll store envelopes", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    fixture.clock.advance(5_000);
+    vi.spyOn(store, "completePoll").mockResolvedValue({
+      status: "completed",
+    } as never);
+    await expect(
+      fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "store_unavailable" });
+  });
+
+  it("fails closed for malformed cancel store envelopes", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    vi.spyOn(store, "cancel").mockResolvedValue({
+      status: "unexpected",
+    } as never);
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "store_unavailable" });
+  });
+
+  it("fails closed for malformed cleanup-claim store envelopes", async () => {
+    const store = new TestCeremonyStore();
+    vi.spyOn(store, "claimCleanup").mockResolvedValue({
+      status: "granted",
+    } as never);
+    const { flow } = createFixture({ store });
+    await expect(flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "store_unavailable",
+    });
+  });
+
+  it("fails closed for malformed cleanup-completion store envelopes", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    vi.spyOn(store, "completeCleanup").mockResolvedValue(null as never);
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "store_unavailable" });
+  });
 
   it.each(["store", "provider"] as const)(
     "bounds and aborts stalled %s operations while observing late rejection",
@@ -637,8 +1032,9 @@ describe("Codex device ceremony flow", () => {
     expect(fixture.client.begin).not.toHaveBeenCalled();
   });
 
-  it("propagates a reason-free abort to an active provider wait", async () => {
-    const fixture = createFixture();
+  it("terminalizes caller abort while independently retaining and cleaning late begin", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
     const gate = deferred<CodexDeviceClientBeginOutcome>();
     let context: ControlPlaneOperationContext | undefined;
     fixture.client.begin.mockImplementation((_input, value) => {
@@ -651,10 +1047,52 @@ describe("Codex device ceremony flow", () => {
     controller.abort(SECRET_CANARY);
 
     await expect(begin).resolves.toEqual({ ok: false, error: "aborted" });
-    expect(context?.signal.aborted).toBe(true);
+    expect(context?.signal.aborted).toBe(false);
     expect(context?.signal.reason).not.toBe(SECRET_CANARY);
-    gate.reject(new Error(SECRET_CANARY));
-    await Promise.resolve();
+    gate.resolve({
+      providerSessionRef: "caller-abort-session",
+      userCode: "ABCD-1234",
+    });
+    await vi.waitFor(() =>
+      expect(fixture.client.cancel).toHaveBeenCalledWith(
+        expect.objectContaining({ providerSessionRef: "caller-abort-session" }),
+        expect.any(Object)
+      )
+    );
+    const record = Array.from(store.records.values())[0];
+    expect(record).toMatchObject({
+      status: "cancelled",
+      cleanupSessionRefs: [],
+    });
+  });
+
+  it("retries an initially failed abort transition after the begin ref is durable", async () => {
+    const store = new TestCeremonyStore();
+    vi.spyOn(store, "cancel").mockRejectedValueOnce(new Error(SECRET_CANARY));
+    const fixture = createFixture({ store });
+    const gate = deferred<CodexDeviceClientBeginOutcome>();
+    fixture.client.begin.mockImplementation(() => gate.promise);
+    const controller = new AbortController();
+    const begin = fixture.flow.begin(OWNER_A, controller.signal);
+    await vi.waitFor(() => expect(fixture.client.begin).toHaveBeenCalledOnce());
+    controller.abort(SECRET_CANARY);
+    await expect(begin).resolves.toEqual({ ok: false, error: "aborted" });
+
+    gate.resolve({
+      providerSessionRef: "abort-retry-session",
+      userCode: "ABCD-1234",
+    });
+    await vi.waitFor(() => {
+      const record = Array.from(store.records.values())[0];
+      expect(record).toMatchObject({
+        status: "cancelled",
+        cleanupSessionRefs: [],
+      });
+    });
+    expect(fixture.client.cancel).toHaveBeenCalledWith(
+      expect.objectContaining({ providerSessionRef: "abort-retry-session" }),
+      expect.any(Object)
+    );
   });
 
   it("recovers an ambiguous late reserve on a same-request retry", async () => {
@@ -678,13 +1116,13 @@ describe("Codex device ceremony flow", () => {
     expect(retry).toMatchObject({ ok: true, ceremony: { status: "pending" } });
   });
 
-  it("recovers an ambiguous activate commit without another provider begin", async () => {
+  it("recovers an ambiguous begin-result commit without another provider begin", async () => {
     const store = new TestCeremonyStore();
-    const originalActivate = store.activate.bind(store);
+    const originalRecordBegin = store.recordBegin.bind(store);
     const gate = deferred<void>();
-    vi.spyOn(store, "activate").mockImplementationOnce(
+    vi.spyOn(store, "recordBegin").mockImplementationOnce(
       async (input, context) => {
-        const committed = await originalActivate(input, context);
+        const committed = await originalRecordBegin(input, context);
         await gate.promise;
         return committed;
       }
@@ -699,6 +1137,30 @@ describe("Codex device ceremony flow", () => {
     const retry = await fixture.flow.begin(OWNER_A);
     expect(retry).toMatchObject({ ok: true, ceremony: { status: "pending" } });
     expect(fixture.client.begin).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers an uncommitted begin-result timeout with the persisted idempotency key", async () => {
+    const store = new TestCeremonyStore();
+    const client = new TestDeviceClient();
+    const storeGate = deferred<RecordBeginOutcome>();
+    vi.spyOn(store, "recordBegin").mockImplementationOnce(
+      () => storeGate.promise
+    );
+    const fixture = createFixture({ client, store, timeout: 5 });
+    await expect(fixture.flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "timed_out",
+    });
+    storeGate.reject(new Error(SECRET_CANARY));
+
+    await expect(fixture.flow.begin(OWNER_A)).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "pending" },
+    });
+    expect(client.begin).toHaveBeenCalledTimes(2);
+    expect(client.begin.mock.calls[0]?.[0]).toEqual(
+      client.begin.mock.calls[1]?.[0]
+    );
   });
 
   it("recovers an ambiguous poll completion from durable authorized state", async () => {
@@ -757,12 +1219,41 @@ describe("Codex device ceremony flow", () => {
     });
   });
 
+  it("recovers an ambiguous cleanup completion without repeating provider cleanup", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store, timeout: 5 });
+    const ceremony = await beginCeremony(fixture);
+    const originalCompleteCleanup = store.completeCleanup.bind(store);
+    const gate = deferred<void>();
+    vi.spyOn(store, "completeCleanup").mockImplementationOnce(
+      async (input, context) => {
+        const committed = await originalCompleteCleanup(input, context);
+        await gate.promise;
+        return committed;
+      }
+    );
+
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({ ok: false, error: "timed_out" });
+    gate.resolve();
+    const freshManager = createFixture({ client: fixture.client, store });
+    await expect(
+      freshManager.flow.cancel(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toMatchObject({
+      ok: true,
+      ceremony: { status: "cancelled" },
+    });
+    expect(fixture.client.cancel).toHaveBeenCalledTimes(1);
+  });
+
   it("does not accept caller-selected URLs, commands, models, homes, or env", async () => {
     const fixture = createFixture();
     await beginCeremony(fixture);
     const beginInput = fixture.client.begin.mock.calls[0]?.[0];
     expect(beginInput).toEqual({
       ceremonyId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+      providerBeginKey: "KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK1",
     });
     expect(JSON.stringify(beginInput)).not.toMatch(
       /url|command|model|home|env/i

--- a/services/agent-gateway/codex-device-flow.test.ts
+++ b/services/agent-gateway/codex-device-flow.test.ts
@@ -68,6 +68,7 @@ class TestCeremonyStore implements CodexDeviceCeremonyStore {
         input.nowMilliseconds + input.pollIntervalMilliseconds,
       revision: 1,
       providerBeginKey: input.providerBeginKey,
+      providerBeginPending: true,
       cleanupSessionRefs: [],
     };
     this.records.set(input.ceremonyId, record);
@@ -92,7 +93,10 @@ class TestCeremonyStore implements CodexDeviceCeremonyStore {
         this.records.set(input.ceremonyId, current);
         return { status: "current", record: current };
       }
-      const retained = this.retainCleanup(current, input.providerSessionRef);
+      const retained = {
+        ...this.retainCleanup(current, input.providerSessionRef),
+        providerBeginPending: false,
+      };
       this.records.set(input.ceremonyId, retained);
       return { status: "recorded", record: retained };
     }
@@ -101,6 +105,7 @@ class TestCeremonyStore implements CodexDeviceCeremonyStore {
       status: "pending",
       userCode: input.userCode,
       providerSessionRef: input.providerSessionRef,
+      providerBeginPending: false,
       revision: current.revision + 1,
     };
     this.records.set(input.ceremonyId, activated);
@@ -345,6 +350,37 @@ function deferred<T>() {
     reject = rejectPromise;
   });
   return { promise, reject, resolve };
+}
+
+/** Wraps nested plain data so every post-snapshot property read throws. */
+function createReadHostileSource(
+  value: unknown,
+  counter: { reads: number }
+): unknown {
+  if (Array.isArray(value)) {
+    const target = value.map((item) => createReadHostileSource(item, counter));
+    return new Proxy(target, {
+      get: (_target, key) => {
+        if (key === "then") return undefined;
+        counter.reads += 1;
+        throw new Error(SECRET_CANARY);
+      },
+    });
+  }
+  if (typeof value === "object" && value !== null) {
+    const target = Object.create(null) as Record<string, unknown>;
+    for (const [key, nested] of Object.entries(value)) {
+      target[key] = createReadHostileSource(nested, counter);
+    }
+    return new Proxy(target, {
+      get: (_target, key) => {
+        if (key === "then") return undefined;
+        counter.reads += 1;
+        throw new Error(SECRET_CANARY);
+      },
+    });
+  }
+  return value;
 }
 
 /** Identifies the two nonterminal durable statuses. */
@@ -754,9 +790,9 @@ describe("Codex device ceremony flow", () => {
       const cleanupGate = deferred<void>();
       client.begin.mockImplementation(() => beginGate.promise);
       if (failureMode === "timeout") {
-        client.cancel.mockImplementationOnce(() => cleanupGate.promise);
+        client.cancel.mockImplementation(() => cleanupGate.promise);
       } else {
-        client.cancel.mockRejectedValueOnce(new Error(SECRET_CANARY));
+        client.cancel.mockRejectedValue(new Error(SECRET_CANARY));
       }
       const fixture = createFixture({ client, store, timeout: 20 });
       const begin = fixture.flow.begin(OWNER_A);
@@ -886,6 +922,102 @@ describe("Codex device ceremony flow", () => {
     });
   });
 
+  it("snapshots every store family, provider result, and scope before hostile reads", async () => {
+    const store = new TestCeremonyStore();
+    const client = new TestDeviceClient();
+    const counter = { reads: 0 };
+    let receivedFrozenScope = false;
+    const originalReserve = store.reserve.bind(store);
+    const originalRecordBegin = store.recordBegin.bind(store);
+    const originalPreparePoll = store.preparePoll.bind(store);
+    const originalCompletePoll = store.completePoll.bind(store);
+    const originalCancel = store.cancel.bind(store);
+    const originalClaimCleanup = store.claimCleanup.bind(store);
+    const originalCompleteCleanup = store.completeCleanup.bind(store);
+    vi.spyOn(store, "reserve").mockImplementation(async (input, context) => {
+      receivedFrozenScope = Object.isFrozen(input.scope);
+      return createReadHostileSource(
+        await originalReserve(input, context),
+        counter
+      ) as never;
+    });
+    vi.spyOn(store, "recordBegin").mockImplementation(
+      async (input, context) =>
+        createReadHostileSource(
+          await originalRecordBegin(input, context),
+          counter
+        ) as never
+    );
+    vi.spyOn(store, "preparePoll").mockImplementation(
+      async (input, context) =>
+        createReadHostileSource(
+          await originalPreparePoll(input, context),
+          counter
+        ) as never
+    );
+    vi.spyOn(store, "completePoll").mockImplementation(
+      async (input, context) =>
+        createReadHostileSource(
+          await originalCompletePoll(input, context),
+          counter
+        ) as never
+    );
+    vi.spyOn(store, "cancel").mockImplementation(
+      async (input, context) =>
+        createReadHostileSource(
+          await originalCancel(input, context),
+          counter
+        ) as never
+    );
+    vi.spyOn(store, "claimCleanup").mockImplementation(
+      async (input, context) =>
+        createReadHostileSource(
+          await originalClaimCleanup(input, context),
+          counter
+        ) as never
+    );
+    vi.spyOn(store, "completeCleanup").mockImplementation(
+      async (input, context) =>
+        createReadHostileSource(
+          await originalCompleteCleanup(input, context),
+          counter
+        ) as never
+    );
+    client.begin.mockResolvedValue(
+      createReadHostileSource(
+        { providerSessionRef: "snapshot-session", userCode: "ABCD-1234" },
+        counter
+      ) as never
+    );
+    client.poll.mockResolvedValue(
+      createReadHostileSource({ status: "pending" }, counter) as never
+    );
+    const fixture = createFixture({ client, store });
+    const hostileScope = createReadHostileSource(
+      OWNER_A,
+      counter
+    ) as CodexDeviceScope;
+
+    const beginResult = await fixture.flow.begin(hostileScope);
+    if (!beginResult.ok) {
+      throw new Error("expected snapshotted ceremony");
+    }
+    expect(beginResult).toMatchObject({
+      ok: true,
+      ceremony: { status: "pending" },
+    });
+    const ceremony = beginResult.ceremony;
+    fixture.clock.advance(5_000);
+    await expect(
+      fixture.flow.poll(hostileScope, ceremony.ceremonyId)
+    ).resolves.toMatchObject({ ok: true, ceremony: { status: "pending" } });
+    await expect(
+      fixture.flow.cancel(hostileScope, ceremony.ceremonyId)
+    ).resolves.toMatchObject({ ok: true, ceremony: { status: "cancelled" } });
+    expect(receivedFrozenScope).toBe(true);
+    expect(counter.reads).toBe(0);
+  });
+
   it("fails closed for hostile store envelope accessors", async () => {
     const store = new TestCeremonyStore();
     const hostile = new Proxy(
@@ -901,6 +1033,54 @@ describe("Codex device ceremony flow", () => {
     const result = await flow.begin(OWNER_A);
     expect(result).toEqual({ ok: false, error: "store_unavailable" });
     expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it("rejects accessors and cycles without invoking or leaking them", async () => {
+    let getterReads = 0;
+    const accessorScope = {
+      connectionId: OWNER_A.connectionId,
+      requestId: OWNER_A.requestId,
+    } as Record<string, unknown>;
+    Object.defineProperty(accessorScope, "ownerId", {
+      enumerable: true,
+      get: () => {
+        getterReads += 1;
+        throw new Error(SECRET_CANARY);
+      },
+    });
+    const fixture = createFixture();
+    await expect(
+      fixture.flow.begin(accessorScope as CodexDeviceScope)
+    ).resolves.toEqual({ ok: false, error: "not_found" });
+
+    const providerAccessor = { providerSessionRef: "session" } as Record<
+      string,
+      unknown
+    >;
+    Object.defineProperty(providerAccessor, "userCode", {
+      enumerable: true,
+      get: () => {
+        getterReads += 1;
+        throw new Error(SECRET_CANARY);
+      },
+    });
+    fixture.client.begin.mockResolvedValue(providerAccessor as never);
+    await expect(fixture.flow.begin(OWNER_A)).resolves.toEqual({
+      ok: false,
+      error: "provider_unavailable",
+    });
+
+    const cyclic: Record<string, unknown> = {
+      providerSessionRef: "session",
+      userCode: "ABCD-1234",
+    };
+    cyclic.extra = cyclic;
+    const cyclicFixture = createFixture();
+    cyclicFixture.client.begin.mockResolvedValue(cyclic as never);
+    const cyclicResult = await cyclicFixture.flow.begin(OWNER_A);
+    expect(cyclicResult).toEqual({ ok: false, error: "provider_unavailable" });
+    expect(getterReads).toBe(0);
+    expect(JSON.stringify(cyclicResult)).not.toContain(SECRET_CANARY);
   });
 
   it("fails closed for null or malformed runtime scope", async () => {
@@ -1066,6 +1246,100 @@ describe("Codex device ceremony flow", () => {
     });
   });
 
+  it("records and cleans provider success after caller abort and server deadline", async () => {
+    const store = new TestCeremonyStore();
+    const client = new TestDeviceClient();
+    const gate = deferred<CodexDeviceClientBeginOutcome>();
+    client.begin.mockImplementation(() => gate.promise);
+    const fixture = createFixture({ client, store, timeout: 5 });
+    const controller = new AbortController();
+    const begin = fixture.flow.begin(OWNER_A, controller.signal);
+    await vi.waitFor(() => expect(client.begin).toHaveBeenCalledOnce(), {
+      interval: 1,
+      timeout: 10,
+    });
+    controller.abort(SECRET_CANARY);
+    await expect(begin).resolves.toEqual({ ok: false, error: "aborted" });
+    await vi.waitFor(() =>
+      expect(client.begin.mock.calls[0]?.[1].signal.aborted).toBe(true)
+    );
+
+    gate.resolve({
+      providerSessionRef: "post-deadline-session",
+      userCode: "ABCD-1234",
+    });
+    await vi.waitFor(() =>
+      expect(client.cancel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerSessionRef: "post-deadline-session",
+        }),
+        expect.any(Object)
+      )
+    );
+    const record = Array.from(store.records.values())[0];
+    expect(record).toMatchObject({
+      status: "cancelled",
+      providerBeginPending: false,
+      cleanupSessionRefs: [],
+    });
+  });
+
+  it("makes pre-aborted explicit cancel terminal and cleanup retry-safe", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    const controller = new AbortController();
+    controller.abort(SECRET_CANARY);
+
+    await expect(
+      fixture.flow.cancel(OWNER_A, ceremony.ceremonyId, controller.signal)
+    ).resolves.toEqual({ ok: false, error: "aborted" });
+    await vi.waitFor(() =>
+      expect(store.records.get(ceremony.ceremonyId)).toMatchObject({
+        status: "cancelled",
+        cleanupSessionRefs: [],
+      })
+    );
+    expect(fixture.client.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("continues an explicit cancel store transition after mid-wait abort", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store, timeout: 200 });
+    const ceremony = await beginCeremony(fixture);
+    const originalCancel = store.cancel.bind(store);
+    const gate = deferred<void>();
+    let storeSignal: AbortSignal | undefined;
+    vi.spyOn(store, "cancel").mockImplementationOnce(async (input, context) => {
+      storeSignal = context.signal;
+      await gate.promise;
+      return originalCancel(input, context);
+    });
+    const controller = new AbortController();
+    const cancellation = fixture.flow.cancel(
+      OWNER_A,
+      ceremony.ceremonyId,
+      controller.signal
+    );
+    await vi.waitFor(() => expect(storeSignal).toBeDefined(), {
+      interval: 1,
+      timeout: 20,
+    });
+    controller.abort(SECRET_CANARY);
+    await expect(cancellation).resolves.toEqual({
+      ok: false,
+      error: "aborted",
+    });
+    expect(storeSignal?.aborted).toBe(false);
+    gate.resolve();
+    await vi.waitFor(() =>
+      expect(store.records.get(ceremony.ceremonyId)).toMatchObject({
+        status: "cancelled",
+        cleanupSessionRefs: [],
+      })
+    );
+  });
+
   it("retries an initially failed abort transition after the begin ref is durable", async () => {
     const store = new TestCeremonyStore();
     vi.spyOn(store, "cancel").mockRejectedValueOnce(new Error(SECRET_CANARY));
@@ -1160,6 +1434,57 @@ describe("Codex device ceremony flow", () => {
     expect(client.begin).toHaveBeenCalledTimes(2);
     expect(client.begin.mock.calls[0]?.[0]).toEqual(
       client.begin.mock.calls[1]?.[0]
+    );
+  });
+
+  it("recovers terminal cleanup when late ref persistence did not commit", async () => {
+    const store = new TestCeremonyStore();
+    const client = new TestDeviceClient();
+    const beginGate = deferred<CodexDeviceClientBeginOutcome>();
+    const recordGate = deferred<RecordBeginOutcome>();
+    client.begin.mockImplementationOnce(() => beginGate.promise);
+    vi.spyOn(store, "recordBegin").mockImplementationOnce(
+      () => recordGate.promise
+    );
+    const fixture = createFixture({ client, store, timeout: 5 });
+    const begin = fixture.flow.begin(OWNER_A);
+    await vi.waitFor(() => expect(client.begin).toHaveBeenCalledOnce(), {
+      interval: 1,
+      timeout: 10,
+    });
+    const ceremonyId = client.begin.mock.calls[0]?.[0].ceremonyId;
+    fixture.clock.advance(60_000);
+    await fixture.flow.poll(OWNER_A, ceremonyId);
+    beginGate.resolve({
+      providerSessionRef: "uncommitted-terminal-session",
+      userCode: "ABCD-1234",
+    });
+    await expect(begin).resolves.toEqual({ ok: false, error: "timed_out" });
+    recordGate.reject(new Error(SECRET_CANARY));
+    expect(store.records.get(ceremonyId)).toMatchObject({
+      status: "expired",
+      providerBeginPending: true,
+      cleanupSessionRefs: [],
+    });
+
+    client.begin.mockResolvedValue({
+      providerSessionRef: "uncommitted-terminal-session",
+      userCode: "ABCD-1234",
+    });
+    const freshManager = createFixture({ client, store });
+    await freshManager.flow.cancel(OWNER_A, ceremonyId);
+    await vi.waitFor(() =>
+      expect(store.records.get(ceremonyId)).toMatchObject({
+        status: "expired",
+        providerBeginPending: false,
+        cleanupSessionRefs: [],
+      })
+    );
+    expect(client.cancel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerSessionRef: "uncommitted-terminal-session",
+      }),
+      expect.any(Object)
     );
   });
 

--- a/services/agent-gateway/codex-device-flow.test.ts
+++ b/services/agent-gateway/codex-device-flow.test.ts
@@ -1083,6 +1083,141 @@ describe("Codex device ceremony flow", () => {
     expect(JSON.stringify(cyclicResult)).not.toContain(SECRET_CANARY);
   });
 
+  it("rejects huge sparse arrays before enumerating their claimed length", async () => {
+    const fixture = createFixture();
+    const sparseTarget: unknown[] = [];
+    sparseTarget.length = 0xffff_fffe;
+    let ownKeyReads = 0;
+    const sparse = new Proxy(sparseTarget, {
+      ownKeys: () => {
+        ownKeyReads += 1;
+        throw new Error(SECRET_CANARY);
+      },
+    });
+    fixture.client.begin.mockResolvedValue({
+      providerSessionRef: "sparse-session",
+      userCode: "ABCD-1234",
+      extra: sparse,
+    } as never);
+
+    const result = await fixture.flow.begin(OWNER_A);
+
+    expect(result).toEqual({ ok: false, error: "provider_unavailable" });
+    expect(ownKeyReads).toBe(0);
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it("rejects dense primitive arrays over the cardinality limit", async () => {
+    const store = new TestCeremonyStore();
+    vi.spyOn(store, "reserve").mockResolvedValue({
+      status: "not_found",
+      extra: Array.from({ length: 9 }, (_value, index) =>
+        index === 8 ? SECRET_CANARY : index
+      ),
+    } as never);
+    const fixture = createFixture({ store });
+
+    const result = await fixture.flow.begin(OWNER_A);
+
+    expect(result).toEqual({ ok: false, error: "store_unavailable" });
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it("rejects plain primitive objects over the own-key limit", async () => {
+    const fixture = createFixture();
+    const oversized = Object.fromEntries(
+      Array.from({ length: 17 }, (_value, index) => [
+        `field_${index}`,
+        index === 16 ? SECRET_CANARY : index,
+      ])
+    );
+    fixture.client.begin.mockResolvedValue({
+      providerSessionRef: "object-session",
+      userCode: "ABCD-1234",
+      extra: oversized,
+    } as never);
+
+    const result = await fixture.flow.begin(OWNER_A);
+
+    expect(result).toEqual({ ok: false, error: "provider_unavailable" });
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it("charges combined nested primitives and slots to one snapshot budget", async () => {
+    const fixture = createFixture();
+    const nested = Array.from({ length: 8 }, (_value, branch) => ({
+      values: Array.from({ length: 8 }, (_item, index) =>
+        branch === 7 && index === 7 ? SECRET_CANARY : `${branch}:${index}`
+      ),
+    }));
+    fixture.client.begin.mockResolvedValue({
+      providerSessionRef: "nested-session",
+      userCode: "ABCD-1234",
+      extra: nested,
+    } as never);
+
+    const result = await fixture.flow.begin(OWNER_A);
+
+    expect(result).toEqual({ ok: false, error: "provider_unavailable" });
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it.each([
+    `${SECRET_CANARY}${"A".repeat(1_024)}`,
+    `${SECRET_CANARY}${"€".repeat(680)}`,
+  ])("bounds runtime string code units and UTF-8 bytes", async (oversized) => {
+    const fixture = createFixture();
+    fixture.client.begin.mockResolvedValue({
+      providerSessionRef: "string-session",
+      userCode: "ABCD-1234",
+      extra: oversized,
+    } as never);
+
+    const result = await fixture.flow.begin(OWNER_A);
+
+    expect(result).toEqual({ ok: false, error: "provider_unavailable" });
+    expect(JSON.stringify(result)).not.toContain(SECRET_CANARY);
+  });
+
+  it("accepts the maximum valid record, array, key, and entry boundaries", async () => {
+    const store = new TestCeremonyStore();
+    const fixture = createFixture({ store });
+    const ceremony = await beginCeremony(fixture);
+    const active = store.records.get(ceremony.ceremonyId);
+    if (!active) throw new Error("expected durable ceremony");
+    // The first cleanup claim combines the maximum 16-key record, eight refs,
+    // account shape, and five-key envelope at exactly the shared entry budget.
+    const boundaryRecord: CodexDeviceCeremonyRecord = {
+      ...active,
+      status: "authorized",
+      account: { type: "chatgpt", present: true },
+      cleanupSessionRefs: Array.from(
+        { length: 8 },
+        (_value, index) => `boundary-cleanup-${index}`
+      ),
+    };
+    store.records.set(ceremony.ceremonyId, boundaryRecord);
+    vi.spyOn(store, "preparePoll").mockResolvedValue({
+      status: "current",
+      record: boundaryRecord,
+    });
+
+    await expect(
+      fixture.flow.poll(OWNER_A, ceremony.ceremonyId)
+    ).resolves.toEqual({
+      ok: true,
+      ceremony: {
+        ceremonyId: ceremony.ceremonyId,
+        status: "authorized",
+        verificationUrl: OFFICIAL_URL,
+        expiresAtMilliseconds: ceremony.expiresAtMilliseconds,
+        pollIntervalMilliseconds: ceremony.pollIntervalMilliseconds,
+        account: { type: "chatgpt", present: true },
+      },
+    });
+    expect(fixture.client.cancel).toHaveBeenCalledTimes(8);
+  });
+
   it("fails closed for null or malformed runtime scope", async () => {
     const fixture = createFixture();
     await expect(fixture.flow.begin(null as never)).resolves.toEqual({

--- a/services/agent-gateway/codex-device-flow.ts
+++ b/services/agent-gateway/codex-device-flow.ts
@@ -1,0 +1,802 @@
+import { randomBytes } from "node:crypto";
+
+import {
+  awaitControlPlaneOperation,
+  type ControlPlaneOperationContext,
+} from "./control-plane.ts";
+
+const CEREMONY_ID_BYTES = 24;
+const MAX_IDENTIFIER_LENGTH = 160;
+const MAX_PROVIDER_SESSION_REF_LENGTH = 512;
+const USER_CODE_PATTERN = /^[A-Z0-9](?:[A-Z0-9-]{2,14}[A-Z0-9])$/;
+
+type CodexDeviceAccountType = "chatgpt" | "api_key";
+type CodexDeviceStatus =
+  | "starting"
+  | "pending"
+  | "authorized"
+  | "cancelled"
+  | "expired"
+  | "denied";
+
+type CodexDeviceScope = Readonly<{
+  ownerId: string;
+  connectionId: string;
+  requestId: string;
+}>;
+
+type CodexDeviceAccount = Readonly<{
+  type: CodexDeviceAccountType;
+  present: true;
+}>;
+
+type CodexDeviceCeremonyRecord = Readonly<{
+  ceremonyId: string;
+  ownerId: string;
+  connectionId: string;
+  requestId: string;
+  status: CodexDeviceStatus;
+  createdAtMilliseconds: number;
+  expiresAtMilliseconds: number;
+  pollIntervalMilliseconds: number;
+  nextPollAtMilliseconds: number;
+  revision: number;
+  userCode?: string;
+  providerSessionRef?: string;
+  account?: CodexDeviceAccount;
+}>;
+
+type CodexDeviceProjection = Readonly<{
+  ceremonyId: string;
+  status: CodexDeviceStatus;
+  verificationUrl: string;
+  expiresAtMilliseconds: number;
+  pollIntervalMilliseconds: number;
+  userCode?: string;
+  account?: CodexDeviceAccount;
+}>;
+
+type CodexDeviceErrorCode =
+  | "aborted"
+  | "active_ceremony_exists"
+  | "invalid_provider_response"
+  | "not_found"
+  | "provider_unavailable"
+  | "store_unavailable"
+  | "timed_out";
+
+type CodexDeviceResult =
+  | Readonly<{ ok: true; ceremony: CodexDeviceProjection }>
+  | Readonly<{ ok: false; error: CodexDeviceErrorCode }>;
+
+type ReserveCeremonyOutcome =
+  | Readonly<{ status: "reserved"; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "same_request"; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "active_other_request" }>
+  | Readonly<{ status: "not_found" }>
+  | Readonly<{ status: "id_collision" }>;
+
+type ActivateCeremonyOutcome =
+  | Readonly<{ status: "activated"; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "current"; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "not_found" }>;
+
+type PreparePollOutcome =
+  | Readonly<{
+      status: "granted";
+      record: CodexDeviceCeremonyRecord;
+      pollRevision: number;
+      providerSessionRef: string;
+    }>
+  | Readonly<{
+      status: "current";
+      record: CodexDeviceCeremonyRecord;
+    }>
+  | Readonly<{ status: "not_found" }>;
+
+type CompletePollOutcome =
+  | Readonly<{ status: "completed"; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "stale"; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "not_found" }>;
+
+type CancelCeremonyOutcome =
+  | Readonly<{
+      status: "cancelled" | "current";
+      record: CodexDeviceCeremonyRecord;
+      providerSessionRef?: string;
+    }>
+  | Readonly<{ status: "not_found" }>;
+
+type CodexDevicePollCompletion =
+  | Readonly<{ status: "pending" }>
+  | Readonly<{ status: "denied" }>
+  | Readonly<{ status: "expired" }>
+  | Readonly<{ status: "authorized"; account: CodexDeviceAccount }>;
+
+type CodexDeviceClientBeginOutcome = Readonly<{
+  providerSessionRef: string;
+  userCode: string;
+}>;
+
+interface CodexDeviceClient {
+  /**
+   * Starts or recovers a provider ceremony idempotently by ceremonyId.
+   * Implementations must never vary command, model, home, or environment from
+   * caller input because none of those values are accepted by this contract.
+   */
+  begin(
+    input: Readonly<{ ceremonyId: string }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<CodexDeviceClientBeginOutcome>;
+
+  /** Polls the server-held provider session without returning raw output. */
+  poll(
+    input: Readonly<{
+      ceremonyId: string;
+      providerSessionRef: string;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<CodexDevicePollCompletion>;
+
+  /** Cancels a provider ceremony idempotently by ceremonyId. */
+  cancel(
+    input: Readonly<{
+      ceremonyId: string;
+      providerSessionRef: string;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<void>;
+}
+
+interface CodexDeviceCeremonyStore {
+  /**
+   * Atomically expires stale ceremonies, enforces one active ceremony per
+   * connection, and reserves the supplied server-generated identifier. A
+   * cross-owner connection match must be concealed as not_found. A different
+   * request owned by the same owner is active_other_request;
+   * implementations must never disclose the conflicting record.
+   */
+  reserve(
+    input: Readonly<{
+      ceremonyId: string;
+      scope: CodexDeviceScope;
+      nowMilliseconds: number;
+      expiresAtMilliseconds: number;
+      pollIntervalMilliseconds: number;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<ReserveCeremonyOutcome>;
+
+  /** Activates only the matching starting record, or returns current state. */
+  activate(
+    input: Readonly<{
+      ceremonyId: string;
+      scope: CodexDeviceScope;
+      nowMilliseconds: number;
+      userCode: string;
+      providerSessionRef: string;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<ActivateCeremonyOutcome>;
+
+  /**
+   * Atomically validates scope, applies expiry and poll throttling, and grants
+   * at most one poll revision for the current interval.
+   */
+  preparePoll(
+    input: Readonly<{
+      ceremonyId: string;
+      scope: CodexDeviceScope;
+      nowMilliseconds: number;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<PreparePollOutcome>;
+
+  /** Commits a provider result only while its granted revision remains live. */
+  completePoll(
+    input: Readonly<{
+      ceremonyId: string;
+      scope: CodexDeviceScope;
+      nowMilliseconds: number;
+      pollRevision: number;
+      completion: CodexDevicePollCompletion;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<CompletePollOutcome>;
+
+  /** Atomically validates scope and makes cancellation terminal/idempotent. */
+  cancel(
+    input: Readonly<{
+      ceremonyId: string;
+      scope: CodexDeviceScope;
+      nowMilliseconds: number;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<CancelCeremonyOutcome>;
+}
+
+type CodexDeviceFlowOptions = Readonly<{
+  client: CodexDeviceClient;
+  store: CodexDeviceCeremonyStore;
+  officialVerificationUrl: string;
+  ceremonyTtlMilliseconds: number;
+  pollIntervalMilliseconds: number;
+  dependencyTimeoutMilliseconds: number;
+  now?: () => number;
+  createCeremonyId?: () => string;
+}>;
+
+type CodexDeviceFlow = Readonly<{
+  begin: (
+    scope: CodexDeviceScope,
+    requestSignal?: AbortSignal
+  ) => Promise<CodexDeviceResult>;
+  poll: (
+    scope: CodexDeviceScope,
+    ceremonyId: string,
+    requestSignal?: AbortSignal
+  ) => Promise<CodexDeviceResult>;
+  cancel: (
+    scope: CodexDeviceScope,
+    ceremonyId: string,
+    requestSignal?: AbortSignal
+  ) => Promise<CodexDeviceResult>;
+}>;
+
+/** Creates the provider-neutral Codex device authorization coordinator. */
+function createCodexDeviceFlow(
+  options: CodexDeviceFlowOptions
+): CodexDeviceFlow {
+  validateOptions(options);
+  const verificationUrl = normalizeOfficialVerificationUrl(
+    options.officialVerificationUrl
+  );
+  const now = options.now ?? Date.now;
+  const createCeremonyId = options.createCeremonyId ?? defaultCeremonyId;
+
+  /** Starts or recovers one request-bound ceremony without duplicate sessions. */
+  async function begin(
+    scope: CodexDeviceScope,
+    requestSignal?: AbortSignal
+  ): Promise<CodexDeviceResult> {
+    if (!isValidScope(scope)) return failure("not_found");
+    const nowMilliseconds = now();
+    const ceremonyId = createCeremonyId();
+    if (!isValidCeremonyId(ceremonyId)) return failure("store_unavailable");
+
+    const reservation = await awaitDependency(
+      (context) =>
+        options.store.reserve(
+          {
+            ceremonyId,
+            scope,
+            nowMilliseconds,
+            expiresAtMilliseconds:
+              nowMilliseconds + options.ceremonyTtlMilliseconds,
+            pollIntervalMilliseconds: options.pollIntervalMilliseconds,
+          },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      requestSignal,
+      "store"
+    );
+    if (!reservation.ok) return reservation.result;
+    if (reservation.value.status === "active_other_request") {
+      return failure("active_ceremony_exists");
+    }
+    if (reservation.value.status === "not_found") return failure("not_found");
+    if (reservation.value.status === "id_collision") {
+      return failure("store_unavailable");
+    }
+
+    const record = reservation.value.record;
+    if (!isValidRecord(record, scope, record.ceremonyId)) {
+      return failure("store_unavailable");
+    }
+    if (record.status !== "starting") {
+      return resultFromRecord(
+        record,
+        scope,
+        record.ceremonyId,
+        verificationUrl
+      );
+    }
+
+    const providerBegin = await awaitDependency(
+      (context) =>
+        options.client.begin({ ceremonyId: record.ceremonyId }, context),
+      options.dependencyTimeoutMilliseconds,
+      requestSignal,
+      "provider"
+    );
+    if (!providerBegin.ok) return providerBegin.result;
+    if (!isValidBeginOutcome(providerBegin.value)) {
+      return failure("invalid_provider_response");
+    }
+
+    const activation = await awaitDependency(
+      (context) =>
+        options.store.activate(
+          {
+            ceremonyId: record.ceremonyId,
+            scope,
+            nowMilliseconds: now(),
+            userCode: providerBegin.value.userCode,
+            providerSessionRef: providerBegin.value.providerSessionRef,
+          },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      requestSignal,
+      "store"
+    );
+    if (!activation.ok) return activation.result;
+    if (activation.value.status === "not_found") return failure("not_found");
+    if (!isValidRecord(activation.value.record, scope, record.ceremonyId)) {
+      return failure("store_unavailable");
+    }
+    if (
+      activation.value.status === "current" &&
+      (activation.value.record.status === "cancelled" ||
+        activation.value.record.status === "expired")
+    ) {
+      // A provider begin can settle after the durable ceremony became terminal.
+      // Cancel that newly learned session, but never cancel a concurrently
+      // activated pending session owned by the same idempotency key.
+      const cleanup = await awaitDependency(
+        (context) =>
+          options.client.cancel(
+            {
+              ceremonyId: record.ceremonyId,
+              providerSessionRef: providerBegin.value.providerSessionRef,
+            },
+            context
+          ),
+        options.dependencyTimeoutMilliseconds,
+        requestSignal,
+        "provider"
+      );
+      if (!cleanup.ok) return cleanup.result;
+    }
+    return resultFromRecord(
+      activation.value.record,
+      scope,
+      record.ceremonyId,
+      verificationUrl
+    );
+  }
+
+  /** Polls at the store-granted cadence and fences every late completion. */
+  async function poll(
+    scope: CodexDeviceScope,
+    ceremonyId: string,
+    requestSignal?: AbortSignal
+  ): Promise<CodexDeviceResult> {
+    if (!isValidScope(scope) || !isValidCeremonyId(ceremonyId)) {
+      return failure("not_found");
+    }
+    const prepared = await awaitDependency(
+      (context) =>
+        options.store.preparePoll(
+          { ceremonyId, scope, nowMilliseconds: now() },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      requestSignal,
+      "store"
+    );
+    if (!prepared.ok) return prepared.result;
+    if (prepared.value.status === "not_found") return failure("not_found");
+    if (prepared.value.status === "current") {
+      return resultFromRecord(
+        prepared.value.record,
+        scope,
+        ceremonyId,
+        verificationUrl
+      );
+    }
+    const grantedPoll = prepared.value;
+    if (
+      !isValidRecord(grantedPoll.record, scope, ceremonyId) ||
+      grantedPoll.record.status !== "pending" ||
+      !isValidProviderSessionRef(grantedPoll.providerSessionRef) ||
+      grantedPoll.record.providerSessionRef !==
+        grantedPoll.providerSessionRef ||
+      !Number.isSafeInteger(grantedPoll.pollRevision) ||
+      grantedPoll.pollRevision !== grantedPoll.record.revision
+    ) {
+      return failure("store_unavailable");
+    }
+
+    const providerPoll = await awaitDependency(
+      (context) =>
+        options.client.poll(
+          {
+            ceremonyId,
+            providerSessionRef: grantedPoll.providerSessionRef,
+          },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      requestSignal,
+      "provider"
+    );
+    if (!providerPoll.ok) return providerPoll.result;
+    if (!isValidPollCompletion(providerPoll.value)) {
+      return failure("invalid_provider_response");
+    }
+
+    const completed = await awaitDependency(
+      (context) =>
+        options.store.completePoll(
+          {
+            ceremonyId,
+            scope,
+            nowMilliseconds: now(),
+            pollRevision: grantedPoll.pollRevision,
+            completion: providerPoll.value,
+          },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      requestSignal,
+      "store"
+    );
+    if (!completed.ok) return completed.result;
+    if (completed.value.status === "not_found") return failure("not_found");
+    return resultFromRecord(
+      completed.value.record,
+      scope,
+      ceremonyId,
+      verificationUrl
+    );
+  }
+
+  /** Commits terminal cancellation before bounded provider cleanup. */
+  async function cancel(
+    scope: CodexDeviceScope,
+    ceremonyId: string,
+    requestSignal?: AbortSignal
+  ): Promise<CodexDeviceResult> {
+    if (!isValidScope(scope) || !isValidCeremonyId(ceremonyId)) {
+      return failure("not_found");
+    }
+    const cancellation = await awaitDependency(
+      (context) =>
+        options.store.cancel(
+          { ceremonyId, scope, nowMilliseconds: now() },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      requestSignal,
+      "store"
+    );
+    if (!cancellation.ok) return cancellation.result;
+    if (cancellation.value.status === "not_found") return failure("not_found");
+    const durableCancellation = cancellation.value;
+    if (
+      !isValidRecord(durableCancellation.record, scope, ceremonyId) ||
+      (durableCancellation.providerSessionRef !== undefined &&
+        (!isValidProviderSessionRef(durableCancellation.providerSessionRef) ||
+          durableCancellation.record.providerSessionRef !==
+            durableCancellation.providerSessionRef))
+    ) {
+      return failure("store_unavailable");
+    }
+
+    if (durableCancellation.providerSessionRef) {
+      const providerSessionRef = durableCancellation.providerSessionRef;
+      const providerCancellation = await awaitDependency(
+        (context) =>
+          options.client.cancel(
+            {
+              ceremonyId,
+              providerSessionRef,
+            },
+            context
+          ),
+        options.dependencyTimeoutMilliseconds,
+        requestSignal,
+        "provider"
+      );
+      if (!providerCancellation.ok) return providerCancellation.result;
+    }
+    return resultFromRecord(
+      durableCancellation.record,
+      scope,
+      ceremonyId,
+      verificationUrl
+    );
+  }
+
+  return Object.freeze({ begin, poll, cancel });
+}
+
+/** Bounds one injected dependency and maps all opaque failures to stable codes. */
+async function awaitDependency<T>(
+  operation: (context: ControlPlaneOperationContext) => PromiseLike<T>,
+  timeoutMilliseconds: number,
+  requestSignal: AbortSignal | undefined,
+  kind: "provider" | "store"
+): Promise<
+  | Readonly<{ ok: true; value: T }>
+  | Readonly<{ ok: false; result: CodexDeviceResult }>
+> {
+  const outcome = await awaitControlPlaneOperation(
+    operation,
+    timeoutMilliseconds,
+    requestSignal
+  );
+  if (outcome.status === "fulfilled") return { ok: true, value: outcome.value };
+  if (outcome.status === "aborted") {
+    return { ok: false, result: failure("aborted") };
+  }
+  if (outcome.status === "timed_out") {
+    return { ok: false, result: failure("timed_out") };
+  }
+  return {
+    ok: false,
+    result: failure(
+      kind === "store" ? "store_unavailable" : "provider_unavailable"
+    ),
+  };
+}
+
+/** Projects the only ceremony fields safe for an untrusted browser. */
+function project(
+  record: CodexDeviceCeremonyRecord,
+  verificationUrl: string
+): CodexDeviceProjection {
+  const projection: {
+    ceremonyId: string;
+    status: CodexDeviceStatus;
+    verificationUrl: string;
+    expiresAtMilliseconds: number;
+    pollIntervalMilliseconds: number;
+    userCode?: string;
+    account?: CodexDeviceAccount;
+  } = {
+    ceremonyId: record.ceremonyId,
+    status: record.status,
+    verificationUrl,
+    expiresAtMilliseconds: record.expiresAtMilliseconds,
+    pollIntervalMilliseconds: record.pollIntervalMilliseconds,
+  };
+  if (record.status === "pending" && record.userCode) {
+    projection.userCode = record.userCode;
+  }
+  if (record.status === "authorized" && record.account) {
+    projection.account = Object.freeze({
+      type: record.account.type,
+      present: true,
+    });
+  }
+  return Object.freeze(projection);
+}
+
+/** Validates durable state before returning any portion to the browser. */
+function resultFromRecord(
+  record: CodexDeviceCeremonyRecord,
+  scope: CodexDeviceScope,
+  ceremonyId: string,
+  verificationUrl: string
+): CodexDeviceResult {
+  return isValidRecord(record, scope, ceremonyId)
+    ? success(project(record, verificationUrl))
+    : failure("store_unavailable");
+}
+
+/** Rejects corrupted, over-shaped, or cross-scope durable ceremony records. */
+function isValidRecord(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string
+): value is CodexDeviceCeremonyRecord {
+  if (!isPlainObject(value)) return false;
+  if (
+    value.ceremonyId !== ceremonyId ||
+    !isValidCeremonyId(ceremonyId) ||
+    value.ownerId !== scope.ownerId ||
+    value.connectionId !== scope.connectionId ||
+    value.requestId !== scope.requestId ||
+    ![
+      "starting",
+      "pending",
+      "authorized",
+      "cancelled",
+      "expired",
+      "denied",
+    ].includes(String(value.status))
+  ) {
+    return false;
+  }
+  const finiteIntegers = [
+    value.createdAtMilliseconds,
+    value.expiresAtMilliseconds,
+    value.pollIntervalMilliseconds,
+    value.nextPollAtMilliseconds,
+    value.revision,
+  ];
+  if (
+    !finiteIntegers.every(
+      (item) => typeof item === "number" && Number.isSafeInteger(item)
+    ) ||
+    (value.pollIntervalMilliseconds as number) <= 0 ||
+    (value.revision as number) <= 0 ||
+    (value.expiresAtMilliseconds as number) <=
+      (value.createdAtMilliseconds as number)
+  ) {
+    return false;
+  }
+  if (value.status === "pending") {
+    return (
+      typeof value.userCode === "string" &&
+      USER_CODE_PATTERN.test(value.userCode) &&
+      isValidProviderSessionRef(value.providerSessionRef)
+    );
+  }
+  if (value.status === "authorized") return isValidAccount(value.account);
+  return true;
+}
+
+/** Validates provider begin output without reflecting its malformed values. */
+function isValidBeginOutcome(
+  value: unknown
+): value is CodexDeviceClientBeginOutcome {
+  if (!isPlainObject(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 2 &&
+    keys.includes("providerSessionRef") &&
+    keys.includes("userCode") &&
+    typeof value.providerSessionRef === "string" &&
+    isValidProviderSessionRef(value.providerSessionRef) &&
+    typeof value.userCode === "string" &&
+    USER_CODE_PATTERN.test(value.userCode)
+  );
+}
+
+/** Accepts only the finite provider poll union used by the state machine. */
+function isValidPollCompletion(
+  value: unknown
+): value is CodexDevicePollCompletion {
+  if (!isPlainObject(value) || typeof value.status !== "string") return false;
+  const keys = Object.keys(value);
+  if (["pending", "denied", "expired"].includes(value.status)) {
+    return keys.length === 1;
+  }
+  if (value.status !== "authorized" || keys.length !== 2) return false;
+  return isValidAccount(value.account);
+}
+
+/** Validates the only account presence shape permitted across the boundary. */
+function isValidAccount(value: unknown): value is CodexDeviceAccount {
+  if (!isPlainObject(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 2 &&
+    keys.includes("type") &&
+    keys.includes("present") &&
+    (value.type === "chatgpt" || value.type === "api_key") &&
+    value.present === true
+  );
+}
+
+/** Bounds the opaque server-only provider session reference. */
+function isValidProviderSessionRef(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_PROVIDER_SESSION_REF_LENGTH &&
+    !hasControlCharacters(value)
+  );
+}
+
+/** Detects control bytes without embedding them in a lint-hostile regex. */
+function hasControlCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) return true;
+  }
+  return false;
+}
+
+/** Constrains the browser URL to one server-owned HTTPS URL with no payload. */
+function normalizeOfficialVerificationUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new TypeError("officialVerificationUrl must be a valid HTTPS URL");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.origin === "null"
+  ) {
+    throw new TypeError("officialVerificationUrl must be a clean HTTPS URL");
+  }
+  return url.toString();
+}
+
+/** Validates all finite server policy before any dependency can execute. */
+function validateOptions(options: CodexDeviceFlowOptions): void {
+  for (const value of [
+    options.ceremonyTtlMilliseconds,
+    options.pollIntervalMilliseconds,
+    options.dependencyTimeoutMilliseconds,
+  ]) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new TypeError("device-flow time bounds must be positive integers");
+    }
+  }
+  if (options.pollIntervalMilliseconds >= options.ceremonyTtlMilliseconds) {
+    throw new TypeError("poll interval must be shorter than ceremony TTL");
+  }
+}
+
+/** Validates opaque caller scope without reflecting which field failed. */
+function isValidScope(scope: CodexDeviceScope): boolean {
+  return [scope.ownerId, scope.connectionId, scope.requestId].every(
+    (value) =>
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= MAX_IDENTIFIER_LENGTH
+  );
+}
+
+/** Recognizes the fixed entropy and alphabet of server-generated IDs. */
+function isValidCeremonyId(value: string): boolean {
+  return /^[A-Za-z0-9_-]{32}$/.test(value);
+}
+
+/** Generates a 192-bit opaque identifier without caller-controlled material. */
+function defaultCeremonyId(): string {
+  return randomBytes(CEREMONY_ID_BYTES).toString("base64url");
+}
+
+/** Creates a stable successful result without extra provider fields. */
+function success(ceremony: CodexDeviceProjection): CodexDeviceResult {
+  return Object.freeze({ ok: true, ceremony });
+}
+
+/** Creates one non-reflective browser error shape. */
+function failure(error: CodexDeviceErrorCode): CodexDeviceResult {
+  return Object.freeze({ ok: false, error });
+}
+
+/** Rejects arrays and class instances from provider-controlled results. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export {
+  type ActivateCeremonyOutcome,
+  type CancelCeremonyOutcome,
+  type CodexDeviceAccount,
+  type CodexDeviceAccountType,
+  type CodexDeviceCeremonyRecord,
+  type CodexDeviceCeremonyStore,
+  type CodexDeviceClient,
+  type CodexDeviceClientBeginOutcome,
+  type CodexDeviceErrorCode,
+  type CodexDeviceFlow,
+  type CodexDeviceFlowOptions,
+  type CodexDevicePollCompletion,
+  type CodexDeviceProjection,
+  type CodexDeviceResult,
+  type CodexDeviceScope,
+  type CodexDeviceStatus,
+  type CompletePollOutcome,
+  createCodexDeviceFlow,
+  type PreparePollOutcome,
+  type ReserveCeremonyOutcome,
+};

--- a/services/agent-gateway/codex-device-flow.ts
+++ b/services/agent-gateway/codex-device-flow.ts
@@ -9,8 +9,12 @@ const CEREMONY_ID_BYTES = 24;
 const MAX_CLEANUP_SESSION_REFS = 8;
 const MAX_IDENTIFIER_LENGTH = 160;
 const MAX_PROVIDER_SESSION_REF_LENGTH = 512;
+const MAX_RUNTIME_ARRAY_LENGTH = MAX_CLEANUP_SESSION_REFS;
+const MAX_RUNTIME_OWN_STRING_KEYS = 16;
 const MAX_RUNTIME_SNAPSHOT_DEPTH = 16;
-const MAX_RUNTIME_SNAPSHOT_NODES = 256;
+const MAX_RUNTIME_SNAPSHOT_ENTRIES = 65;
+const MAX_RUNTIME_STRING_CODE_UNITS = 1_024;
+const MAX_RUNTIME_STRING_UTF8_BYTES = 2_048;
 const USER_CODE_PATTERN = /^[A-Z0-9](?:[A-Z0-9-]{2,14}[A-Z0-9])$/;
 const OFFICIAL_CODEX_VERIFICATION_URLS = Object.freeze([
   "https://auth.openai.com/codex/device",
@@ -821,7 +825,7 @@ function awaitCallerLifecycle(
 }
 
 type RuntimeSnapshotState = {
-  nodes: number;
+  entries: number;
   seen: WeakSet<object>;
 };
 
@@ -832,7 +836,7 @@ function parseRuntimeSnapshot<T>(
 ): T | null {
   try {
     const state: RuntimeSnapshotState = {
-      nodes: 0,
+      entries: 0,
       seen: new WeakSet<object>(),
     };
     const snapshot = snapshotRuntimeValue(source, state, 0);
@@ -850,27 +854,32 @@ function snapshotRuntimeValue(
 ): unknown {
   if (
     source === null ||
-    typeof source === "string" ||
     typeof source === "number" ||
     typeof source === "boolean"
   ) {
+    consumeSnapshotEntries(state, 1);
+    return source;
+  }
+  if (typeof source === "string") {
+    consumeSnapshotEntries(state, 1);
+    if (
+      source.length > MAX_RUNTIME_STRING_CODE_UNITS ||
+      Buffer.byteLength(source, "utf8") > MAX_RUNTIME_STRING_UTF8_BYTES
+    ) {
+      throw new TypeError("oversized runtime string");
+    }
     return source;
   }
   if (
     typeof source !== "object" ||
     depth > MAX_RUNTIME_SNAPSHOT_DEPTH ||
-    state.nodes >= MAX_RUNTIME_SNAPSHOT_NODES ||
     state.seen.has(source)
   ) {
     throw new TypeError("invalid runtime snapshot");
   }
-  state.nodes += 1;
+  consumeSnapshotEntries(state, 1);
   state.seen.add(source);
   const prototype = Reflect.getPrototypeOf(source);
-  const keys = Reflect.ownKeys(source);
-  if (keys.some((key) => typeof key === "symbol")) {
-    throw new TypeError("symbol runtime keys are unavailable");
-  }
 
   if (Array.isArray(source)) {
     if (prototype !== Array.prototype) {
@@ -881,33 +890,47 @@ function snapshotRuntimeValue(
     if (
       typeof length !== "number" ||
       !Number.isSafeInteger(length) ||
-      length < 0
+      length < 0 ||
+      length > MAX_RUNTIME_ARRAY_LENGTH
     ) {
       throw new TypeError("invalid runtime array length");
     }
-    const expectedKeys: string[] = Array.from({ length }, (_value, index) =>
-      String(index)
-    );
+    // Length is capped before own-key enumeration so a huge sparse array never
+    // drives an allocation or iteration proportional to its claimed length.
+    const keys = Reflect.ownKeys(source);
     if (
-      keys.length !== expectedKeys.length + 1 ||
-      !keys.includes("length") ||
-      !expectedKeys.every((key) => keys.includes(key))
+      keys.length > MAX_RUNTIME_OWN_STRING_KEYS ||
+      keys.some((key) => typeof key === "symbol") ||
+      keys.length !== length + 1
     ) {
       throw new TypeError("sparse or extended runtime array");
     }
-    const snapshot = expectedKeys.map((key) => {
+    // Charge every own slot plus the primitive length value. Indexed values
+    // are charged recursively below.
+    consumeSnapshotEntries(state, keys.length + 1);
+    const snapshot: unknown[] = [];
+    for (let index = 0; index < length; index += 1) {
+      const key = String(index);
       const descriptor = Reflect.getOwnPropertyDescriptor(source, key);
       if (!descriptor || !("value" in descriptor) || !descriptor.enumerable) {
         throw new TypeError("runtime array accessors are unavailable");
       }
-      return snapshotRuntimeValue(descriptor.value, state, depth + 1);
-    });
+      snapshot.push(snapshotRuntimeValue(descriptor.value, state, depth + 1));
+    }
     return Object.freeze(snapshot);
   }
 
   if (prototype !== Object.prototype && prototype !== null) {
     throw new TypeError("non-plain runtime object");
   }
+  const keys = Reflect.ownKeys(source);
+  if (
+    keys.length > MAX_RUNTIME_OWN_STRING_KEYS ||
+    keys.some((key) => typeof key === "symbol")
+  ) {
+    throw new TypeError("runtime object cardinality is unavailable");
+  }
+  consumeSnapshotEntries(state, keys.length);
   const snapshot = Object.create(null) as Record<string, unknown>;
   for (const key of keys as string[]) {
     const descriptor = Reflect.getOwnPropertyDescriptor(source, key);
@@ -922,6 +945,17 @@ function snapshotRuntimeValue(
     });
   }
   return Object.freeze(snapshot);
+}
+
+/** Charges values and property/array slots to one total snapshot budget. */
+function consumeSnapshotEntries(
+  state: RuntimeSnapshotState,
+  count: number
+): void {
+  if (state.entries + count > MAX_RUNTIME_SNAPSHOT_ENTRIES) {
+    throw new TypeError("runtime snapshot budget exhausted");
+  }
+  state.entries += count;
 }
 
 /** Normalizes caller scope once before it crosses any durable boundary. */

--- a/services/agent-gateway/codex-device-flow.ts
+++ b/services/agent-gateway/codex-device-flow.ts
@@ -9,6 +9,8 @@ const CEREMONY_ID_BYTES = 24;
 const MAX_CLEANUP_SESSION_REFS = 8;
 const MAX_IDENTIFIER_LENGTH = 160;
 const MAX_PROVIDER_SESSION_REF_LENGTH = 512;
+const MAX_RUNTIME_SNAPSHOT_DEPTH = 16;
+const MAX_RUNTIME_SNAPSHOT_NODES = 256;
 const USER_CODE_PATTERN = /^[A-Z0-9](?:[A-Z0-9-]{2,14}[A-Z0-9])$/;
 const OFFICIAL_CODEX_VERIFICATION_URLS = Object.freeze([
   "https://auth.openai.com/codex/device",
@@ -46,6 +48,7 @@ type CodexDeviceCeremonyRecord = Readonly<{
   nextPollAtMilliseconds: number;
   revision: number;
   providerBeginKey: string;
+  providerBeginPending: boolean;
   userCode?: string;
   providerSessionRef?: string;
   cleanupSessionRefs: readonly string[];
@@ -327,7 +330,8 @@ function createCodexDeviceFlow(
     scope: CodexDeviceScope,
     requestSignal?: AbortSignal
   ): Promise<CodexDeviceResult> {
-    if (!safelyValidate(() => isValidScope(scope))) return failure("not_found");
+    const durableScope = parseScopeSnapshot(scope);
+    if (!durableScope) return failure("not_found");
     const nowMilliseconds = readServerTime();
     if (nowMilliseconds === null) return failure("store_unavailable");
     const ceremonyId = safelyCreateOpaqueId(createCeremonyId);
@@ -340,7 +344,7 @@ function createCodexDeviceFlow(
           {
             ceremonyId,
             providerBeginKey,
-            scope,
+            scope: durableScope,
             nowMilliseconds,
             expiresAtMilliseconds:
               nowMilliseconds + options.ceremonyTtlMilliseconds,
@@ -353,13 +357,8 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!reservation.ok) return reservation.result;
-    const reserved = safelyParse(() =>
-      parseReserveOutcome(
-        reservation.value,
-        scope,
-        ceremonyId,
-        providerBeginKey
-      )
+    const reserved = parseRuntimeSnapshot(reservation.value, (value) =>
+      parseReserveOutcome(value, durableScope, ceremonyId, providerBeginKey)
     );
     if (!reserved) return failure("store_unavailable");
     if (reserved.status === "active_other_request") {
@@ -372,11 +371,11 @@ function createCodexDeviceFlow(
 
     const record = reserved.record;
     if (record.status !== "starting") {
-      const cleaned = await drainCleanup(record, scope);
+      const cleaned = await drainCleanup(record, durableScope);
       if (!cleaned.ok) return cleaned.result;
       return resultFromRecord(
         cleaned.record,
-        scope,
+        durableScope,
         record.ceremonyId,
         verificationUrl
       );
@@ -385,12 +384,14 @@ function createCodexDeviceFlow(
     // Once the durable reservation commits, provider settlement and cleanup are
     // server-owned. Caller abort stops waiting but cannot discard a late ref.
     const lifecycleState: BeginLifecycleState = { abortRequested: false };
-    const lifecycle = settleProviderBegin(record, scope, lifecycleState).catch(
-      () => failure("provider_unavailable")
-    );
+    const lifecycle = settleProviderBegin(
+      record,
+      durableScope,
+      lifecycleState
+    ).catch(() => failure("provider_unavailable"));
     return awaitCallerLifecycle(lifecycle, requestSignal, () => {
       lifecycleState.abortRequested = true;
-      return terminalizeAfterCallerAbort(record, scope);
+      return terminalizeAfterCallerAbort(record, durableScope);
     });
   }
 
@@ -416,8 +417,8 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!cancellation.ok) return;
-    const durable = safelyParse(() =>
-      parseCancelOutcome(cancellation.value, scope, record.ceremonyId)
+    const durable = parseRuntimeSnapshot(cancellation.value, (value) =>
+      parseCancelOutcome(value, scope, record.ceremonyId)
     );
     if (!durable || durable.status === "not_found") return;
     await drainCleanup(durable.record, scope);
@@ -429,21 +430,67 @@ function createCodexDeviceFlow(
     scope: CodexDeviceScope,
     lifecycleState: BeginLifecycleState
   ): Promise<CodexDeviceResult> {
-    const providerBegin = await awaitDependency(
-      (context) =>
+    const operationController = new AbortController();
+    const deadlineAtMilliseconds =
+      Date.now() + options.dependencyTimeoutMilliseconds;
+    return new Promise<CodexDeviceResult>((resolve) => {
+      let responseSettled = false;
+      const finishResponse = (result: CodexDeviceResult): void => {
+        if (responseSettled) return;
+        responseSettled = true;
+        clearTimeout(timeout);
+        resolve(result);
+      };
+      const timeout = setTimeout(() => {
+        operationController.abort();
+        finishResponse(failure("timed_out"));
+      }, options.dependencyTimeoutMilliseconds);
+      const rawBegin = Promise.resolve().then(() =>
         options.client.begin(
           {
             ceremonyId: record.ceremonyId,
             providerBeginKey: record.providerBeginKey,
           },
-          context
-        ),
-      options.dependencyTimeoutMilliseconds,
-      undefined,
-      "provider"
+          Object.freeze({
+            signal: operationController.signal,
+            deadlineAtMilliseconds,
+          })
+        )
+      );
+      const durableSettlement = rawBegin.then(
+        (value) => {
+          // A fulfillment owns reconciliation even after the response deadline.
+          clearTimeout(timeout);
+          return recordProviderBeginResult(
+            value,
+            record,
+            scope,
+            lifecycleState
+          );
+        },
+        () => {
+          clearTimeout(timeout);
+          return failure("provider_unavailable");
+        }
+      );
+      durableSettlement.then(finishResponse, () =>
+        finishResponse(failure("provider_unavailable"))
+      );
+    });
+  }
+
+  /** Persists and reconciles one provider begin result, including late success. */
+  async function recordProviderBeginResult(
+    rawProviderResult: unknown,
+    record: CodexDeviceCeremonyRecord,
+    scope: CodexDeviceScope,
+    lifecycleState: BeginLifecycleState
+  ): Promise<CodexDeviceResult> {
+    const providerResult = parseRuntimeSnapshot(
+      rawProviderResult,
+      parseProviderBeginOutcome
     );
-    if (!providerBegin.ok) return providerBegin.result;
-    if (!safelyValidate(() => isValidBeginOutcome(providerBegin.value))) {
+    if (!providerResult) {
       return failure("provider_unavailable");
     }
     const nowMilliseconds = readServerTime();
@@ -456,8 +503,8 @@ function createCodexDeviceFlow(
             providerBeginKey: record.providerBeginKey,
             scope,
             nowMilliseconds,
-            userCode: providerBegin.value.userCode,
-            providerSessionRef: providerBegin.value.providerSessionRef,
+            userCode: providerResult.userCode,
+            providerSessionRef: providerResult.providerSessionRef,
           },
           context
         ),
@@ -466,13 +513,13 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!recordedBegin.ok) return recordedBegin.result;
-    const recorded = safelyParse(() =>
+    const recorded = parseRuntimeSnapshot(recordedBegin.value, (value) =>
       parseRecordBeginOutcome(
-        recordedBegin.value,
+        value,
         scope,
         record.ceremonyId,
         record.providerBeginKey,
-        providerBegin.value.providerSessionRef
+        providerResult.providerSessionRef
       )
     );
     if (!recorded) return failure("store_unavailable");
@@ -498,10 +545,8 @@ function createCodexDeviceFlow(
     ceremonyId: string,
     requestSignal?: AbortSignal
   ): Promise<CodexDeviceResult> {
-    if (
-      !safelyValidate(() => isValidScope(scope)) ||
-      !isValidCeremonyId(ceremonyId)
-    ) {
+    const durableScope = parseScopeSnapshot(scope);
+    if (!durableScope || !isValidCeremonyId(ceremonyId)) {
       return failure("not_found");
     }
     const prepareAtMilliseconds = readServerTime();
@@ -509,7 +554,11 @@ function createCodexDeviceFlow(
     const prepared = await awaitDependency(
       (context) =>
         options.store.preparePoll(
-          { ceremonyId, scope, nowMilliseconds: prepareAtMilliseconds },
+          {
+            ceremonyId,
+            scope: durableScope,
+            nowMilliseconds: prepareAtMilliseconds,
+          },
           context
         ),
       options.dependencyTimeoutMilliseconds,
@@ -517,17 +566,17 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!prepared.ok) return prepared.result;
-    const preparedOutcome = safelyParse(() =>
-      parsePreparePollOutcome(prepared.value, scope, ceremonyId)
+    const preparedOutcome = parseRuntimeSnapshot(prepared.value, (value) =>
+      parsePreparePollOutcome(value, durableScope, ceremonyId)
     );
     if (!preparedOutcome) return failure("store_unavailable");
     if (preparedOutcome.status === "not_found") return failure("not_found");
     if (preparedOutcome.status === "current") {
-      const cleaned = await drainCleanup(preparedOutcome.record, scope);
+      const cleaned = await drainCleanup(preparedOutcome.record, durableScope);
       if (!cleaned.ok) return cleaned.result;
       return resultFromRecord(
         cleaned.record,
-        scope,
+        durableScope,
         ceremonyId,
         verificationUrl
       );
@@ -549,7 +598,11 @@ function createCodexDeviceFlow(
       "provider"
     );
     if (!providerPoll.ok) return providerPoll.result;
-    if (!safelyValidate(() => isValidPollCompletion(providerPoll.value))) {
+    const providerCompletion = parseRuntimeSnapshot(
+      providerPoll.value,
+      parseProviderPollOutcome
+    );
+    if (!providerCompletion) {
       return failure("provider_unavailable");
     }
     const completeAtMilliseconds = readServerTime();
@@ -560,10 +613,10 @@ function createCodexDeviceFlow(
         options.store.completePoll(
           {
             ceremonyId,
-            scope,
+            scope: durableScope,
             nowMilliseconds: completeAtMilliseconds,
             pollRevision: grantedPoll.pollRevision,
-            completion: providerPoll.value,
+            completion: providerCompletion,
           },
           context
         ),
@@ -572,14 +625,19 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!completed.ok) return completed.result;
-    const completedOutcome = safelyParse(() =>
-      parseCompletePollOutcome(completed.value, scope, ceremonyId)
+    const completedOutcome = parseRuntimeSnapshot(completed.value, (value) =>
+      parseCompletePollOutcome(value, durableScope, ceremonyId)
     );
     if (!completedOutcome) return failure("store_unavailable");
     if (completedOutcome.status === "not_found") return failure("not_found");
-    const cleaned = await drainCleanup(completedOutcome.record, scope);
+    const cleaned = await drainCleanup(completedOutcome.record, durableScope);
     if (!cleaned.ok) return cleaned.result;
-    return resultFromRecord(cleaned.record, scope, ceremonyId, verificationUrl);
+    return resultFromRecord(
+      cleaned.record,
+      durableScope,
+      ceremonyId,
+      verificationUrl
+    );
   }
 
   /** Commits terminal cancellation before bounded provider cleanup. */
@@ -588,27 +646,45 @@ function createCodexDeviceFlow(
     ceremonyId: string,
     requestSignal?: AbortSignal
   ): Promise<CodexDeviceResult> {
-    if (
-      !safelyValidate(() => isValidScope(scope)) ||
-      !isValidCeremonyId(ceremonyId)
-    ) {
+    const durableScope = parseScopeSnapshot(scope);
+    if (!durableScope || !isValidCeremonyId(ceremonyId)) {
       return failure("not_found");
     }
+    const lifecycle = commitExplicitCancellation(
+      durableScope,
+      ceremonyId
+    ).catch(() => failure("store_unavailable"));
+    return awaitCallerLifecycle(lifecycle, requestSignal);
+  }
+
+  /** Owns terminal cancellation independently from the browser response signal. */
+  async function commitExplicitCancellation(
+    scope: CodexDeviceScope,
+    ceremonyId: string
+  ): Promise<CodexDeviceResult> {
     const nowMilliseconds = readServerTime();
     if (nowMilliseconds === null) return failure("store_unavailable");
     const cancellation = await awaitDependency(
       (context) =>
         options.store.cancel({ ceremonyId, scope, nowMilliseconds }, context),
       options.dependencyTimeoutMilliseconds,
-      requestSignal,
+      undefined,
       "store"
     );
     if (!cancellation.ok) return cancellation.result;
-    const durableCancellation = safelyParse(() =>
-      parseCancelOutcome(cancellation.value, scope, ceremonyId)
+    const durableCancellation = parseRuntimeSnapshot(
+      cancellation.value,
+      (value) => parseCancelOutcome(value, scope, ceremonyId)
     );
     if (!durableCancellation) return failure("store_unavailable");
     if (durableCancellation.status === "not_found") return failure("not_found");
+    if (durableCancellation.record.providerBeginPending) {
+      // Recovery continues independently; terminal cancellation is already
+      // durable and should not wait for a provider that may settle much later.
+      settleProviderBegin(durableCancellation.record, scope, {
+        abortRequested: true,
+      }).catch(() => failure("provider_unavailable"));
+    }
     const cleaned = await drainCleanup(durableCancellation.record, scope);
     if (!cleaned.ok) return cleaned.result;
     return resultFromRecord(cleaned.record, scope, ceremonyId, verificationUrl);
@@ -643,8 +719,8 @@ function createCodexDeviceFlow(
         "store"
       );
       if (!claimedCleanup.ok) return claimedCleanup;
-      const claimed = safelyParse(() =>
-        parseClaimCleanupOutcome(claimedCleanup.value, scope, record.ceremonyId)
+      const claimed = parseRuntimeSnapshot(claimedCleanup.value, (value) =>
+        parseClaimCleanupOutcome(value, scope, record.ceremonyId)
       );
       if (!claimed) {
         return { ok: false, result: failure("store_unavailable") };
@@ -694,9 +770,9 @@ function createCodexDeviceFlow(
         "store"
       );
       if (!completedCleanup.ok) return completedCleanup;
-      const completed = safelyParse(() =>
+      const completed = parseRuntimeSnapshot(completedCleanup.value, (value) =>
         parseCompleteCleanupOutcome(
-          completedCleanup.value,
+          value,
           scope,
           record.ceremonyId,
           claimed.providerSessionRef
@@ -744,22 +820,115 @@ function awaitCallerLifecycle(
   });
 }
 
-/** Converts hostile accessors or malformed runtime envelopes into null. */
-function safelyParse<T>(parser: () => T | null): T | null {
+type RuntimeSnapshotState = {
+  nodes: number;
+  seen: WeakSet<object>;
+};
+
+/** Copies one injected boundary into a closed, deeply frozen data snapshot. */
+function parseRuntimeSnapshot<T>(
+  source: unknown,
+  parser: (snapshot: unknown) => T | null
+): T | null {
   try {
-    return parser();
+    const state: RuntimeSnapshotState = {
+      nodes: 0,
+      seen: new WeakSet<object>(),
+    };
+    const snapshot = snapshotRuntimeValue(source, state, 0);
+    return parser(snapshot);
   } catch {
     return null;
   }
 }
 
-/** Converts hostile accessors in a runtime validator into a false result. */
-function safelyValidate(validator: () => boolean): boolean {
-  try {
-    return validator();
-  } catch {
-    return false;
+/** Recursively snapshots data properties without invoking source getters. */
+function snapshotRuntimeValue(
+  source: unknown,
+  state: RuntimeSnapshotState,
+  depth: number
+): unknown {
+  if (
+    source === null ||
+    typeof source === "string" ||
+    typeof source === "number" ||
+    typeof source === "boolean"
+  ) {
+    return source;
   }
+  if (
+    typeof source !== "object" ||
+    depth > MAX_RUNTIME_SNAPSHOT_DEPTH ||
+    state.nodes >= MAX_RUNTIME_SNAPSHOT_NODES ||
+    state.seen.has(source)
+  ) {
+    throw new TypeError("invalid runtime snapshot");
+  }
+  state.nodes += 1;
+  state.seen.add(source);
+  const prototype = Reflect.getPrototypeOf(source);
+  const keys = Reflect.ownKeys(source);
+  if (keys.some((key) => typeof key === "symbol")) {
+    throw new TypeError("symbol runtime keys are unavailable");
+  }
+
+  if (Array.isArray(source)) {
+    if (prototype !== Array.prototype) {
+      throw new TypeError("non-plain runtime array");
+    }
+    const lengthDescriptor = Reflect.getOwnPropertyDescriptor(source, "length");
+    const length = lengthDescriptor?.value;
+    if (
+      typeof length !== "number" ||
+      !Number.isSafeInteger(length) ||
+      length < 0
+    ) {
+      throw new TypeError("invalid runtime array length");
+    }
+    const expectedKeys: string[] = Array.from({ length }, (_value, index) =>
+      String(index)
+    );
+    if (
+      keys.length !== expectedKeys.length + 1 ||
+      !keys.includes("length") ||
+      !expectedKeys.every((key) => keys.includes(key))
+    ) {
+      throw new TypeError("sparse or extended runtime array");
+    }
+    const snapshot = expectedKeys.map((key) => {
+      const descriptor = Reflect.getOwnPropertyDescriptor(source, key);
+      if (!descriptor || !("value" in descriptor) || !descriptor.enumerable) {
+        throw new TypeError("runtime array accessors are unavailable");
+      }
+      return snapshotRuntimeValue(descriptor.value, state, depth + 1);
+    });
+    return Object.freeze(snapshot);
+  }
+
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError("non-plain runtime object");
+  }
+  const snapshot = Object.create(null) as Record<string, unknown>;
+  for (const key of keys as string[]) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(source, key);
+    if (!descriptor || !("value" in descriptor) || !descriptor.enumerable) {
+      throw new TypeError("runtime accessors are unavailable");
+    }
+    Object.defineProperty(snapshot, key, {
+      configurable: false,
+      enumerable: true,
+      value: snapshotRuntimeValue(descriptor.value, state, depth + 1),
+      writable: false,
+    });
+  }
+  return Object.freeze(snapshot);
+}
+
+/** Normalizes caller scope once before it crosses any durable boundary. */
+function parseScopeSnapshot(source: unknown): CodexDeviceScope | null {
+  return parseRuntimeSnapshot(source, (snapshot) =>
+    isValidScope(snapshot) ? (snapshot as CodexDeviceScope) : null
+  );
 }
 
 /** Parses the exact atomic reserve envelope before any record dereference. */
@@ -819,6 +988,7 @@ function parseRecordBeginOutcome(
     !hasExactKeys(value, ["status", "record"]) ||
     !isValidRecord(value.record, scope, ceremonyId) ||
     value.record.providerBeginKey !== providerBeginKey ||
+    value.record.providerBeginPending !== false ||
     value.record.status === "starting" ||
     (value.record.providerSessionRef !== providerSessionRef &&
       !value.record.cleanupSessionRefs.includes(providerSessionRef))
@@ -1067,7 +1237,7 @@ function resultFromRecord(
   ceremonyId: string,
   verificationUrl: string
 ): CodexDeviceResult {
-  return safelyValidate(() => isValidRecord(record, scope, ceremonyId))
+  return isValidRecord(record, scope, ceremonyId)
     ? success(project(record, verificationUrl))
     : failure("store_unavailable");
 }
@@ -1079,6 +1249,36 @@ function isValidRecord(
   ceremonyId?: string
 ): value is CodexDeviceCeremonyRecord {
   if (!isPlainObject(value)) return false;
+  const requiredKeys = [
+    "ceremonyId",
+    "ownerId",
+    "connectionId",
+    "requestId",
+    "status",
+    "createdAtMilliseconds",
+    "expiresAtMilliseconds",
+    "pollIntervalMilliseconds",
+    "nextPollAtMilliseconds",
+    "revision",
+    "providerBeginKey",
+    "providerBeginPending",
+    "cleanupSessionRefs",
+  ];
+  const allowedKeys = new Set([
+    ...requiredKeys,
+    "userCode",
+    "providerSessionRef",
+    "account",
+  ]);
+  const recordKeys = Object.keys(value);
+  if (
+    !requiredKeys.every((key) =>
+      Object.prototype.hasOwnProperty.call(value, key)
+    ) ||
+    recordKeys.some((key) => !allowedKeys.has(key))
+  ) {
+    return false;
+  }
   if (
     !isValidCeremonyId(value.ceremonyId) ||
     (ceremonyId !== undefined && value.ceremonyId !== ceremonyId) ||
@@ -1098,6 +1298,7 @@ function isValidRecord(
   }
   if (
     !isValidCeremonyId(value.providerBeginKey) ||
+    typeof value.providerBeginPending !== "boolean" ||
     !Array.isArray(value.cleanupSessionRefs) ||
     value.cleanupSessionRefs.length > MAX_CLEANUP_SESSION_REFS ||
     !value.cleanupSessionRefs.every(isValidProviderSessionRef) ||
@@ -1110,7 +1311,8 @@ function isValidRecord(
     (value.userCode !== undefined ||
       value.providerSessionRef !== undefined ||
       value.account !== undefined ||
-      value.cleanupSessionRefs.length !== 0)
+      value.cleanupSessionRefs.length !== 0 ||
+      value.providerBeginPending !== true)
   ) {
     return false;
   }
@@ -1138,7 +1340,8 @@ function isValidRecord(
       USER_CODE_PATTERN.test(value.userCode) &&
       isValidProviderSessionRef(value.providerSessionRef) &&
       !value.cleanupSessionRefs.includes(value.providerSessionRef) &&
-      value.account === undefined
+      value.account === undefined &&
+      value.providerBeginPending === false
     );
   }
   if (
@@ -1169,6 +1372,15 @@ function isValidBeginOutcome(
   );
 }
 
+/** Returns only a pre-snapshotted, closed provider begin envelope. */
+function parseProviderBeginOutcome(
+  value: unknown
+): CodexDeviceClientBeginOutcome | null {
+  return isValidBeginOutcome(value)
+    ? (value as CodexDeviceClientBeginOutcome)
+    : null;
+}
+
 /** Accepts only the finite provider poll union used by the state machine. */
 function isValidPollCompletion(
   value: unknown
@@ -1180,6 +1392,15 @@ function isValidPollCompletion(
   }
   if (value.status !== "authorized" || keys.length !== 2) return false;
   return isValidAccount(value.account);
+}
+
+/** Returns only a pre-snapshotted, subscription-safe poll completion. */
+function parseProviderPollOutcome(
+  value: unknown
+): CodexDevicePollCompletion | null {
+  return isValidPollCompletion(value)
+    ? (value as CodexDevicePollCompletion)
+    : null;
 }
 
 /** Validates the only account presence shape permitted across the boundary. */

--- a/services/agent-gateway/codex-device-flow.ts
+++ b/services/agent-gateway/codex-device-flow.ts
@@ -6,11 +6,15 @@ import {
 } from "./control-plane.ts";
 
 const CEREMONY_ID_BYTES = 24;
+const MAX_CLEANUP_SESSION_REFS = 8;
 const MAX_IDENTIFIER_LENGTH = 160;
 const MAX_PROVIDER_SESSION_REF_LENGTH = 512;
 const USER_CODE_PATTERN = /^[A-Z0-9](?:[A-Z0-9-]{2,14}[A-Z0-9])$/;
+const OFFICIAL_CODEX_VERIFICATION_URLS = Object.freeze([
+  "https://auth.openai.com/codex/device",
+] as const);
 
-type CodexDeviceAccountType = "chatgpt" | "api_key";
+type CodexDeviceAccountType = "chatgpt";
 type CodexDeviceStatus =
   | "starting"
   | "pending"
@@ -41,8 +45,10 @@ type CodexDeviceCeremonyRecord = Readonly<{
   pollIntervalMilliseconds: number;
   nextPollAtMilliseconds: number;
   revision: number;
+  providerBeginKey: string;
   userCode?: string;
   providerSessionRef?: string;
+  cleanupSessionRefs: readonly string[];
   account?: CodexDeviceAccount;
 }>;
 
@@ -59,7 +65,6 @@ type CodexDeviceProjection = Readonly<{
 type CodexDeviceErrorCode =
   | "aborted"
   | "active_ceremony_exists"
-  | "invalid_provider_response"
   | "not_found"
   | "provider_unavailable"
   | "store_unavailable"
@@ -76,8 +81,8 @@ type ReserveCeremonyOutcome =
   | Readonly<{ status: "not_found" }>
   | Readonly<{ status: "id_collision" }>;
 
-type ActivateCeremonyOutcome =
-  | Readonly<{ status: "activated"; record: CodexDeviceCeremonyRecord }>
+type RecordBeginOutcome =
+  | Readonly<{ status: "recorded"; record: CodexDeviceCeremonyRecord }>
   | Readonly<{ status: "current"; record: CodexDeviceCeremonyRecord }>
   | Readonly<{ status: "not_found" }>;
 
@@ -103,7 +108,24 @@ type CancelCeremonyOutcome =
   | Readonly<{
       status: "cancelled" | "current";
       record: CodexDeviceCeremonyRecord;
-      providerSessionRef?: string;
+    }>
+  | Readonly<{ status: "not_found" }>;
+
+type ClaimCleanupOutcome =
+  | Readonly<{
+      status: "granted";
+      record: CodexDeviceCeremonyRecord;
+      cleanupRevision: number;
+      providerBeginKey: string;
+      providerSessionRef: string;
+    }>
+  | Readonly<{ status: "current"; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "not_found" }>;
+
+type CompleteCleanupOutcome =
+  | Readonly<{
+      status: "completed" | "current";
+      record: CodexDeviceCeremonyRecord;
     }>
   | Readonly<{ status: "not_found" }>;
 
@@ -120,12 +142,13 @@ type CodexDeviceClientBeginOutcome = Readonly<{
 
 interface CodexDeviceClient {
   /**
-   * Starts or recovers a provider ceremony idempotently by ceremonyId.
+   * Starts or recovers a provider ceremony atomically and idempotently by the
+   * persisted ceremonyId/providerBeginKey pair across processes and restarts.
    * Implementations must never vary command, model, home, or environment from
    * caller input because none of those values are accepted by this contract.
    */
   begin(
-    input: Readonly<{ ceremonyId: string }>,
+    input: Readonly<{ ceremonyId: string; providerBeginKey: string }>,
     context: ControlPlaneOperationContext
   ): PromiseLike<CodexDeviceClientBeginOutcome>;
 
@@ -133,15 +156,17 @@ interface CodexDeviceClient {
   poll(
     input: Readonly<{
       ceremonyId: string;
+      providerBeginKey: string;
       providerSessionRef: string;
     }>,
     context: ControlPlaneOperationContext
   ): PromiseLike<CodexDevicePollCompletion>;
 
-  /** Cancels a provider ceremony idempotently by ceremonyId. */
+  /** Cancels one exact provider session idempotently by persisted begin key. */
   cancel(
     input: Readonly<{
       ceremonyId: string;
+      providerBeginKey: string;
       providerSessionRef: string;
     }>,
     context: ControlPlaneOperationContext
@@ -159,6 +184,7 @@ interface CodexDeviceCeremonyStore {
   reserve(
     input: Readonly<{
       ceremonyId: string;
+      providerBeginKey: string;
       scope: CodexDeviceScope;
       nowMilliseconds: number;
       expiresAtMilliseconds: number;
@@ -167,17 +193,22 @@ interface CodexDeviceCeremonyStore {
     context: ControlPlaneOperationContext
   ): PromiseLike<ReserveCeremonyOutcome>;
 
-  /** Activates only the matching starting record, or returns current state. */
-  activate(
+  /**
+   * Atomically records every idempotent begin result. The first result may
+   * activate a starting record; terminal and race-loser references must be
+   * retained in cleanupSessionRefs until completeCleanup removes them.
+   */
+  recordBegin(
     input: Readonly<{
       ceremonyId: string;
+      providerBeginKey: string;
       scope: CodexDeviceScope;
       nowMilliseconds: number;
       userCode: string;
       providerSessionRef: string;
     }>,
     context: ControlPlaneOperationContext
-  ): PromiseLike<ActivateCeremonyOutcome>;
+  ): PromiseLike<RecordBeginOutcome>;
 
   /**
    * Atomically validates scope, applies expiry and poll throttling, and grants
@@ -213,6 +244,28 @@ interface CodexDeviceCeremonyStore {
     }>,
     context: ControlPlaneOperationContext
   ): PromiseLike<CancelCeremonyOutcome>;
+
+  /** Atomically grants one retained provider session for idempotent cleanup. */
+  claimCleanup(
+    input: Readonly<{
+      ceremonyId: string;
+      scope: CodexDeviceScope;
+      nowMilliseconds: number;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<ClaimCleanupOutcome>;
+
+  /** Removes only the exact cleanup revision/reference after provider success. */
+  completeCleanup(
+    input: Readonly<{
+      ceremonyId: string;
+      scope: CodexDeviceScope;
+      nowMilliseconds: number;
+      cleanupRevision: number;
+      providerSessionRef: string;
+    }>,
+    context: ControlPlaneOperationContext
+  ): PromiseLike<CompleteCleanupOutcome>;
 }
 
 type CodexDeviceFlowOptions = Readonly<{
@@ -224,6 +277,7 @@ type CodexDeviceFlowOptions = Readonly<{
   dependencyTimeoutMilliseconds: number;
   now?: () => number;
   createCeremonyId?: () => string;
+  createProviderBeginKey?: () => string;
 }>;
 
 type CodexDeviceFlow = Readonly<{
@@ -243,6 +297,8 @@ type CodexDeviceFlow = Readonly<{
   ) => Promise<CodexDeviceResult>;
 }>;
 
+type BeginLifecycleState = { abortRequested: boolean };
+
 /** Creates the provider-neutral Codex device authorization coordinator. */
 function createCodexDeviceFlow(
   options: CodexDeviceFlowOptions
@@ -253,22 +309,37 @@ function createCodexDeviceFlow(
   );
   const now = options.now ?? Date.now;
   const createCeremonyId = options.createCeremonyId ?? defaultCeremonyId;
+  const createProviderBeginKey =
+    options.createProviderBeginKey ?? defaultCeremonyId;
+
+  /** Reads the injected clock without exposing exceptions or invalid values. */
+  function readServerTime(): number | null {
+    try {
+      const value = now();
+      return isValidTimestamp(value) ? value : null;
+    } catch {
+      return null;
+    }
+  }
 
   /** Starts or recovers one request-bound ceremony without duplicate sessions. */
   async function begin(
     scope: CodexDeviceScope,
     requestSignal?: AbortSignal
   ): Promise<CodexDeviceResult> {
-    if (!isValidScope(scope)) return failure("not_found");
-    const nowMilliseconds = now();
-    const ceremonyId = createCeremonyId();
-    if (!isValidCeremonyId(ceremonyId)) return failure("store_unavailable");
+    if (!safelyValidate(() => isValidScope(scope))) return failure("not_found");
+    const nowMilliseconds = readServerTime();
+    if (nowMilliseconds === null) return failure("store_unavailable");
+    const ceremonyId = safelyCreateOpaqueId(createCeremonyId);
+    const providerBeginKey = safelyCreateOpaqueId(createProviderBeginKey);
+    if (!ceremonyId || !providerBeginKey) return failure("store_unavailable");
 
     const reservation = await awaitDependency(
       (context) =>
         options.store.reserve(
           {
             ceremonyId,
+            providerBeginKey,
             scope,
             nowMilliseconds,
             expiresAtMilliseconds:
@@ -282,85 +353,139 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!reservation.ok) return reservation.result;
-    if (reservation.value.status === "active_other_request") {
+    const reserved = safelyParse(() =>
+      parseReserveOutcome(
+        reservation.value,
+        scope,
+        ceremonyId,
+        providerBeginKey
+      )
+    );
+    if (!reserved) return failure("store_unavailable");
+    if (reserved.status === "active_other_request") {
       return failure("active_ceremony_exists");
     }
-    if (reservation.value.status === "not_found") return failure("not_found");
-    if (reservation.value.status === "id_collision") {
+    if (reserved.status === "not_found") return failure("not_found");
+    if (reserved.status === "id_collision") {
       return failure("store_unavailable");
     }
 
-    const record = reservation.value.record;
-    if (!isValidRecord(record, scope, record.ceremonyId)) {
-      return failure("store_unavailable");
-    }
+    const record = reserved.record;
     if (record.status !== "starting") {
+      const cleaned = await drainCleanup(record, scope);
+      if (!cleaned.ok) return cleaned.result;
       return resultFromRecord(
-        record,
+        cleaned.record,
         scope,
         record.ceremonyId,
         verificationUrl
       );
     }
 
-    const providerBegin = await awaitDependency(
-      (context) =>
-        options.client.begin({ ceremonyId: record.ceremonyId }, context),
-      options.dependencyTimeoutMilliseconds,
-      requestSignal,
-      "provider"
+    // Once the durable reservation commits, provider settlement and cleanup are
+    // server-owned. Caller abort stops waiting but cannot discard a late ref.
+    const lifecycleState: BeginLifecycleState = { abortRequested: false };
+    const lifecycle = settleProviderBegin(record, scope, lifecycleState).catch(
+      () => failure("provider_unavailable")
     );
-    if (!providerBegin.ok) return providerBegin.result;
-    if (!isValidBeginOutcome(providerBegin.value)) {
-      return failure("invalid_provider_response");
-    }
+    return awaitCallerLifecycle(lifecycle, requestSignal, () => {
+      lifecycleState.abortRequested = true;
+      return terminalizeAfterCallerAbort(record, scope);
+    });
+  }
 
-    const activation = await awaitDependency(
+  /** Makes caller-aborted begin terminal while the provider settles independently. */
+  async function terminalizeAfterCallerAbort(
+    record: CodexDeviceCeremonyRecord,
+    scope: CodexDeviceScope
+  ): Promise<void> {
+    const nowMilliseconds = readServerTime();
+    if (nowMilliseconds === null) return;
+    const cancellation = await awaitDependency(
       (context) =>
-        options.store.activate(
+        options.store.cancel(
           {
             ceremonyId: record.ceremonyId,
             scope,
-            nowMilliseconds: now(),
+            nowMilliseconds,
+          },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      undefined,
+      "store"
+    );
+    if (!cancellation.ok) return;
+    const durable = safelyParse(() =>
+      parseCancelOutcome(cancellation.value, scope, record.ceremonyId)
+    );
+    if (!durable || durable.status === "not_found") return;
+    await drainCleanup(durable.record, scope);
+  }
+
+  /** Records an idempotent provider begin result before any cleanup attempt. */
+  async function settleProviderBegin(
+    record: CodexDeviceCeremonyRecord,
+    scope: CodexDeviceScope,
+    lifecycleState: BeginLifecycleState
+  ): Promise<CodexDeviceResult> {
+    const providerBegin = await awaitDependency(
+      (context) =>
+        options.client.begin(
+          {
+            ceremonyId: record.ceremonyId,
+            providerBeginKey: record.providerBeginKey,
+          },
+          context
+        ),
+      options.dependencyTimeoutMilliseconds,
+      undefined,
+      "provider"
+    );
+    if (!providerBegin.ok) return providerBegin.result;
+    if (!safelyValidate(() => isValidBeginOutcome(providerBegin.value))) {
+      return failure("provider_unavailable");
+    }
+    const nowMilliseconds = readServerTime();
+    if (nowMilliseconds === null) return failure("store_unavailable");
+    const recordedBegin = await awaitDependency(
+      (context) =>
+        options.store.recordBegin(
+          {
+            ceremonyId: record.ceremonyId,
+            providerBeginKey: record.providerBeginKey,
+            scope,
+            nowMilliseconds,
             userCode: providerBegin.value.userCode,
             providerSessionRef: providerBegin.value.providerSessionRef,
           },
           context
         ),
       options.dependencyTimeoutMilliseconds,
-      requestSignal,
+      undefined,
       "store"
     );
-    if (!activation.ok) return activation.result;
-    if (activation.value.status === "not_found") return failure("not_found");
-    if (!isValidRecord(activation.value.record, scope, record.ceremonyId)) {
-      return failure("store_unavailable");
+    if (!recordedBegin.ok) return recordedBegin.result;
+    const recorded = safelyParse(() =>
+      parseRecordBeginOutcome(
+        recordedBegin.value,
+        scope,
+        record.ceremonyId,
+        record.providerBeginKey,
+        providerBegin.value.providerSessionRef
+      )
+    );
+    if (!recorded) return failure("store_unavailable");
+    if (recorded.status === "not_found") return failure("not_found");
+    if (lifecycleState.abortRequested) {
+      // Retry the durable terminal transition after the ref is recorded. This
+      // closes an ambiguous or failed first cancellation attempt during abort.
+      await terminalizeAfterCallerAbort(recorded.record, scope);
     }
-    if (
-      activation.value.status === "current" &&
-      (activation.value.record.status === "cancelled" ||
-        activation.value.record.status === "expired")
-    ) {
-      // A provider begin can settle after the durable ceremony became terminal.
-      // Cancel that newly learned session, but never cancel a concurrently
-      // activated pending session owned by the same idempotency key.
-      const cleanup = await awaitDependency(
-        (context) =>
-          options.client.cancel(
-            {
-              ceremonyId: record.ceremonyId,
-              providerSessionRef: providerBegin.value.providerSessionRef,
-            },
-            context
-          ),
-        options.dependencyTimeoutMilliseconds,
-        requestSignal,
-        "provider"
-      );
-      if (!cleanup.ok) return cleanup.result;
-    }
+    const cleaned = await drainCleanup(recorded.record, scope);
+    if (!cleaned.ok) return cleaned.result;
     return resultFromRecord(
-      activation.value.record,
+      cleaned.record,
       scope,
       record.ceremonyId,
       verificationUrl
@@ -373,13 +498,18 @@ function createCodexDeviceFlow(
     ceremonyId: string,
     requestSignal?: AbortSignal
   ): Promise<CodexDeviceResult> {
-    if (!isValidScope(scope) || !isValidCeremonyId(ceremonyId)) {
+    if (
+      !safelyValidate(() => isValidScope(scope)) ||
+      !isValidCeremonyId(ceremonyId)
+    ) {
       return failure("not_found");
     }
+    const prepareAtMilliseconds = readServerTime();
+    if (prepareAtMilliseconds === null) return failure("store_unavailable");
     const prepared = await awaitDependency(
       (context) =>
         options.store.preparePoll(
-          { ceremonyId, scope, nowMilliseconds: now() },
+          { ceremonyId, scope, nowMilliseconds: prepareAtMilliseconds },
           context
         ),
       options.dependencyTimeoutMilliseconds,
@@ -387,33 +517,29 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!prepared.ok) return prepared.result;
-    if (prepared.value.status === "not_found") return failure("not_found");
-    if (prepared.value.status === "current") {
+    const preparedOutcome = safelyParse(() =>
+      parsePreparePollOutcome(prepared.value, scope, ceremonyId)
+    );
+    if (!preparedOutcome) return failure("store_unavailable");
+    if (preparedOutcome.status === "not_found") return failure("not_found");
+    if (preparedOutcome.status === "current") {
+      const cleaned = await drainCleanup(preparedOutcome.record, scope);
+      if (!cleaned.ok) return cleaned.result;
       return resultFromRecord(
-        prepared.value.record,
+        cleaned.record,
         scope,
         ceremonyId,
         verificationUrl
       );
     }
-    const grantedPoll = prepared.value;
-    if (
-      !isValidRecord(grantedPoll.record, scope, ceremonyId) ||
-      grantedPoll.record.status !== "pending" ||
-      !isValidProviderSessionRef(grantedPoll.providerSessionRef) ||
-      grantedPoll.record.providerSessionRef !==
-        grantedPoll.providerSessionRef ||
-      !Number.isSafeInteger(grantedPoll.pollRevision) ||
-      grantedPoll.pollRevision !== grantedPoll.record.revision
-    ) {
-      return failure("store_unavailable");
-    }
+    const grantedPoll = preparedOutcome;
 
     const providerPoll = await awaitDependency(
       (context) =>
         options.client.poll(
           {
             ceremonyId,
+            providerBeginKey: grantedPoll.record.providerBeginKey,
             providerSessionRef: grantedPoll.providerSessionRef,
           },
           context
@@ -423,9 +549,11 @@ function createCodexDeviceFlow(
       "provider"
     );
     if (!providerPoll.ok) return providerPoll.result;
-    if (!isValidPollCompletion(providerPoll.value)) {
-      return failure("invalid_provider_response");
+    if (!safelyValidate(() => isValidPollCompletion(providerPoll.value))) {
+      return failure("provider_unavailable");
     }
+    const completeAtMilliseconds = readServerTime();
+    if (completeAtMilliseconds === null) return failure("store_unavailable");
 
     const completed = await awaitDependency(
       (context) =>
@@ -433,7 +561,7 @@ function createCodexDeviceFlow(
           {
             ceremonyId,
             scope,
-            nowMilliseconds: now(),
+            nowMilliseconds: completeAtMilliseconds,
             pollRevision: grantedPoll.pollRevision,
             completion: providerPoll.value,
           },
@@ -444,13 +572,14 @@ function createCodexDeviceFlow(
       "store"
     );
     if (!completed.ok) return completed.result;
-    if (completed.value.status === "not_found") return failure("not_found");
-    return resultFromRecord(
-      completed.value.record,
-      scope,
-      ceremonyId,
-      verificationUrl
+    const completedOutcome = safelyParse(() =>
+      parseCompletePollOutcome(completed.value, scope, ceremonyId)
     );
+    if (!completedOutcome) return failure("store_unavailable");
+    if (completedOutcome.status === "not_found") return failure("not_found");
+    const cleaned = await drainCleanup(completedOutcome.record, scope);
+    if (!cleaned.ok) return cleaned.result;
+    return resultFromRecord(cleaned.record, scope, ceremonyId, verificationUrl);
   }
 
   /** Commits terminal cancellation before bounded provider cleanup. */
@@ -459,58 +588,404 @@ function createCodexDeviceFlow(
     ceremonyId: string,
     requestSignal?: AbortSignal
   ): Promise<CodexDeviceResult> {
-    if (!isValidScope(scope) || !isValidCeremonyId(ceremonyId)) {
+    if (
+      !safelyValidate(() => isValidScope(scope)) ||
+      !isValidCeremonyId(ceremonyId)
+    ) {
       return failure("not_found");
     }
+    const nowMilliseconds = readServerTime();
+    if (nowMilliseconds === null) return failure("store_unavailable");
     const cancellation = await awaitDependency(
       (context) =>
-        options.store.cancel(
-          { ceremonyId, scope, nowMilliseconds: now() },
-          context
-        ),
+        options.store.cancel({ ceremonyId, scope, nowMilliseconds }, context),
       options.dependencyTimeoutMilliseconds,
       requestSignal,
       "store"
     );
     if (!cancellation.ok) return cancellation.result;
-    if (cancellation.value.status === "not_found") return failure("not_found");
-    const durableCancellation = cancellation.value;
-    if (
-      !isValidRecord(durableCancellation.record, scope, ceremonyId) ||
-      (durableCancellation.providerSessionRef !== undefined &&
-        (!isValidProviderSessionRef(durableCancellation.providerSessionRef) ||
-          durableCancellation.record.providerSessionRef !==
-            durableCancellation.providerSessionRef))
-    ) {
-      return failure("store_unavailable");
-    }
+    const durableCancellation = safelyParse(() =>
+      parseCancelOutcome(cancellation.value, scope, ceremonyId)
+    );
+    if (!durableCancellation) return failure("store_unavailable");
+    if (durableCancellation.status === "not_found") return failure("not_found");
+    const cleaned = await drainCleanup(durableCancellation.record, scope);
+    if (!cleaned.ok) return cleaned.result;
+    return resultFromRecord(cleaned.record, scope, ceremonyId, verificationUrl);
+  }
 
-    if (durableCancellation.providerSessionRef) {
-      const providerSessionRef = durableCancellation.providerSessionRef;
-      const providerCancellation = await awaitDependency(
+  /** Drains durable cleanup work under server-owned deadlines, never caller abort. */
+  async function drainCleanup(
+    initialRecord: CodexDeviceCeremonyRecord,
+    scope: CodexDeviceScope
+  ): Promise<
+    | Readonly<{ ok: true; record: CodexDeviceCeremonyRecord }>
+    | Readonly<{ ok: false; result: CodexDeviceResult }>
+  > {
+    let record = initialRecord;
+    for (let attempt = 0; attempt < MAX_CLEANUP_SESSION_REFS; attempt += 1) {
+      const claimAtMilliseconds = readServerTime();
+      if (claimAtMilliseconds === null) {
+        return { ok: false, result: failure("store_unavailable") };
+      }
+      const claimedCleanup = await awaitDependency(
         (context) =>
-          options.client.cancel(
+          options.store.claimCleanup(
             {
-              ceremonyId,
-              providerSessionRef,
+              ceremonyId: record.ceremonyId,
+              scope,
+              nowMilliseconds: claimAtMilliseconds,
             },
             context
           ),
         options.dependencyTimeoutMilliseconds,
-        requestSignal,
+        undefined,
+        "store"
+      );
+      if (!claimedCleanup.ok) return claimedCleanup;
+      const claimed = safelyParse(() =>
+        parseClaimCleanupOutcome(claimedCleanup.value, scope, record.ceremonyId)
+      );
+      if (!claimed) {
+        return { ok: false, result: failure("store_unavailable") };
+      }
+      if (claimed.status === "not_found") {
+        return { ok: false, result: failure("not_found") };
+      }
+      record = claimed.record;
+      if (claimed.status === "current") return { ok: true, record };
+
+      const providerCancellation = await awaitDependency(
+        (context) =>
+          options.client.cancel(
+            {
+              ceremonyId: record.ceremonyId,
+              providerBeginKey: claimed.providerBeginKey,
+              providerSessionRef: claimed.providerSessionRef,
+            },
+            context
+          ),
+        options.dependencyTimeoutMilliseconds,
+        undefined,
         "provider"
       );
-      if (!providerCancellation.ok) return providerCancellation.result;
+      if (!providerCancellation.ok) return providerCancellation;
+      if (providerCancellation.value !== undefined) {
+        return { ok: false, result: failure("provider_unavailable") };
+      }
+      const completeAtMilliseconds = readServerTime();
+      if (completeAtMilliseconds === null) {
+        return { ok: false, result: failure("store_unavailable") };
+      }
+      const completedCleanup = await awaitDependency(
+        (context) =>
+          options.store.completeCleanup(
+            {
+              ceremonyId: record.ceremonyId,
+              scope,
+              nowMilliseconds: completeAtMilliseconds,
+              cleanupRevision: claimed.cleanupRevision,
+              providerSessionRef: claimed.providerSessionRef,
+            },
+            context
+          ),
+        options.dependencyTimeoutMilliseconds,
+        undefined,
+        "store"
+      );
+      if (!completedCleanup.ok) return completedCleanup;
+      const completed = safelyParse(() =>
+        parseCompleteCleanupOutcome(
+          completedCleanup.value,
+          scope,
+          record.ceremonyId,
+          claimed.providerSessionRef
+        )
+      );
+      if (!completed) {
+        return { ok: false, result: failure("store_unavailable") };
+      }
+      if (completed.status === "not_found") {
+        return { ok: false, result: failure("not_found") };
+      }
+      record = completed.record;
     }
-    return resultFromRecord(
-      durableCancellation.record,
-      scope,
-      ceremonyId,
-      verificationUrl
-    );
+    return record.cleanupSessionRefs.length === 0
+      ? { ok: true, record }
+      : { ok: false, result: failure("store_unavailable") };
   }
 
   return Object.freeze({ begin, poll, cancel });
+}
+
+/** Lets a caller stop waiting without aborting the server-owned lifecycle. */
+function awaitCallerLifecycle(
+  lifecycle: Promise<CodexDeviceResult>,
+  requestSignal?: AbortSignal,
+  onAbort?: () => Promise<void>
+): Promise<CodexDeviceResult> {
+  if (!requestSignal) return lifecycle;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: CodexDeviceResult): void => {
+      if (settled) return;
+      settled = true;
+      requestSignal.removeEventListener("abort", handleAbort);
+      resolve(result);
+    };
+    const handleAbort = (): void => {
+      // The server-owned terminal transition continues after the response.
+      onAbort?.().catch(() => undefined);
+      finish(failure("aborted"));
+    };
+    requestSignal.addEventListener("abort", handleAbort, { once: true });
+    if (requestSignal.aborted) handleAbort();
+    lifecycle.then(finish, () => finish(failure("provider_unavailable")));
+  });
+}
+
+/** Converts hostile accessors or malformed runtime envelopes into null. */
+function safelyParse<T>(parser: () => T | null): T | null {
+  try {
+    return parser();
+  } catch {
+    return null;
+  }
+}
+
+/** Converts hostile accessors in a runtime validator into a false result. */
+function safelyValidate(validator: () => boolean): boolean {
+  try {
+    return validator();
+  } catch {
+    return false;
+  }
+}
+
+/** Parses the exact atomic reserve envelope before any record dereference. */
+function parseReserveOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  proposedCeremonyId: string,
+  proposedProviderBeginKey: string
+): ReserveCeremonyOutcome | null {
+  if (!isPlainObject(value) || typeof value.status !== "string") return null;
+  if (
+    ["active_other_request", "not_found", "id_collision"].includes(value.status)
+  ) {
+    return hasExactKeys(value, ["status"])
+      ? (value as ReserveCeremonyOutcome)
+      : null;
+  }
+  if (
+    (value.status !== "reserved" && value.status !== "same_request") ||
+    !hasExactKeys(value, ["status", "record"]) ||
+    !isValidRecord(value.record, scope)
+  ) {
+    return null;
+  }
+  if (
+    value.status === "reserved" &&
+    (value.record.ceremonyId !== proposedCeremonyId ||
+      value.record.providerBeginKey !== proposedProviderBeginKey ||
+      value.record.status !== "starting")
+  ) {
+    return null;
+  }
+  if (
+    value.status === "same_request" &&
+    value.record.status !== "starting" &&
+    value.record.status !== "pending"
+  ) {
+    return null;
+  }
+  return value as ReserveCeremonyOutcome;
+}
+
+/** Parses the exact durable provider-begin result envelope. */
+function parseRecordBeginOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string,
+  providerBeginKey: string,
+  providerSessionRef: string
+): RecordBeginOutcome | null {
+  if (!isPlainObject(value) || typeof value.status !== "string") return null;
+  if (value.status === "not_found") {
+    return hasExactKeys(value, ["status"]) ? { status: "not_found" } : null;
+  }
+  if (
+    (value.status !== "recorded" && value.status !== "current") ||
+    !hasExactKeys(value, ["status", "record"]) ||
+    !isValidRecord(value.record, scope, ceremonyId) ||
+    value.record.providerBeginKey !== providerBeginKey ||
+    value.record.status === "starting" ||
+    (value.record.providerSessionRef !== providerSessionRef &&
+      !value.record.cleanupSessionRefs.includes(providerSessionRef))
+  ) {
+    return null;
+  }
+  return value as RecordBeginOutcome;
+}
+
+/** Parses and verifies poll grants before a provider session is touched. */
+function parsePreparePollOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string
+): PreparePollOutcome | null {
+  if (!isPlainObject(value) || typeof value.status !== "string") return null;
+  if (value.status === "not_found") {
+    return hasExactKeys(value, ["status"]) ? { status: "not_found" } : null;
+  }
+  if (value.status === "current") {
+    return hasExactKeys(value, ["status", "record"]) &&
+      isValidRecord(value.record, scope, ceremonyId)
+      ? (value as PreparePollOutcome)
+      : null;
+  }
+  if (
+    value.status !== "granted" ||
+    !hasExactKeys(value, [
+      "status",
+      "record",
+      "pollRevision",
+      "providerSessionRef",
+    ]) ||
+    !isValidRecord(value.record, scope, ceremonyId) ||
+    value.record.status !== "pending" ||
+    !isValidProviderSessionRef(value.providerSessionRef) ||
+    value.record.providerSessionRef !== value.providerSessionRef ||
+    !Number.isSafeInteger(value.pollRevision) ||
+    value.pollRevision !== value.record.revision
+  ) {
+    return null;
+  }
+  return value as PreparePollOutcome;
+}
+
+/** Parses the exact poll-completion store envelope. */
+function parseCompletePollOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string
+): CompletePollOutcome | null {
+  const parsed = parseRecordOutcome(value, scope, ceremonyId, [
+    "completed",
+    "stale",
+  ]) as CompletePollOutcome | null;
+  if (
+    parsed?.status === "completed" &&
+    !["pending", "authorized", "denied", "expired"].includes(
+      parsed.record.status
+    )
+  ) {
+    return null;
+  }
+  return parsed;
+}
+
+/** Parses the exact cancellation store envelope. */
+function parseCancelOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string
+): CancelCeremonyOutcome | null {
+  const parsed = parseRecordOutcome(value, scope, ceremonyId, [
+    "cancelled",
+    "current",
+  ]) as CancelCeremonyOutcome | null;
+  if (
+    (parsed?.status === "cancelled" && parsed.record.status !== "cancelled") ||
+    (parsed?.status === "current" &&
+      (parsed.record.status === "starting" ||
+        parsed.record.status === "pending"))
+  ) {
+    return null;
+  }
+  return parsed;
+}
+
+/** Parses a cleanup grant and proves its reference remains durably retained. */
+function parseClaimCleanupOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string
+): ClaimCleanupOutcome | null {
+  if (!isPlainObject(value) || typeof value.status !== "string") return null;
+  if (value.status === "not_found") {
+    return hasExactKeys(value, ["status"]) ? { status: "not_found" } : null;
+  }
+  if (value.status === "current") {
+    return hasExactKeys(value, ["status", "record"]) &&
+      isValidRecord(value.record, scope, ceremonyId) &&
+      value.record.cleanupSessionRefs.length === 0
+      ? (value as ClaimCleanupOutcome)
+      : null;
+  }
+  if (
+    value.status !== "granted" ||
+    !hasExactKeys(value, [
+      "status",
+      "record",
+      "cleanupRevision",
+      "providerBeginKey",
+      "providerSessionRef",
+    ]) ||
+    !isValidRecord(value.record, scope, ceremonyId) ||
+    value.providerBeginKey !== value.record.providerBeginKey ||
+    !isValidProviderSessionRef(value.providerSessionRef) ||
+    !value.record.cleanupSessionRefs.includes(value.providerSessionRef) ||
+    !Number.isSafeInteger(value.cleanupRevision) ||
+    value.cleanupRevision !== value.record.revision
+  ) {
+    return null;
+  }
+  return value as ClaimCleanupOutcome;
+}
+
+/** Parses cleanup completion without assuming a successful removal. */
+function parseCompleteCleanupOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string,
+  providerSessionRef: string
+): CompleteCleanupOutcome | null {
+  const parsed = parseRecordOutcome(value, scope, ceremonyId, [
+    "completed",
+    "current",
+  ]) as CompleteCleanupOutcome | null;
+  if (
+    parsed?.status === "completed" &&
+    parsed.record.cleanupSessionRefs.includes(providerSessionRef)
+  ) {
+    return null;
+  }
+  return parsed;
+}
+
+/** Parses a common exact status/record or not-found store envelope. */
+function parseRecordOutcome(
+  value: unknown,
+  scope: CodexDeviceScope,
+  ceremonyId: string,
+  statuses: readonly string[]
+):
+  | Readonly<{ status: string; record: CodexDeviceCeremonyRecord }>
+  | Readonly<{ status: "not_found" }>
+  | null {
+  if (!isPlainObject(value) || typeof value.status !== "string") return null;
+  if (value.status === "not_found") {
+    return hasExactKeys(value, ["status"]) ? { status: "not_found" } : null;
+  }
+  return statuses.includes(value.status) &&
+    hasExactKeys(value, ["status", "record"]) &&
+    isValidRecord(value.record, scope, ceremonyId)
+    ? (value as Readonly<{
+        status: string;
+        record: CodexDeviceCeremonyRecord;
+      }>)
+    : null;
 }
 
 /** Bounds one injected dependency and maps all opaque failures to stable codes. */
@@ -523,11 +998,21 @@ async function awaitDependency<T>(
   | Readonly<{ ok: true; value: T }>
   | Readonly<{ ok: false; result: CodexDeviceResult }>
 > {
-  const outcome = await awaitControlPlaneOperation(
-    operation,
-    timeoutMilliseconds,
-    requestSignal
-  );
+  let outcome;
+  try {
+    outcome = await awaitControlPlaneOperation(
+      operation,
+      timeoutMilliseconds,
+      requestSignal
+    );
+  } catch {
+    return {
+      ok: false,
+      result: failure(
+        kind === "store" ? "store_unavailable" : "provider_unavailable"
+      ),
+    };
+  }
   if (outcome.status === "fulfilled") return { ok: true, value: outcome.value };
   if (outcome.status === "aborted") {
     return { ok: false, result: failure("aborted") };
@@ -582,7 +1067,7 @@ function resultFromRecord(
   ceremonyId: string,
   verificationUrl: string
 ): CodexDeviceResult {
-  return isValidRecord(record, scope, ceremonyId)
+  return safelyValidate(() => isValidRecord(record, scope, ceremonyId))
     ? success(project(record, verificationUrl))
     : failure("store_unavailable");
 }
@@ -591,12 +1076,12 @@ function resultFromRecord(
 function isValidRecord(
   value: unknown,
   scope: CodexDeviceScope,
-  ceremonyId: string
+  ceremonyId?: string
 ): value is CodexDeviceCeremonyRecord {
   if (!isPlainObject(value)) return false;
   if (
-    value.ceremonyId !== ceremonyId ||
-    !isValidCeremonyId(ceremonyId) ||
+    !isValidCeremonyId(value.ceremonyId) ||
+    (ceremonyId !== undefined && value.ceremonyId !== ceremonyId) ||
     value.ownerId !== scope.ownerId ||
     value.connectionId !== scope.connectionId ||
     value.requestId !== scope.requestId ||
@@ -608,6 +1093,24 @@ function isValidRecord(
       "expired",
       "denied",
     ].includes(String(value.status))
+  ) {
+    return false;
+  }
+  if (
+    !isValidCeremonyId(value.providerBeginKey) ||
+    !Array.isArray(value.cleanupSessionRefs) ||
+    value.cleanupSessionRefs.length > MAX_CLEANUP_SESSION_REFS ||
+    !value.cleanupSessionRefs.every(isValidProviderSessionRef) ||
+    new Set(value.cleanupSessionRefs).size !== value.cleanupSessionRefs.length
+  ) {
+    return false;
+  }
+  if (
+    value.status === "starting" &&
+    (value.userCode !== undefined ||
+      value.providerSessionRef !== undefined ||
+      value.account !== undefined ||
+      value.cleanupSessionRefs.length !== 0)
   ) {
     return false;
   }
@@ -633,10 +1136,19 @@ function isValidRecord(
     return (
       typeof value.userCode === "string" &&
       USER_CODE_PATTERN.test(value.userCode) &&
-      isValidProviderSessionRef(value.providerSessionRef)
+      isValidProviderSessionRef(value.providerSessionRef) &&
+      !value.cleanupSessionRefs.includes(value.providerSessionRef) &&
+      value.account === undefined
     );
   }
+  if (
+    value.providerSessionRef !== undefined &&
+    !isValidProviderSessionRef(value.providerSessionRef)
+  ) {
+    return false;
+  }
   if (value.status === "authorized") return isValidAccount(value.account);
+  if (value.account !== undefined) return false;
   return true;
 }
 
@@ -678,7 +1190,7 @@ function isValidAccount(value: unknown): value is CodexDeviceAccount {
     keys.length === 2 &&
     keys.includes("type") &&
     keys.includes("present") &&
-    (value.type === "chatgpt" || value.type === "api_key") &&
+    value.type === "chatgpt" &&
     value.present === true
   );
 }
@@ -711,14 +1223,20 @@ function normalizeOfficialVerificationUrl(value: string): string {
     throw new TypeError("officialVerificationUrl must be a valid HTTPS URL");
   }
   if (
+    value !== url.href ||
     url.protocol !== "https:" ||
     url.username ||
     url.password ||
     url.search ||
     url.hash ||
-    url.origin === "null"
+    url.origin === "null" ||
+    !OFFICIAL_CODEX_VERIFICATION_URLS.includes(
+      url.href as (typeof OFFICIAL_CODEX_VERIFICATION_URLS)[number]
+    )
   ) {
-    throw new TypeError("officialVerificationUrl must be a clean HTTPS URL");
+    throw new TypeError(
+      "officialVerificationUrl must match the Codex verification allowlist"
+    );
   }
   return url.toString();
 }
@@ -740,7 +1258,13 @@ function validateOptions(options: CodexDeviceFlowOptions): void {
 }
 
 /** Validates opaque caller scope without reflecting which field failed. */
-function isValidScope(scope: CodexDeviceScope): boolean {
+function isValidScope(scope: unknown): scope is CodexDeviceScope {
+  if (
+    !isPlainObject(scope) ||
+    !hasExactKeys(scope, ["ownerId", "connectionId", "requestId"])
+  ) {
+    return false;
+  }
   return [scope.ownerId, scope.connectionId, scope.requestId].every(
     (value) =>
       typeof value === "string" &&
@@ -750,8 +1274,23 @@ function isValidScope(scope: CodexDeviceScope): boolean {
 }
 
 /** Recognizes the fixed entropy and alphabet of server-generated IDs. */
-function isValidCeremonyId(value: string): boolean {
-  return /^[A-Za-z0-9_-]{32}$/.test(value);
+function isValidCeremonyId(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{32}$/.test(value);
+}
+
+/** Calls a server-owned identifier generator without reflecting its failure. */
+function safelyCreateOpaqueId(generator: () => string): string | null {
+  try {
+    const value = generator();
+    return isValidCeremonyId(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Recognizes finite nonnegative millisecond timestamps. */
+function isValidTimestamp(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
 }
 
 /** Generates a 192-bit opaque identifier without caller-controlled material. */
@@ -774,13 +1313,33 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  } catch {
+    return false;
+  }
+}
+
+/** Requires an exact envelope key set at every injected runtime boundary. */
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[]
+): boolean {
+  try {
+    const keys = Object.keys(value);
+    return (
+      keys.length === expected.length &&
+      expected.every((key) => Object.prototype.hasOwnProperty.call(value, key))
+    );
+  } catch {
+    return false;
+  }
 }
 
 export {
-  type ActivateCeremonyOutcome,
   type CancelCeremonyOutcome,
+  type ClaimCleanupOutcome,
   type CodexDeviceAccount,
   type CodexDeviceAccountType,
   type CodexDeviceCeremonyRecord,
@@ -795,8 +1354,10 @@ export {
   type CodexDeviceResult,
   type CodexDeviceScope,
   type CodexDeviceStatus,
+  type CompleteCleanupOutcome,
   type CompletePollOutcome,
   createCodexDeviceFlow,
   type PreparePollOutcome,
+  type RecordBeginOutcome,
   type ReserveCeremonyOutcome,
 };


### PR DESCRIPTION
## Feature

Adds the Codex-first, dependency-injected device authorization ceremony contract for the agent gateway. This slice is pure orchestration only: it does not start Codex, log in, persist credentials, use the network, open a listener, deploy a host, or write a database.

## Architecture

The flow binds begin, poll, and cancel to owner + connection + request + a server-generated opaque ceremony ID. Atomic durable-store transitions enforce one active ceremony per connection, durable poll throttling, idempotent cancellation, exact expiry, and revision-fenced completion so delayed authorization cannot win after cancel or expiry.

The injected CodexDeviceClient accepts no caller-selected URL, command, model, home, or environment. Every store and client wait is abort/deadline bounded, and late settlements remain observed. Store corruption, malformed provider output, cross-owner access, ambiguous commits, and dependency failures fail closed behind stable non-reflective results.

```text
signed gateway request
        |
        v
 begin / poll / cancel
        |
        +---- atomic durable transition ---- ceremony record
        |                                      server only
        v
 idempotent CodexDeviceClient call
        |
        +---- fenced atomic completion ----> safe browser projection
```

The browser receives only the fixed official HTTPS verification URL, validated short user code while pending, finite expiry/poll interval, stable status, and strict account type/presence after authorization. Tokens, provider session references, raw provider output, paths, commands, errors, environment, and credential handles are never projected.

## Deferred gates

- PR #39 branded Codex-home authority integration
- real Codex app-server adapter and device-login protocol
- encrypted durable store and credential persistence
- persistent host, key custody, backup, and deployment
- human-authorized live-account and recovery testing
- Claude authorization, intentionally deferred

## Validation

- `pnpm typecheck`
- `pnpm test` (72 files, 813 tests)
- `pnpm lint` (0 errors; 5 pre-existing warnings)
- `pnpm format:check`
- `git diff --check`
- focused ceremony suite: 38 adversarial tests
