### PR TITLE
feat(ai): add server-only gateway client

### DIFF
--- a/docs/GATEWAY_SERVER_CLIENT.md
+++ b/docs/GATEWAY_SERVER_CLIENT.md
@@ -8,12 +8,13 @@ connection, access credentials, or provide a public route.
 ## Architecture
 
 ```text
-authenticated server context
-  { owner, mindmap, connection, operation, request }
+server request intent
+  { mindmap, connection, operation, request }
                     |
                     v
-        owner-scoped connection resolver
-     (Codex + connected + selected default)
+ atomic server authorization + resolution
+ (derive Clerk owner; verify resource + connection;
+  canonicalize ids; allow operation/default/Codex)
                     |
                     v
        fixed-context assertion signer
@@ -31,22 +32,29 @@ authenticated server context
 
 The invocation API deliberately has no gateway URL, base path, issuer,
 audience, provider, command, model, environment, credential, token, or generic
-request body. It accepts only authenticated server-derived owner/resource
-context, one connection id, one compile-time gateway operation, one request id,
-and an optional abort signal. The operation-to-path table and base path are
-fixed in the module. The HTTPS origin and trust dependencies are injected once
-when the server client is constructed and are validated before any request.
+request body or owner authority. It accepts only a narrow resource intent, one
+connection id, one compile-time gateway operation, one request id, and an
+optional abort signal. Browser-supplied owner or context fields are rejected.
+The operation-to-path table and base path are fixed in the module. The HTTPS
+origin must be an exact member of a nonempty construction-time allowlist.
+Allowlist entries reject userinfo, trailing dots, localhost/local names, IP and
+private/link-local literals, Unicode/punycode confusables, and noncanonical
+default ports. A non-default port is permitted only as an exact explicit
+allowlist entry. Validation performs no DNS lookup.
 
 ## Fail-closed contract
 
-- The resolver receives the asserted owner, requested connection, fixed Codex
-  provider, and `requireDefault: true`. Missing, cross-owner, mismatched,
-  pending, expired, revoked, errored, and non-default results all fail before
-  assertion signing.
-- The signer receives the fixed issuer/audience and the exact owner,
-  connection, provider, operation, and request id. Signer output is opaque,
-  bounded, and rejected if it can inject headers.
-- Resolver, signer, transport, and response reads are bounded by server-owned
+- One injected server dependency derives the current Clerk subject internally,
+  atomically verifies resource and connection ownership, verifies Codex,
+  connected/default status and the allowed operation, and returns canonical
+  resource/connection ids. Its result type is not part of the execute API.
+  Missing, malformed, cross-owner, mismatched, unavailable, and timed-out
+  results all produce the same secret-free `authorization_unavailable`/404
+  outcome before signing, preventing a resource/connection existence oracle.
+- The signer receives the fixed issuer/audience and only the resolved owner,
+  canonical connection, provider, operation, and request id. Signer output is
+  opaque, bounded, and rejected if it can inject headers.
+- Authorization, signer, transport, and response reads are bounded by server-owned
   deadlines. Derived reason-free abort signals are sent to dependencies. Late
   fulfillment and rejection remain observed after timeout or caller abort.
 - Transport always uses `POST`, `application/json`, `redirect: "error"`, the
@@ -57,6 +65,10 @@ when the server client is constructed and are validated before any request.
   success/error schemas and exact error-status pairs are accepted. Dependency
   messages, response bodies, assertion bytes, and abort reasons never appear
   in public errors.
+- A response body is disposed behind a finite cleanup bound whenever transport
+  fulfillment arrives after timeout/abort or metadata, routing, status,
+  content-type, JSON, or schema validation rejects it. Cleanup failures and
+  late settlement are always observed and never replace the stable outcome.
 - There is no API-key, operator-login, alternate-provider, or credential-store
   fallback.
 
@@ -71,7 +83,7 @@ still requires human approval of:
 1. the persistent gateway host and exact HTTPS origin;
 2. the internal assertion issuer, audience, signing-key custody, rotation, and
    backup procedure;
-3. the Next.js server resolver backed by owner-scoped connection metadata;
+3. the Next.js server authority resolver backed by owner-scoped metadata;
 4. private routing, certificate, redirect, timeout, and response-size policy;
 5. the real Codex account ceremony and credential-isolation validation; and
 6. deployment and any database write or migration.

--- a/docs/GATEWAY_SERVER_CLIENT.md
+++ b/docs/GATEWAY_SERVER_CLIENT.md
@@ -1,0 +1,81 @@
+# Next.js gateway server client
+
+`lib/gateway/server-client.ts` is the server-only, Codex-first request boundary
+between authenticated Next.js code and the private agent gateway. This slice is
+deployment-neutral: it does not read environment variables, open a network
+connection, access credentials, or provide a public route.
+
+## Architecture
+
+```text
+authenticated server context
+  { owner, mindmap, connection, operation, request }
+                    |
+                    v
+        owner-scoped connection resolver
+     (Codex + connected + selected default)
+                    |
+                    v
+       fixed-context assertion signer
+ (issuer + audience + exact request binding)
+                    |
+                    v
+ https://allowlisted-origin/internal/v1/operations/<allowlisted operation>
+                    |
+                    v
+ injected fetch transport (POST, redirect=error, derived abort signal)
+                    |
+                    v
+ bounded JSON stream -> exact status/schema map -> secret-free result/error
+```
+
+The invocation API deliberately has no gateway URL, base path, issuer,
+audience, provider, command, model, environment, credential, token, or generic
+request body. It accepts only authenticated server-derived owner/resource
+context, one connection id, one compile-time gateway operation, one request id,
+and an optional abort signal. The operation-to-path table and base path are
+fixed in the module. The HTTPS origin and trust dependencies are injected once
+when the server client is constructed and are validated before any request.
+
+## Fail-closed contract
+
+- The resolver receives the asserted owner, requested connection, fixed Codex
+  provider, and `requireDefault: true`. Missing, cross-owner, mismatched,
+  pending, expired, revoked, errored, and non-default results all fail before
+  assertion signing.
+- The signer receives the fixed issuer/audience and the exact owner,
+  connection, provider, operation, and request id. Signer output is opaque,
+  bounded, and rejected if it can inject headers.
+- Resolver, signer, transport, and response reads are bounded by server-owned
+  deadlines. Derived reason-free abort signals are sent to dependencies. Late
+  fulfillment and rejection remain observed after timeout or caller abort.
+- Transport always uses `POST`, `application/json`, `redirect: "error"`, the
+  fixed operation URL, and a request body containing only the server-derived
+  resource reference. Redirected, cross-origin, cross-path, missing-body, and
+  non-JSON responses fail closed.
+- Response bytes and chunks are bounded while streaming. Only exact gateway
+  success/error schemas and exact error-status pairs are accepted. Dependency
+  messages, response bodies, assertion bytes, and abort reasons never appear
+  in public errors.
+- There is no API-key, operator-login, alternate-provider, or credential-store
+  fallback.
+
+`createFetchGatewayTransport` adapts an explicitly supplied fetch-compatible
+function. The module never captures global `fetch`; tests use injected fakes.
+
+## Human gates before live wiring
+
+This slice does not authorize deployment or real credential use. Live wiring
+still requires human approval of:
+
+1. the persistent gateway host and exact HTTPS origin;
+2. the internal assertion issuer, audience, signing-key custody, rotation, and
+   backup procedure;
+3. the Next.js server resolver backed by owner-scoped connection metadata;
+4. private routing, certificate, redirect, timeout, and response-size policy;
+5. the real Codex account ceremony and credential-isolation validation; and
+6. deployment and any database write or migration.
+
+Claude remains deferred. Adding another provider requires a separate reviewed
+operation/claim contract; it must not broaden this Codex-only client or create
+fallback behavior.

--- a/lib/gateway/server-client.test.ts
+++ b/lib/gateway/server-client.test.ts
@@ -4,9 +4,10 @@ import {
   createFetchGatewayTransport,
   createGatewayServerClient,
   type GatewayAssertionSigner,
+  type GatewayAuthorityResolver,
   type GatewayClientError,
   type GatewayClientRequest,
-  type GatewayConnectionResolver,
+  type GatewayResponseBody,
   type GatewayServerClientOptions,
   type GatewayTransport,
   type GatewayTransportRequest,
@@ -20,23 +21,49 @@ const RESPONSE_URL = `${ORIGIN}/internal/v1/operations/chat`;
 const SECRET = "secret-canary-never-reflect";
 
 type Fixture = Readonly<{
-  resolver: GatewayConnectionResolver;
+  authorityResolver: GatewayAuthorityResolver;
   signer: GatewayAssertionSigner;
   transport: GatewayTransport;
-  resolverCalls: ReturnType<typeof vi.fn>;
+  authorizeCalls: ReturnType<typeof vi.fn>;
   signerCalls: ReturnType<typeof vi.fn>;
   transportCalls: ReturnType<typeof vi.fn>;
 }>;
+
+/** Builds one authority result that only the injected server dependency returns. */
+function authorizedResolution(
+  overrides: Readonly<{
+    ownerId?: string;
+    resource?: Record<string, unknown>;
+    connection?: Record<string, unknown>;
+    operation?: GatewayClientRequest["operation"];
+  }> = {}
+) {
+  return {
+    ownerId: overrides.ownerId ?? "owner-1",
+    resource: {
+      type: "mindmap" as const,
+      requestedId: "map-1",
+      canonicalId: "canonical-map-1",
+      ...overrides.resource,
+    },
+    connection: {
+      requestedId: "connection-1",
+      canonicalId: "canonical-connection-1",
+      provider: "codex" as const,
+      status: "connected" as const,
+      isDefault: true,
+      ...overrides.connection,
+    },
+    operation: overrides.operation ?? ("chat" as const),
+  };
+}
 
 /** Builds a valid server-derived request with explicit narrow overrides. */
 function request(
   overrides: Partial<GatewayClientRequest> = {}
 ): GatewayClientRequest {
   return {
-    context: {
-      ownerId: "owner-1",
-      resource: { type: "mindmap", id: "map-1" },
-    },
+    resource: { type: "mindmap", id: "map-1" },
     connectionId: "connection-1",
     operation: "chat",
     requestId: "request-1",
@@ -71,6 +98,42 @@ function jsonResponse(
   };
 }
 
+/** Builds a response whose body disposal can be asserted independently. */
+function trackedJsonResponse(
+  value: unknown,
+  overrides: Partial<GatewayTransportResponse> = {},
+  cancelImplementation?: () => void | PromiseLike<void>
+): Readonly<{
+  response: GatewayTransportResponse;
+  cancel: ReturnType<typeof vi.fn>;
+}> {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  const cancel = vi.fn(
+    cancelImplementation ?? (() => stream.cancel().then(() => undefined))
+  );
+  const body: GatewayResponseBody = {
+    getReader: () => stream.getReader(),
+    cancel,
+  };
+  return {
+    response: {
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({ "content-type": "application/json" }),
+      body,
+      ...overrides,
+    },
+    cancel,
+  };
+}
+
 /** Creates injected dependencies whose calls can be inspected without I/O. */
 function fixture(
   response: GatewayTransportResponse = jsonResponse({
@@ -78,20 +141,14 @@ function fixture(
     data: { answer: "done" },
   })
 ): Fixture {
-  const resolverCalls = vi.fn(async () => ({
-    ownerId: "owner-1",
-    connectionId: "connection-1",
-    provider: "codex" as const,
-    status: "connected" as const,
-    isDefault: true,
-  }));
+  const authorizeCalls = vi.fn(async () => authorizedResolution());
   const signerCalls = vi.fn(async () => "signed-assertion");
   const transportCalls = vi.fn(async () => response);
   return {
-    resolver: { resolve: resolverCalls },
+    authorityResolver: { authorize: authorizeCalls },
     signer: { sign: signerCalls },
     transport: { send: transportCalls },
-    resolverCalls,
+    authorizeCalls,
     signerCalls,
     transportCalls,
   };
@@ -104,13 +161,14 @@ function client(
 ) {
   return createGatewayServerClient({
     gatewayOrigin: ORIGIN,
+    gatewayOriginAllowlist: [ORIGIN],
     issuer: "sprig-next-server",
     audience: "sprig-agent-gateway",
-    connectionResolver: current.resolver,
+    authorityResolver: current.authorityResolver,
     assertionSigner: current.signer,
     transport: current.transport,
     requestTimeoutMs: 1_000,
-    resolverTimeoutMs: 100,
+    authorizationTimeoutMs: 100,
     signerTimeoutMs: 100,
     maxResponseBytes: 4_096,
     maxResponseChunks: 32,
@@ -141,14 +199,15 @@ describe("gateway server client", () => {
     const result = await client(current).execute(request());
 
     expect(result).toEqual({ answer: "done" });
-    expect(current.resolverCalls).toHaveBeenCalledTimes(1);
-    expect(current.resolverCalls.mock.calls[0]?.[0]).toEqual({
-      ownerId: "owner-1",
+    expect(current.authorizeCalls).toHaveBeenCalledTimes(1);
+    expect(current.authorizeCalls.mock.calls[0]?.[0]).toEqual({
+      resource: { type: "mindmap", id: "map-1" },
       connectionId: "connection-1",
       provider: "codex",
+      operation: "chat",
       requireDefault: true,
     });
-    expect(current.resolverCalls.mock.calls[0]?.[1]).toMatchObject({
+    expect(current.authorizeCalls.mock.calls[0]?.[1]).toMatchObject({
       signal: expect.any(AbortSignal),
       deadlineAtMilliseconds: expect.any(Number),
     });
@@ -156,7 +215,7 @@ describe("gateway server client", () => {
       issuer: "sprig-next-server",
       audience: "sprig-agent-gateway",
       subject: "owner-1",
-      connectionId: "connection-1",
+      connectionId: "canonical-connection-1",
       provider: "codex",
       operation: "chat",
       requestId: "request-1",
@@ -173,7 +232,9 @@ describe("gateway server client", () => {
         "x-request-id": "request-1",
       },
       body: JSON.stringify({
-        input: { resource: { type: "mindmap", id: "map-1" } },
+        input: {
+          resource: { type: "mindmap", id: "canonical-map-1" },
+        },
       }),
       redirect: "error",
       signal: expect.any(AbortSignal),
@@ -186,92 +247,75 @@ describe("gateway server client", () => {
   it.each([
     [null, "missing"],
     [
-      {
-        ownerId: "owner-2",
-        connectionId: "connection-1",
-        provider: "codex",
-        status: "connected",
-        isDefault: true,
-      },
-      "cross-owner",
+      authorizedResolution({ resource: { requestedId: "other-map" } }),
+      "resource mismatch",
     ],
     [
-      {
-        ownerId: "owner-1",
-        connectionId: "connection-2",
-        provider: "codex",
-        status: "connected",
-        isDefault: true,
-      },
+      authorizedResolution({ connection: { requestedId: "other-connection" } }),
       "connection mismatch",
     ],
     [
-      {
-        ownerId: "owner-1",
-        connectionId: "connection-1",
-        provider: "claude",
-        status: "connected",
-        isDefault: true,
-      },
+      authorizedResolution({ connection: { provider: "claude" } }),
       "provider mismatch",
     ],
-    [
-      {
-        ownerId: "owner-1",
-        connectionId: "connection-1",
-        provider: "codex",
-        status: "revoked",
-        isDefault: true,
-      },
-      "revoked",
-    ],
-    [
-      {
-        ownerId: "owner-1",
-        connectionId: "connection-1",
-        provider: "codex",
-        status: "expired",
-        isDefault: true,
-      },
-      "expired",
-    ],
-    [
-      {
-        ownerId: "owner-1",
-        connectionId: "connection-1",
-        provider: "codex",
-        status: "connected",
-        isDefault: false,
-      },
-      "non-default",
-    ],
+    [authorizedResolution({ connection: { status: "revoked" } }), "revoked"],
+    [authorizedResolution({ connection: { status: "expired" } }), "expired"],
+    [authorizedResolution({ connection: { isDefault: false } }), "non-default"],
+    [authorizedResolution({ operation: "node-editing" }), "operation mismatch"],
+    [{ ownerId: SECRET }, "malformed"],
   ] as const)(
-    "fails closed on %s connection state",
+    "collapses %s authority state to the same oracle-resistant result",
     async (resolved, _description) => {
       const current = fixture();
-      current.resolverCalls.mockResolvedValueOnce(resolved);
+      current.authorizeCalls.mockResolvedValueOnce(resolved);
 
-      await expectCode(
-        () => client(current).execute(request()),
-        "connection_unavailable"
-      );
+      await expect(client(current).execute(request())).rejects.toMatchObject({
+        code: "authorization_unavailable",
+        status: 404,
+        message: "Gateway client request failed",
+      });
       expect(current.signerCalls).not.toHaveBeenCalled();
       expect(current.transportCalls).not.toHaveBeenCalled();
     }
   );
 
-  it("does not expose whether a probed connection belongs to another owner", async () => {
+  it.each([
+    "cross-owner resource",
+    "cross-owner connection",
+    "store unavailable",
+  ])("does not expose %s resolution failure", async () => {
     const current = fixture();
-    current.resolverCalls.mockRejectedValueOnce(
-      new Error(`database owner mismatch ${SECRET}`)
+    current.authorizeCalls.mockRejectedValueOnce(
+      new Error(`authority detail ${SECRET}`)
     );
 
-    await expectCode(
-      () => client(current).execute(request()),
-      "gateway_unavailable"
-    );
-    await expect(client(current).execute(request())).resolves.toBeDefined();
+    await expect(client(current).execute(request())).rejects.toMatchObject({
+      code: "authorization_unavailable",
+      status: 404,
+      message: "Gateway client request failed",
+    });
+    expect(current.signerCalls).not.toHaveBeenCalled();
+    expect(current.transportCalls).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { ownerId: "browser-owner-2" },
+    { context: { ownerId: "browser-owner-2" } },
+    { resourceOwnerId: "browser-owner-2" },
+  ])(
+    "rejects browser-forged authority fields before resolution",
+    async (forgery) => {
+      const current = fixture();
+      const forged = { ...request(), ...forgery } as GatewayClientRequest;
+
+      await expectCode(
+        () => client(current).execute(forged),
+        "gateway_client_configuration_invalid"
+      );
+      expect(current.authorizeCalls).not.toHaveBeenCalled();
+      expect(current.signerCalls).not.toHaveBeenCalled();
+    }
+  );
 
   it.each([
     "http://gateway.example.test",
@@ -281,15 +325,60 @@ describe("gateway server client", () => {
     "https://gateway.example.test#evil",
     "https://gateway.example.test@evil.test",
     "https://gateway.example.test/",
+    "https://gateway.example.test.",
+    "https://localhost",
+    "https://agent.localhost",
+    "https://agent.local",
+    "https://127.0.0.1",
+    "https://10.0.0.1",
+    "https://169.254.169.254",
+    "https://[::1]",
+    "https://xn--gteway-9za.example.test",
+    "https://gаteway.example.test",
+    "https://Gateway.example.test",
+    "https://gateway.example.test:443",
   ])(
     "rejects noncanonical or injectable gateway origin %s",
     (gatewayOrigin) => {
       const current = fixture();
-      expect(() => client(current, { gatewayOrigin })).toThrowError(
-        "Gateway client request failed"
-      );
+      expect(() =>
+        client(current, {
+          gatewayOrigin,
+          gatewayOriginAllowlist: [gatewayOrigin],
+        })
+      ).toThrowError("Gateway client request failed");
     }
   );
+
+  it("requires a nonempty exact allowlist and exact selected membership", () => {
+    const current = fixture();
+    expect(() => client(current, { gatewayOriginAllowlist: [] })).toThrowError(
+      "Gateway client request failed"
+    );
+    expect(() =>
+      client(current, {
+        gatewayOrigin: "https://other.example.test",
+        gatewayOriginAllowlist: [ORIGIN],
+      })
+    ).toThrowError("Gateway client request failed");
+  });
+
+  it("allows a non-default port only as an exact explicit member", async () => {
+    const current = fixture(
+      jsonResponse(
+        { ok: true, data: "ok" },
+        {
+          url: "https://gateway.example.test:8443/internal/v1/operations/chat",
+        }
+      )
+    );
+    await expect(
+      client(current, {
+        gatewayOrigin: "https://gateway.example.test:8443",
+        gatewayOriginAllowlist: ["https://gateway.example.test:8443"],
+      }).execute(request())
+    ).resolves.toBe("ok");
+  });
 
   it.each([
     {
@@ -312,6 +401,70 @@ describe("gateway server client", () => {
     }
   );
 
+  it.each([
+    "redirect",
+    "cross-route URL",
+    "invalid status",
+    "invalid content type",
+    "throwing metadata",
+    "invalid schema",
+  ] as const)("cancels the body on early %s rejection", async (scenario) => {
+    const overrides: {
+      status?: number;
+      redirected?: boolean;
+      url?: string;
+      headers?: GatewayTransportResponse["headers"];
+    } = {};
+    let value: unknown = { ok: true, data: null };
+    if (scenario === "redirect") overrides.redirected = true;
+    if (scenario === "cross-route URL") {
+      overrides.url = "https://evil.example.test/internal/v1/operations/chat";
+    }
+    if (scenario === "invalid status") overrides.status = 201;
+    if (scenario === "invalid content type") {
+      overrides.headers = new Headers({ "content-type": "text/plain" });
+    }
+    if (scenario === "throwing metadata") {
+      overrides.headers = {
+        get() {
+          throw new Error(SECRET);
+        },
+      };
+    }
+    if (scenario === "invalid schema") {
+      value = { ok: true, data: null, extra: true };
+    }
+    const tracked = trackedJsonResponse(value, overrides);
+    const current = fixture(tracked.response);
+
+    await expectCode(
+      () => client(current).execute(request()),
+      "gateway_response_invalid"
+    );
+    expect(tracked.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["rejecting cleanup", "stalled cleanup"] as const)(
+    "bounds and observes %s without replacing the response failure",
+    async (scenario) => {
+      const tracked = trackedJsonResponse(
+        { ok: true, data: null },
+        { redirected: true },
+        () =>
+          scenario === "rejecting cleanup"
+            ? Promise.reject(new Error(SECRET))
+            : new Promise<void>(() => undefined)
+      );
+      const current = fixture(tracked.response);
+
+      await expectCode(
+        () => client(current, { cleanupTimeoutMs: 10 }).execute(request()),
+        "gateway_response_invalid"
+      );
+      expect(tracked.cancel).toHaveBeenCalledTimes(1);
+    }
+  );
+
   it("rejects runtime attempts to choose an arbitrary operation", async () => {
     const current = fixture();
     await expectCode(
@@ -321,7 +474,7 @@ describe("gateway server client", () => {
         ),
       "gateway_client_configuration_invalid"
     );
-    expect(current.resolverCalls).not.toHaveBeenCalled();
+    expect(current.authorizeCalls).not.toHaveBeenCalled();
   });
 
   it("enforces byte and chunk limits before parsing a response", async () => {
@@ -357,7 +510,7 @@ describe("gateway server client", () => {
       () =>
         client(current, {
           requestTimeoutMs: 20,
-          resolverTimeoutMs: 10,
+          authorizationTimeoutMs: 10,
           signerTimeoutMs: 10,
         }).execute(request()),
       "request_timeout"
@@ -392,23 +545,17 @@ describe("gateway server client", () => {
       () => client(current).execute(request({ signal: controller.signal })),
       "request_aborted"
     );
-    expect(current.resolverCalls).not.toHaveBeenCalled();
+    expect(current.authorizeCalls).not.toHaveBeenCalled();
     expect(current.signerCalls).not.toHaveBeenCalled();
     expect(current.transportCalls).not.toHaveBeenCalled();
   });
 
-  it("closes the abort race between resolver and signer handoff", async () => {
+  it("closes the abort race between authority and signer handoff", async () => {
     const controller = new AbortController();
     const current = fixture();
-    current.resolverCalls.mockImplementationOnce(async () => {
+    current.authorizeCalls.mockImplementationOnce(async () => {
       controller.abort(new Error(SECRET));
-      return {
-        ownerId: "owner-1",
-        connectionId: "connection-1",
-        provider: "codex",
-        status: "connected",
-        isDefault: true,
-      };
+      return authorizedResolution();
     });
 
     await expectCode(
@@ -421,7 +568,7 @@ describe("gateway server client", () => {
 
   it("normalizes hostile request getters without reflecting their messages", async () => {
     const current = fixture();
-    const hostile = Object.defineProperty({}, "context", {
+    const hostile = Object.defineProperty({}, "resource", {
       get() {
         throw new Error(SECRET);
       },
@@ -434,7 +581,7 @@ describe("gateway server client", () => {
     await expect(client(current).execute(hostile)).rejects.not.toThrow(SECRET);
   });
 
-  it.each(["resolver", "signer"] as const)(
+  it.each(["authority", "signer"] as const)(
     "bounds a stalled %s and observes its late rejection",
     async (stage) => {
       let rejectLate: ((error: Error) => void) | undefined;
@@ -442,20 +589,25 @@ describe("gateway server client", () => {
         rejectLate = reject;
       });
       const current = fixture();
-      if (stage === "resolver") {
-        current.resolverCalls.mockReturnValueOnce(stalled);
+      if (stage === "authority") {
+        current.authorizeCalls.mockReturnValueOnce(stalled);
       } else {
         current.signerCalls.mockReturnValueOnce(stalled);
       }
 
-      await expectCode(
-        () =>
-          client(current, {
-            resolverTimeoutMs: 10,
-            signerTimeoutMs: 10,
-          }).execute(request()),
-        "gateway_unavailable"
-      );
+      const pending = client(current, {
+        authorizationTimeoutMs: 10,
+        signerTimeoutMs: 10,
+      }).execute(request());
+      if (stage === "authority") {
+        await expect(pending).rejects.toMatchObject({
+          code: "authorization_unavailable",
+          status: 404,
+          message: "Gateway client request failed",
+        });
+      } else {
+        await expectCode(() => pending, "gateway_unavailable");
+      }
       rejectLate?.(new Error(SECRET));
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(current.transportCalls).not.toHaveBeenCalled();
@@ -475,7 +627,7 @@ describe("gateway server client", () => {
       () =>
         client(current, {
           requestTimeoutMs: 20,
-          resolverTimeoutMs: 10,
+          authorizationTimeoutMs: 10,
           signerTimeoutMs: 10,
         }).execute(request()),
       "request_timeout"
@@ -483,6 +635,45 @@ describe("gateway server client", () => {
     rejectLate?.(new Error(SECRET));
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
+
+  it.each(["timeout", "abort"] as const)(
+    "disposes a response that fulfills after transport %s",
+    async (outcome) => {
+      let resolveLate:
+        | ((response: GatewayTransportResponse) => void)
+        | undefined;
+      const current = fixture();
+      current.transportCalls.mockReturnValueOnce(
+        new Promise<GatewayTransportResponse>((resolve) => {
+          resolveLate = resolve;
+        })
+      );
+      const controller = new AbortController();
+      const pending = client(current, {
+        requestTimeoutMs: outcome === "abort" ? 1_000 : 20,
+        authorizationTimeoutMs: 10,
+        signerTimeoutMs: 10,
+      }).execute(
+        request(outcome === "abort" ? { signal: controller.signal } : {})
+      );
+      const observed = pending.then(
+        () => null,
+        (error: unknown) => error
+      );
+      await vi.waitFor(() =>
+        expect(current.transportCalls).toHaveBeenCalledTimes(1)
+      );
+      if (outcome === "abort") controller.abort();
+      await expect(observed).resolves.toMatchObject({
+        code: outcome === "abort" ? "request_aborted" : "request_timeout",
+        message: "Gateway client request failed",
+      });
+
+      const tracked = trackedJsonResponse({ ok: true, data: null });
+      resolveLate?.(tracked.response);
+      await vi.waitFor(() => expect(tracked.cancel).toHaveBeenCalledTimes(1));
+    }
+  );
 
   it.each([
     [201, { ok: true, data: null }, "application/json"],
@@ -512,22 +703,28 @@ describe("gateway server client", () => {
   );
 
   it("rejects malformed JSON and a missing body", async () => {
+    const malformedStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{not json"));
+        controller.close();
+      },
+    });
+    const cancelMalformed = vi.fn(() => malformedStream.cancel());
     const malformed = fixture({
       status: 200,
       redirected: false,
       url: RESPONSE_URL,
       headers: new Headers({ "content-type": "application/json" }),
-      body: new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode("{not json"));
-          controller.close();
-        },
-      }),
+      body: {
+        getReader: () => malformedStream.getReader(),
+        cancel: cancelMalformed,
+      },
     });
     await expectCode(
       () => client(malformed).execute(request()),
       "gateway_response_invalid"
     );
+    expect(cancelMalformed).toHaveBeenCalledTimes(1);
 
     const missing = fixture({
       status: 200,
@@ -593,22 +790,19 @@ describe("gateway server client", () => {
 
   it("has no API-key, operator-login, URL, path, issuer, audience, model, or command fallback", async () => {
     const current = fixture();
-    current.resolverCalls.mockResolvedValueOnce(null);
+    current.authorizeCalls.mockResolvedValueOnce(null);
     const invocation = request();
     expect(Object.keys(invocation).sort()).toEqual([
       "connectionId",
-      "context",
       "operation",
       "requestId",
-    ]);
-    expect(Object.keys(invocation.context).sort()).toEqual([
-      "ownerId",
       "resource",
     ]);
+    expect(Object.keys(invocation.resource).sort()).toEqual(["id", "type"]);
 
     await expectCode(
       () => client(current).execute(invocation),
-      "connection_unavailable"
+      "authorization_unavailable"
     );
     expect(current.signerCalls).not.toHaveBeenCalled();
     expect(current.transportCalls).not.toHaveBeenCalled();

--- a/lib/gateway/server-client.test.ts
+++ b/lib/gateway/server-client.test.ts
@@ -1,0 +1,645 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createFetchGatewayTransport,
+  createGatewayServerClient,
+  type GatewayAssertionSigner,
+  type GatewayClientError,
+  type GatewayClientRequest,
+  type GatewayConnectionResolver,
+  type GatewayServerClientOptions,
+  type GatewayTransport,
+  type GatewayTransportRequest,
+  type GatewayTransportResponse,
+} from "./server-client.ts";
+
+vi.mock("server-only", () => ({}));
+
+const ORIGIN = "https://gateway.example.test";
+const RESPONSE_URL = `${ORIGIN}/internal/v1/operations/chat`;
+const SECRET = "secret-canary-never-reflect";
+
+type Fixture = Readonly<{
+  resolver: GatewayConnectionResolver;
+  signer: GatewayAssertionSigner;
+  transport: GatewayTransport;
+  resolverCalls: ReturnType<typeof vi.fn>;
+  signerCalls: ReturnType<typeof vi.fn>;
+  transportCalls: ReturnType<typeof vi.fn>;
+}>;
+
+/** Builds a valid server-derived request with explicit narrow overrides. */
+function request(
+  overrides: Partial<GatewayClientRequest> = {}
+): GatewayClientRequest {
+  return {
+    context: {
+      ownerId: "owner-1",
+      resource: { type: "mindmap", id: "map-1" },
+    },
+    connectionId: "connection-1",
+    operation: "chat",
+    requestId: "request-1",
+    ...overrides,
+  };
+}
+
+/** Encodes a JSON value as a configurable bounded response stream. */
+function jsonResponse(
+  value: unknown,
+  overrides: Partial<GatewayTransportResponse> & {
+    chunkSize?: number;
+  } = {}
+): GatewayTransportResponse {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  const chunkSize = overrides.chunkSize ?? bytes.length;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+        controller.enqueue(bytes.slice(offset, offset + chunkSize));
+      }
+      controller.close();
+    },
+  });
+  return {
+    status: 200,
+    redirected: false,
+    url: RESPONSE_URL,
+    headers: new Headers({ "content-type": "application/json" }),
+    body,
+    ...overrides,
+  };
+}
+
+/** Creates injected dependencies whose calls can be inspected without I/O. */
+function fixture(
+  response: GatewayTransportResponse = jsonResponse({
+    ok: true,
+    data: { answer: "done" },
+  })
+): Fixture {
+  const resolverCalls = vi.fn(async () => ({
+    ownerId: "owner-1",
+    connectionId: "connection-1",
+    provider: "codex" as const,
+    status: "connected" as const,
+    isDefault: true,
+  }));
+  const signerCalls = vi.fn(async () => "signed-assertion");
+  const transportCalls = vi.fn(async () => response);
+  return {
+    resolver: { resolve: resolverCalls },
+    signer: { sign: signerCalls },
+    transport: { send: transportCalls },
+    resolverCalls,
+    signerCalls,
+    transportCalls,
+  };
+}
+
+/** Creates the client with small test-safe limits and no global dependencies. */
+function client(
+  current: Fixture,
+  overrides: Partial<GatewayServerClientOptions> = {}
+) {
+  return createGatewayServerClient({
+    gatewayOrigin: ORIGIN,
+    issuer: "sprig-next-server",
+    audience: "sprig-agent-gateway",
+    connectionResolver: current.resolver,
+    assertionSigner: current.signer,
+    transport: current.transport,
+    requestTimeoutMs: 1_000,
+    resolverTimeoutMs: 100,
+    signerTimeoutMs: 100,
+    maxResponseBytes: 4_096,
+    maxResponseChunks: 32,
+    ...overrides,
+  });
+}
+
+/** Reads the stable error code without depending on implementation messages. */
+async function expectCode(
+  operation: () => Promise<unknown>,
+  code: GatewayClientError["code"]
+): Promise<void> {
+  await expect(operation()).rejects.toMatchObject({
+    name: "GatewayClientError",
+    message: "Gateway client request failed",
+    code,
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("gateway server client", () => {
+  it("binds exact owner, connection, provider, operation, request, resource, and route", async () => {
+    const current = fixture();
+    const result = await client(current).execute(request());
+
+    expect(result).toEqual({ answer: "done" });
+    expect(current.resolverCalls).toHaveBeenCalledTimes(1);
+    expect(current.resolverCalls.mock.calls[0]?.[0]).toEqual({
+      ownerId: "owner-1",
+      connectionId: "connection-1",
+      provider: "codex",
+      requireDefault: true,
+    });
+    expect(current.resolverCalls.mock.calls[0]?.[1]).toMatchObject({
+      signal: expect.any(AbortSignal),
+      deadlineAtMilliseconds: expect.any(Number),
+    });
+    expect(current.signerCalls.mock.calls[0]?.[0]).toEqual({
+      issuer: "sprig-next-server",
+      audience: "sprig-agent-gateway",
+      subject: "owner-1",
+      connectionId: "connection-1",
+      provider: "codex",
+      operation: "chat",
+      requestId: "request-1",
+    });
+
+    const transportRequest = current.transportCalls.mock
+      .calls[0]?.[0] as GatewayTransportRequest;
+    expect(transportRequest).toEqual({
+      url: RESPONSE_URL,
+      method: "POST",
+      headers: {
+        authorization: "Bearer signed-assertion",
+        "content-type": "application/json",
+        "x-request-id": "request-1",
+      },
+      body: JSON.stringify({
+        input: { resource: { type: "mindmap", id: "map-1" } },
+      }),
+      redirect: "error",
+      signal: expect.any(AbortSignal),
+    });
+    expect(transportRequest.body).not.toMatch(
+      /command|model|token|credential|environment/i
+    );
+  });
+
+  it.each([
+    [null, "missing"],
+    [
+      {
+        ownerId: "owner-2",
+        connectionId: "connection-1",
+        provider: "codex",
+        status: "connected",
+        isDefault: true,
+      },
+      "cross-owner",
+    ],
+    [
+      {
+        ownerId: "owner-1",
+        connectionId: "connection-2",
+        provider: "codex",
+        status: "connected",
+        isDefault: true,
+      },
+      "connection mismatch",
+    ],
+    [
+      {
+        ownerId: "owner-1",
+        connectionId: "connection-1",
+        provider: "claude",
+        status: "connected",
+        isDefault: true,
+      },
+      "provider mismatch",
+    ],
+    [
+      {
+        ownerId: "owner-1",
+        connectionId: "connection-1",
+        provider: "codex",
+        status: "revoked",
+        isDefault: true,
+      },
+      "revoked",
+    ],
+    [
+      {
+        ownerId: "owner-1",
+        connectionId: "connection-1",
+        provider: "codex",
+        status: "expired",
+        isDefault: true,
+      },
+      "expired",
+    ],
+    [
+      {
+        ownerId: "owner-1",
+        connectionId: "connection-1",
+        provider: "codex",
+        status: "connected",
+        isDefault: false,
+      },
+      "non-default",
+    ],
+  ] as const)(
+    "fails closed on %s connection state",
+    async (resolved, _description) => {
+      const current = fixture();
+      current.resolverCalls.mockResolvedValueOnce(resolved);
+
+      await expectCode(
+        () => client(current).execute(request()),
+        "connection_unavailable"
+      );
+      expect(current.signerCalls).not.toHaveBeenCalled();
+      expect(current.transportCalls).not.toHaveBeenCalled();
+    }
+  );
+
+  it("does not expose whether a probed connection belongs to another owner", async () => {
+    const current = fixture();
+    current.resolverCalls.mockRejectedValueOnce(
+      new Error(`database owner mismatch ${SECRET}`)
+    );
+
+    await expectCode(
+      () => client(current).execute(request()),
+      "gateway_unavailable"
+    );
+    await expect(client(current).execute(request())).resolves.toBeDefined();
+  });
+
+  it.each([
+    "http://gateway.example.test",
+    "https://user:pass@gateway.example.test",
+    "https://gateway.example.test/evil",
+    "https://gateway.example.test?next=https://evil.test",
+    "https://gateway.example.test#evil",
+    "https://gateway.example.test@evil.test",
+    "https://gateway.example.test/",
+  ])(
+    "rejects noncanonical or injectable gateway origin %s",
+    (gatewayOrigin) => {
+      const current = fixture();
+      expect(() => client(current, { gatewayOrigin })).toThrowError(
+        "Gateway client request failed"
+      );
+    }
+  );
+
+  it.each([
+    {
+      redirected: true,
+      url: "https://evil.test/internal/v1/operations/chat",
+    },
+    { redirected: false, url: "https://evil.test/internal/v1/operations/chat" },
+    {
+      redirected: false,
+      url: `${ORIGIN}/internal/v1/operations/chat?url=https://evil.test`,
+    },
+  ])(
+    "rejects redirected or cross-route response metadata",
+    async (metadata) => {
+      const current = fixture(jsonResponse({ ok: true, data: null }, metadata));
+      await expectCode(
+        () => client(current).execute(request()),
+        "gateway_response_invalid"
+      );
+    }
+  );
+
+  it("rejects runtime attempts to choose an arbitrary operation", async () => {
+    const current = fixture();
+    await expectCode(
+      () =>
+        client(current).execute(
+          request({ operation: "shell" as GatewayClientRequest["operation"] })
+        ),
+      "gateway_client_configuration_invalid"
+    );
+    expect(current.resolverCalls).not.toHaveBeenCalled();
+  });
+
+  it("enforces byte and chunk limits before parsing a response", async () => {
+    const oversized = fixture(
+      jsonResponse({ ok: true, data: "x".repeat(128) })
+    );
+    await expectCode(
+      () => client(oversized, { maxResponseBytes: 32 }).execute(request()),
+      "response_too_large"
+    );
+
+    const flooded = fixture(
+      jsonResponse({ ok: true, data: "small" }, { chunkSize: 1 })
+    );
+    await expectCode(
+      () => client(flooded, { maxResponseChunks: 2 }).execute(request()),
+      "response_too_large"
+    );
+  });
+
+  it("times out a stalled response stream and cancels its reader", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({ "content-type": "application/json" }),
+      body,
+    });
+
+    await expectCode(
+      () =>
+        client(current, {
+          requestTimeoutMs: 20,
+          resolverTimeoutMs: 10,
+          signerTimeoutMs: 10,
+        }).execute(request()),
+      "request_timeout"
+    );
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledTimes(1));
+  });
+
+  it("propagates caller abort without reflecting the abort reason", async () => {
+    const controller = new AbortController();
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: new ReadableStream<Uint8Array>(),
+    });
+    const pending = client(current).execute(
+      request({ signal: controller.signal })
+    );
+    controller.abort(new Error(SECRET));
+
+    await expectCode(() => pending, "request_aborted");
+    await expect(pending).rejects.not.toThrow(SECRET);
+  });
+
+  it("never invokes dependencies for an already-aborted request", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error(SECRET));
+    const current = fixture();
+
+    await expectCode(
+      () => client(current).execute(request({ signal: controller.signal })),
+      "request_aborted"
+    );
+    expect(current.resolverCalls).not.toHaveBeenCalled();
+    expect(current.signerCalls).not.toHaveBeenCalled();
+    expect(current.transportCalls).not.toHaveBeenCalled();
+  });
+
+  it("closes the abort race between resolver and signer handoff", async () => {
+    const controller = new AbortController();
+    const current = fixture();
+    current.resolverCalls.mockImplementationOnce(async () => {
+      controller.abort(new Error(SECRET));
+      return {
+        ownerId: "owner-1",
+        connectionId: "connection-1",
+        provider: "codex",
+        status: "connected",
+        isDefault: true,
+      };
+    });
+
+    await expectCode(
+      () => client(current).execute(request({ signal: controller.signal })),
+      "request_aborted"
+    );
+    expect(current.signerCalls).not.toHaveBeenCalled();
+    expect(current.transportCalls).not.toHaveBeenCalled();
+  });
+
+  it("normalizes hostile request getters without reflecting their messages", async () => {
+    const current = fixture();
+    const hostile = Object.defineProperty({}, "context", {
+      get() {
+        throw new Error(SECRET);
+      },
+    }) as GatewayClientRequest;
+
+    await expectCode(
+      () => client(current).execute(hostile),
+      "gateway_client_configuration_invalid"
+    );
+    await expect(client(current).execute(hostile)).rejects.not.toThrow(SECRET);
+  });
+
+  it.each(["resolver", "signer"] as const)(
+    "bounds a stalled %s and observes its late rejection",
+    async (stage) => {
+      let rejectLate: ((error: Error) => void) | undefined;
+      const stalled = new Promise<never>((_resolve, reject) => {
+        rejectLate = reject;
+      });
+      const current = fixture();
+      if (stage === "resolver") {
+        current.resolverCalls.mockReturnValueOnce(stalled);
+      } else {
+        current.signerCalls.mockReturnValueOnce(stalled);
+      }
+
+      await expectCode(
+        () =>
+          client(current, {
+            resolverTimeoutMs: 10,
+            signerTimeoutMs: 10,
+          }).execute(request()),
+        "gateway_unavailable"
+      );
+      rejectLate?.(new Error(SECRET));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(current.transportCalls).not.toHaveBeenCalled();
+    }
+  );
+
+  it("observes transport settlement after an authoritative timeout", async () => {
+    let rejectLate: ((error: Error) => void) | undefined;
+    const current = fixture();
+    current.transportCalls.mockReturnValueOnce(
+      new Promise<never>((_resolve, reject) => {
+        rejectLate = reject;
+      })
+    );
+
+    await expectCode(
+      () =>
+        client(current, {
+          requestTimeoutMs: 20,
+          resolverTimeoutMs: 10,
+          signerTimeoutMs: 10,
+        }).execute(request()),
+      "request_timeout"
+    );
+    rejectLate?.(new Error(SECRET));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it.each([
+    [201, { ok: true, data: null }, "application/json"],
+    [200, { ok: true, data: null, extra: true }, "application/json"],
+    [200, { ok: false, error: { code: "unauthorized" } }, "application/json"],
+    [
+      401,
+      { ok: false, error: { code: "operation_failed" } },
+      "application/json",
+    ],
+    [401, { ok: false, error: { code: "unknown" } }, "application/json"],
+    [200, { ok: true, data: null }, "text/json"],
+  ])(
+    "rejects status/schema/content-type ambiguity",
+    async (status, value, contentType) => {
+      const current = fixture(
+        jsonResponse(value, {
+          status,
+          headers: new Headers({ "content-type": contentType }),
+        })
+      );
+      await expectCode(
+        () => client(current).execute(request()),
+        "gateway_response_invalid"
+      );
+    }
+  );
+
+  it("rejects malformed JSON and a missing body", async () => {
+    const malformed = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("{not json"));
+          controller.close();
+        },
+      }),
+    });
+    await expectCode(
+      () => client(malformed).execute(request()),
+      "gateway_response_invalid"
+    );
+
+    const missing = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: null,
+    });
+    await expectCode(
+      () => client(missing).execute(request()),
+      "gateway_response_invalid"
+    );
+  });
+
+  it("maps only exact gateway error/status pairs to stable codes", async () => {
+    const current = fixture(
+      jsonResponse(
+        { ok: false, error: { code: "rate_limited" } },
+        { status: 429 }
+      )
+    );
+    await expectCode(() => client(current).execute(request()), "rate_limited");
+  });
+
+  it("never reflects dependency, assertion, transport, or response secrets", async () => {
+    const scenarios = [
+      () => {
+        const current = fixture();
+        current.signerCalls.mockRejectedValueOnce(new Error(SECRET));
+        return client(current).execute(request());
+      },
+      () => {
+        const current = fixture();
+        current.signerCalls.mockResolvedValueOnce(`${SECRET}\r\nheader: value`);
+        return client(current).execute(request());
+      },
+      () => {
+        const current = fixture();
+        current.transportCalls.mockRejectedValueOnce(new Error(SECRET));
+        return client(current).execute(request());
+      },
+      () => {
+        const current = fixture({
+          status: 502,
+          redirected: false,
+          url: RESPONSE_URL,
+          headers: new Headers({ "content-type": "application/json" }),
+          body: new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(SECRET));
+              controller.close();
+            },
+          }),
+        });
+        return client(current).execute(request());
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      await expect(scenario()).rejects.not.toThrow(SECRET);
+    }
+  });
+
+  it("has no API-key, operator-login, URL, path, issuer, audience, model, or command fallback", async () => {
+    const current = fixture();
+    current.resolverCalls.mockResolvedValueOnce(null);
+    const invocation = request();
+    expect(Object.keys(invocation).sort()).toEqual([
+      "connectionId",
+      "context",
+      "operation",
+      "requestId",
+    ]);
+    expect(Object.keys(invocation.context).sort()).toEqual([
+      "ownerId",
+      "resource",
+    ]);
+
+    await expectCode(
+      () => client(current).execute(invocation),
+      "connection_unavailable"
+    );
+    expect(current.signerCalls).not.toHaveBeenCalled();
+    expect(current.transportCalls).not.toHaveBeenCalled();
+  });
+});
+
+describe("injected fetch transport", () => {
+  it("forwards the fixed URL and redirect-error policy to only the injected fetch", async () => {
+    const response = new Response("{}", {
+      headers: { "content-type": "application/json" },
+    });
+    const fetchImplementation = vi.fn(async () => response);
+    const transport = createFetchGatewayTransport(fetchImplementation);
+    const controller = new AbortController();
+
+    await expect(
+      transport.send({
+        url: RESPONSE_URL,
+        method: "POST",
+        headers: { authorization: "Bearer assertion" },
+        body: "{}",
+        redirect: "error",
+        signal: controller.signal,
+      })
+    ).resolves.toBe(response);
+    expect(fetchImplementation).toHaveBeenCalledWith(RESPONSE_URL, {
+      method: "POST",
+      headers: { authorization: "Bearer assertion" },
+      body: "{}",
+      redirect: "error",
+      signal: controller.signal,
+    });
+  });
+});

--- a/lib/gateway/server-client.ts
+++ b/lib/gateway/server-client.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { isIP } from "node:net";
+
 import { z } from "zod";
 
 import type { ControlPlaneOperationContext } from "../../services/agent-gateway/control-plane.ts";
@@ -10,14 +12,16 @@ import {
 
 const GATEWAY_BASE_PATH = "/internal/v1";
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
-const DEFAULT_RESOLVER_TIMEOUT_MS = 1_000;
+const DEFAULT_AUTHORIZATION_TIMEOUT_MS = 1_000;
 const DEFAULT_SIGNER_TIMEOUT_MS = 1_000;
 const DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1_024;
 const DEFAULT_MAX_RESPONSE_CHUNKS = 1_024;
+const DEFAULT_CLEANUP_TIMEOUT_MS = 100;
 const MAX_REQUEST_TIMEOUT_MS = 5 * 60_000;
 const MAX_CONTROL_PLANE_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 4 * 1_024 * 1_024;
 const MAX_RESPONSE_CHUNKS = 4_096;
+const MAX_CLEANUP_TIMEOUT_MS = 1_000;
 const MAX_IDENTIFIER_LENGTH = 256;
 
 const OPERATION_PATHS: Readonly<Record<GatewayOperation, string>> =
@@ -71,7 +75,7 @@ const gatewayFailureSchema = z
 type GatewayRemoteErrorCode = z.infer<typeof gatewayErrorCodeSchema>;
 type GatewayClientErrorCode =
   | GatewayRemoteErrorCode
-  | "connection_unavailable"
+  | "authorization_unavailable"
   | "gateway_client_configuration_invalid"
   | "gateway_response_invalid"
   | "gateway_unavailable"
@@ -79,45 +83,55 @@ type GatewayClientErrorCode =
   | "request_timeout"
   | "response_too_large";
 
-type AuthenticatedGatewayContext = Readonly<{
-  ownerId: string;
-  resource: Readonly<{
-    type: "mindmap";
-    id: string;
-  }>;
+type GatewayResourceIntent = Readonly<{
+  type: "mindmap";
+  id: string;
 }>;
 
 type GatewayClientRequest = Readonly<{
-  context: AuthenticatedGatewayContext;
+  resource: GatewayResourceIntent;
   connectionId: string;
   operation: GatewayOperation;
   requestId: string;
   signal?: AbortSignal;
 }>;
 
-type ResolveConnectionInput = Readonly<{
-  ownerId: string;
+type AuthorizeGatewayIntentInput = Readonly<{
+  resource: GatewayResourceIntent;
   connectionId: string;
   provider: "codex";
+  operation: GatewayOperation;
   requireDefault: true;
 }>;
 
-type ResolvedGatewayConnection = Readonly<{
+// Deliberately not exported: execute callers can submit intent, but only the
+// construction-time server resolver can return derived authority.
+type AuthorizedGatewayResolution = Readonly<{
   ownerId: string;
-  connectionId: string;
-  provider: "codex";
-  status: "connected" | "expired" | "pending" | "revoked" | "error";
-  isDefault: boolean;
+  resource: Readonly<{
+    type: "mindmap";
+    requestedId: string;
+    canonicalId: string;
+  }>;
+  connection: Readonly<{
+    requestedId: string;
+    canonicalId: string;
+    provider: "codex";
+    status: "connected" | "expired" | "pending" | "revoked" | "error";
+    isDefault: boolean;
+  }>;
+  operation: GatewayOperation;
 }>;
 
-interface GatewayConnectionResolver {
-  resolve(
-    input: ResolveConnectionInput,
+interface GatewayAuthorityResolver {
+  /** Derives current owner authority and atomically validates the full intent. */
+  authorize(
+    input: AuthorizeGatewayIntentInput,
     context: ControlPlaneOperationContext
   ):
-    | ResolvedGatewayConnection
+    | AuthorizedGatewayResolution
     | null
-    | Promise<ResolvedGatewayConnection | null>;
+    | Promise<AuthorizedGatewayResolution | null>;
 }
 
 type SignAssertionInput = Readonly<{
@@ -146,12 +160,23 @@ type GatewayTransportRequest = Readonly<{
   signal: AbortSignal;
 }>;
 
+interface GatewayResponseBodyReader {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel(): void | PromiseLike<void>;
+  releaseLock(): void;
+}
+
+interface GatewayResponseBody {
+  getReader(): GatewayResponseBodyReader;
+  cancel(): void | PromiseLike<void>;
+}
+
 type GatewayTransportResponse = Readonly<{
   status: number;
   redirected: boolean;
   url: string;
   headers: Pick<Headers, "get">;
-  body: ReadableStream<Uint8Array> | null;
+  body: GatewayResponseBody | null;
 }>;
 
 interface GatewayTransport {
@@ -165,16 +190,18 @@ type FetchImplementation = (
 
 type GatewayServerClientOptions = Readonly<{
   gatewayOrigin: string;
+  gatewayOriginAllowlist: readonly string[];
   issuer: string;
   audience: string;
-  connectionResolver: GatewayConnectionResolver;
+  authorityResolver: GatewayAuthorityResolver;
   assertionSigner: GatewayAssertionSigner;
   transport: GatewayTransport;
   requestTimeoutMs?: number;
-  resolverTimeoutMs?: number;
+  authorizationTimeoutMs?: number;
   signerTimeoutMs?: number;
   maxResponseBytes?: number;
   maxResponseChunks?: number;
+  cleanupTimeoutMs?: number;
 }>;
 
 type GatewayServerClient = Readonly<{
@@ -184,11 +211,13 @@ type GatewayServerClient = Readonly<{
 /** Stable, secret-free client failure suitable for a server route mapping. */
 class GatewayClientError extends Error {
   readonly code: GatewayClientErrorCode;
+  readonly status: number;
 
   constructor(code: GatewayClientErrorCode) {
     super("Gateway client request failed");
     this.name = "GatewayClientError";
     this.code = code;
+    this.status = statusForClientError(code);
   }
 }
 
@@ -254,22 +283,26 @@ function createGatewayServerClient(
       );
 
       try {
-        const connection = await runControlPlaneStage(
+        const resolution = await runAuthorityStage(
           (context) =>
-            configuration.connectionResolver.resolve(
+            configuration.authorityResolver.authorize(
               Object.freeze({
-                ownerId: parsedRequest.context.ownerId,
+                resource: parsedRequest.resource,
                 connectionId: parsedRequest.connectionId,
                 provider: "codex",
+                operation: parsedRequest.operation,
                 requireDefault: true,
               }),
               context
             ),
-          configuration.resolverTimeoutMs,
+          configuration.authorizationTimeoutMs,
           requestController.signal,
           parsedRequest.signal
         );
-        requireUsableConnection(connection, parsedRequest);
+        const authority = requireAuthorizedResolution(
+          resolution,
+          parsedRequest
+        );
 
         const assertion = await runControlPlaneStage(
           (context) =>
@@ -277,10 +310,10 @@ function createGatewayServerClient(
               Object.freeze({
                 issuer: configuration.issuer,
                 audience: configuration.audience,
-                subject: parsedRequest.context.ownerId,
-                connectionId: parsedRequest.connectionId,
+                subject: authority.ownerId,
+                connectionId: authority.connection.canonicalId,
                 provider: "codex",
-                operation: parsedRequest.operation,
+                operation: authority.operation,
                 requestId: parsedRequest.requestId,
               }),
               context
@@ -293,11 +326,14 @@ function createGatewayServerClient(
 
         const url = buildOperationUrl(
           configuration.gatewayOrigin,
-          parsedRequest.operation
+          authority.operation
         );
         const body = JSON.stringify({
           input: {
-            resource: parsedRequest.context.resource,
+            resource: {
+              type: authority.resource.type,
+              id: authority.resource.canonicalId,
+            },
           },
         });
         const transportPromise = Promise.resolve().then(() => {
@@ -326,13 +362,20 @@ function createGatewayServerClient(
         const response = await awaitObserved(
           transportPromise,
           requestController.signal,
-          parsedRequest.signal
+          parsedRequest.signal,
+          (lateResponse) => {
+            observeResponseDisposal(
+              lateResponse,
+              configuration.cleanupTimeoutMs
+            );
+          }
         );
         return await readGatewayResponse(
           response,
           url,
           configuration.maxResponseBytes,
           configuration.maxResponseChunks,
+          configuration.cleanupTimeoutMs,
           requestController.signal,
           parsedRequest.signal
         );
@@ -349,64 +392,69 @@ function createGatewayServerClient(
 }
 
 /** Snapshots and validates all construction-time policy. */
-function readConfiguration(
-  options: GatewayServerClientOptions
-): Required<
-  Omit<GatewayServerClientOptions, "gatewayOrigin" | "issuer" | "audience">
+function readConfiguration(options: GatewayServerClientOptions): Required<
+  Omit<
+    GatewayServerClientOptions,
+    "gatewayOrigin" | "gatewayOriginAllowlist" | "issuer" | "audience"
+  >
 > &
-  Readonly<{ gatewayOrigin: string; issuer: string; audience: string }> {
+  Readonly<{
+    gatewayOrigin: string;
+    gatewayOriginAllowlist: readonly string[];
+    issuer: string;
+    audience: string;
+  }> {
   const requestTimeoutMs =
     options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
-  const resolverTimeoutMs =
-    options.resolverTimeoutMs ?? DEFAULT_RESOLVER_TIMEOUT_MS;
+  const authorizationTimeoutMs =
+    options.authorizationTimeoutMs ?? DEFAULT_AUTHORIZATION_TIMEOUT_MS;
   const signerTimeoutMs = options.signerTimeoutMs ?? DEFAULT_SIGNER_TIMEOUT_MS;
   const maxResponseBytes =
     options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
   const maxResponseChunks =
     options.maxResponseChunks ?? DEFAULT_MAX_RESPONSE_CHUNKS;
-  let parsedOrigin: URL;
-  try {
-    parsedOrigin = new URL(options.gatewayOrigin);
-  } catch {
-    throw clientError("gateway_client_configuration_invalid");
-  }
+  const cleanupTimeoutMs =
+    options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS;
+  const gatewayOriginAllowlist = readGatewayOriginAllowlist(
+    options.gatewayOriginAllowlist
+  );
+  const gatewayOrigin = readSelectedGatewayOrigin(
+    options.gatewayOrigin,
+    gatewayOriginAllowlist
+  );
 
   if (
-    parsedOrigin.protocol !== "https:" ||
-    parsedOrigin.username !== "" ||
-    parsedOrigin.password !== "" ||
-    parsedOrigin.pathname !== "/" ||
-    parsedOrigin.search !== "" ||
-    parsedOrigin.hash !== "" ||
-    parsedOrigin.origin !== options.gatewayOrigin ||
     !isIdentifier(options.issuer) ||
     !isIdentifier(options.audience) ||
-    typeof options.connectionResolver?.resolve !== "function" ||
+    typeof options.authorityResolver?.authorize !== "function" ||
     typeof options.assertionSigner?.sign !== "function" ||
     typeof options.transport?.send !== "function" ||
     !isBoundedInteger(requestTimeoutMs, MAX_REQUEST_TIMEOUT_MS) ||
-    !isBoundedInteger(resolverTimeoutMs, MAX_CONTROL_PLANE_TIMEOUT_MS) ||
-    resolverTimeoutMs > requestTimeoutMs ||
+    !isBoundedInteger(authorizationTimeoutMs, MAX_CONTROL_PLANE_TIMEOUT_MS) ||
+    authorizationTimeoutMs > requestTimeoutMs ||
     !isBoundedInteger(signerTimeoutMs, MAX_CONTROL_PLANE_TIMEOUT_MS) ||
     signerTimeoutMs > requestTimeoutMs ||
     !isBoundedInteger(maxResponseBytes, MAX_RESPONSE_BYTES) ||
-    !isBoundedInteger(maxResponseChunks, MAX_RESPONSE_CHUNKS)
+    !isBoundedInteger(maxResponseChunks, MAX_RESPONSE_CHUNKS) ||
+    !isBoundedInteger(cleanupTimeoutMs, MAX_CLEANUP_TIMEOUT_MS)
   ) {
     throw clientError("gateway_client_configuration_invalid");
   }
 
   return Object.freeze({
-    gatewayOrigin: parsedOrigin.origin,
+    gatewayOrigin,
+    gatewayOriginAllowlist,
     issuer: options.issuer,
     audience: options.audience,
-    connectionResolver: options.connectionResolver,
+    authorityResolver: options.authorityResolver,
     assertionSigner: options.assertionSigner,
     transport: options.transport,
     requestTimeoutMs,
-    resolverTimeoutMs,
+    authorizationTimeoutMs,
     signerTimeoutMs,
     maxResponseBytes,
     maxResponseChunks,
+    cleanupTimeoutMs,
   });
 }
 
@@ -415,9 +463,16 @@ function readRequest(request: GatewayClientRequest): GatewayClientRequest {
   if (
     typeof request !== "object" ||
     request === null ||
-    !isIdentifier(request.context?.ownerId) ||
-    request.context.resource?.type !== "mindmap" ||
-    !isIdentifier(request.context.resource.id) ||
+    !hasExactKeys(request, [
+      "connectionId",
+      "operation",
+      "requestId",
+      "resource",
+      ...(request.signal === undefined ? [] : ["signal"]),
+    ]) ||
+    request.resource?.type !== "mindmap" ||
+    !hasExactKeys(request.resource, ["id", "type"]) ||
+    !isIdentifier(request.resource.id) ||
     !isIdentifier(request.connectionId) ||
     !GATEWAY_OPERATIONS.includes(request.operation) ||
     !isIdentifier(request.requestId) ||
@@ -427,10 +482,7 @@ function readRequest(request: GatewayClientRequest): GatewayClientRequest {
   }
 
   return Object.freeze({
-    context: Object.freeze({
-      ownerId: request.context.ownerId,
-      resource: Object.freeze({ ...request.context.resource }),
-    }),
+    resource: Object.freeze({ ...request.resource }),
     connectionId: request.connectionId,
     operation: request.operation,
     requestId: request.requestId,
@@ -438,7 +490,7 @@ function readRequest(request: GatewayClientRequest): GatewayClientRequest {
   });
 }
 
-/** Executes a resolver or signer behind its own bound and the request deadline. */
+/** Executes an authority or signer dependency behind its request deadline. */
 async function runControlPlaneStage<T>(
   operation: (context: ControlPlaneOperationContext) => T | PromiseLike<T>,
   timeoutMs: number,
@@ -475,20 +527,59 @@ async function runControlPlaneStage<T>(
   }
 }
 
-/** Rejects all missing, mismatched, non-default, or unusable connection state alike. */
-function requireUsableConnection(
-  connection: ResolvedGatewayConnection | null,
+/**
+ * Executes the atomic authorization resolver without exposing whether its
+ * owner, resource, or connection checks failed, timed out, or were unavailable.
+ */
+async function runAuthorityStage<T>(
+  operation: (context: ControlPlaneOperationContext) => T | PromiseLike<T>,
+  timeoutMs: number,
+  requestSignal: AbortSignal,
+  callerSignal?: AbortSignal
+): Promise<T> {
+  try {
+    return await runControlPlaneStage(
+      operation,
+      timeoutMs,
+      requestSignal,
+      callerSignal
+    );
+  } catch {
+    if (callerSignal?.aborted) throw clientError("request_aborted");
+    throw clientError("authorization_unavailable");
+  }
+}
+
+/** Validates and snapshots authority returned only by the server dependency. */
+function requireAuthorizedResolution(
+  resolution: AuthorizedGatewayResolution | null,
   request: GatewayClientRequest
-): asserts connection is ResolvedGatewayConnection {
-  if (
-    connection === null ||
-    connection.ownerId !== request.context.ownerId ||
-    connection.connectionId !== request.connectionId ||
-    connection.provider !== "codex" ||
-    connection.status !== "connected" ||
-    connection.isDefault !== true
-  ) {
-    throw clientError("connection_unavailable");
+): AuthorizedGatewayResolution {
+  try {
+    if (
+      resolution === null ||
+      !isIdentifier(resolution.ownerId) ||
+      resolution.resource.type !== "mindmap" ||
+      resolution.resource.requestedId !== request.resource.id ||
+      !isIdentifier(resolution.resource.canonicalId) ||
+      resolution.connection.requestedId !== request.connectionId ||
+      !isIdentifier(resolution.connection.canonicalId) ||
+      resolution.connection.provider !== "codex" ||
+      resolution.connection.status !== "connected" ||
+      resolution.connection.isDefault !== true ||
+      resolution.operation !== request.operation
+    ) {
+      throw clientError("authorization_unavailable");
+    }
+
+    return Object.freeze({
+      ownerId: resolution.ownerId,
+      resource: Object.freeze({ ...resolution.resource }),
+      connection: Object.freeze({ ...resolution.connection }),
+      operation: resolution.operation,
+    });
+  } catch {
+    throw clientError("authorization_unavailable");
   }
 }
 
@@ -520,33 +611,52 @@ async function readGatewayResponse(
   expectedUrl: string,
   maxBytes: number,
   maxChunks: number,
+  cleanupTimeoutMs: number,
   requestSignal: AbortSignal,
   callerSignal?: AbortSignal
 ): Promise<unknown> {
-  if (
-    typeof response !== "object" ||
-    response === null ||
-    !Number.isInteger(response.status) ||
-    response.redirected !== false ||
-    response.url !== expectedUrl ||
-    typeof response.headers?.get !== "function" ||
-    !isJsonContentType(response.headers.get("content-type")) ||
-    response.body === null
-  ) {
+  const body = readResponseBody(response);
+  let metadataValid = false;
+  try {
+    metadataValid =
+      typeof response === "object" &&
+      response !== null &&
+      isGatewayStatus(response.status) &&
+      response.redirected === false &&
+      response.url === expectedUrl &&
+      typeof response.headers?.get === "function" &&
+      isJsonContentType(response.headers.get("content-type")) &&
+      body !== null &&
+      typeof body.getReader === "function";
+  } catch {
+    // All transport metadata ambiguity shares one response failure below.
+  }
+  if (!metadataValid || body === null) {
+    await disposeResponseBody(body, cleanupTimeoutMs);
     throw clientError("gateway_response_invalid");
   }
 
-  const body = await readBoundedBody(
-    response.body,
-    maxBytes,
-    maxChunks,
-    requestSignal,
-    callerSignal
-  );
+  let encodedBody: Uint8Array;
+  try {
+    encodedBody = await readBoundedBody(
+      body,
+      maxBytes,
+      maxChunks,
+      requestSignal,
+      callerSignal
+    );
+  } catch (error) {
+    await disposeResponseBody(body, cleanupTimeoutMs);
+    if (error instanceof GatewayClientError) throw error;
+    throw clientError("gateway_response_invalid");
+  }
   let value: unknown;
   try {
-    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body));
+    value = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(encodedBody)
+    );
   } catch {
+    await disposeResponseBody(body, cleanupTimeoutMs);
     throw clientError("gateway_response_invalid");
   }
 
@@ -554,9 +664,13 @@ async function readGatewayResponse(
   if (response.status === 200 && success.success) return success.data.data;
 
   const failure = gatewayFailureSchema.safeParse(value);
-  if (!failure.success) throw clientError("gateway_response_invalid");
+  if (!failure.success) {
+    await disposeResponseBody(body, cleanupTimeoutMs);
+    throw clientError("gateway_response_invalid");
+  }
   const expectedStatus = GATEWAY_ERROR_STATUS[failure.data.error.code];
   if (response.status !== expectedStatus) {
+    await disposeResponseBody(body, cleanupTimeoutMs);
     throw clientError("gateway_response_invalid");
   }
   throw clientError(failure.data.error.code);
@@ -564,7 +678,7 @@ async function readGatewayResponse(
 
 /** Reads a response stream with hard byte/chunk limits and observed cancellation. */
 async function readBoundedBody(
-  body: ReadableStream<Uint8Array>,
+  body: GatewayResponseBody,
   maxBytes: number,
   maxChunks: number,
   requestSignal: AbortSignal,
@@ -573,7 +687,7 @@ async function readBoundedBody(
   if (requestSignal.aborted) {
     throw cancellationError(requestSignal, callerSignal);
   }
-  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  let reader: GatewayResponseBodyReader;
   try {
     reader = body.getReader();
   } catch {
@@ -631,11 +745,70 @@ async function readBoundedBody(
   return combined;
 }
 
+/** Reads a body reference without allowing hostile response getters to escape. */
+function readResponseBody(
+  response: GatewayTransportResponse
+): GatewayResponseBody | null {
+  try {
+    return typeof response === "object" && response !== null
+      ? response.body
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Disposes an unused body behind a finite bound and observes cleanup failures. */
+async function disposeResponseBody(
+  body: GatewayResponseBody | null,
+  timeoutMs: number
+): Promise<void> {
+  if (body === null || typeof body !== "object") return;
+
+  const cleanup = Promise.resolve().then(async () => {
+    if (typeof body.cancel === "function") {
+      await body.cancel();
+      return;
+    }
+    if (typeof body.getReader !== "function") return;
+    const reader = body.getReader();
+    try {
+      await reader.cancel();
+    } finally {
+      reader.releaseLock();
+    }
+  });
+  // Both branches resolve: cleanup failures and a stalled cancel are observed
+  // without replacing the original request outcome.
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(finish, timeoutMs);
+    cleanup.then(finish, finish);
+  });
+}
+
+/** Disposes a body returned after request cancellation without awaiting it. */
+function observeResponseDisposal(
+  response: GatewayTransportResponse,
+  timeoutMs: number
+): void {
+  void Promise.resolve()
+    .then(() => disposeResponseBody(readResponseBody(response), timeoutMs))
+    .catch(() => undefined);
+}
+
 /** Awaits a promise while retaining both late fulfillment and rejection handlers. */
 function awaitObserved<T>(
   promise: PromiseLike<T>,
   signal: AbortSignal,
-  callerSignal?: AbortSignal
+  callerSignal?: AbortSignal,
+  onLateFulfilled?: (value: T) => void
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     let settled = false;
@@ -652,7 +825,17 @@ function awaitObserved<T>(
     if (signal.aborted) handleAbort();
 
     Promise.resolve(promise).then(
-      (value) => finish(() => resolve(value)),
+      (value) => {
+        if (settled) {
+          try {
+            onLateFulfilled?.(value);
+          } catch {
+            // Late cleanup hooks are best-effort and must remain observed.
+          }
+          return;
+        }
+        finish(() => resolve(value));
+      },
       () => finish(() => reject(clientError("gateway_unavailable")))
     );
   });
@@ -669,6 +852,112 @@ function cancellationError(
       : requestSignal.aborted
         ? "request_timeout"
         : "gateway_unavailable"
+  );
+}
+
+/** Validates and snapshots a nonempty exact HTTPS origin allowlist. */
+function readGatewayOriginAllowlist(
+  values: readonly string[]
+): readonly string[] {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 32) {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+  const origins = values.map(readCanonicalGatewayOrigin);
+  if (new Set(origins).size !== origins.length) {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+  return Object.freeze(origins);
+}
+
+/** Requires the selected origin to be one exact allowlist member. */
+function readSelectedGatewayOrigin(
+  value: string,
+  allowlist: readonly string[]
+): string {
+  const origin = readCanonicalGatewayOrigin(value);
+  if (!allowlist.includes(origin)) {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+  return origin;
+}
+
+/**
+ * Accepts one canonical HTTPS origin with a public-looking ASCII DNS host.
+ * A non-default port is accepted only when its exact origin is allowlisted.
+ */
+function readCanonicalGatewayOrigin(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+
+  const hostname = parsed.hostname;
+  const labels = hostname.split(".");
+  const addressCandidate = hostname.replace(/^\[|\]$/g, "");
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    parsed.origin !== value ||
+    hostname.length === 0 ||
+    hostname.endsWith(".") ||
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.includes("xn--") ||
+    isIP(addressCandidate) !== 0 ||
+    !/^[a-z0-9.-]+$/.test(hostname) ||
+    labels.length < 2 ||
+    labels.some(
+      (label) =>
+        label.length === 0 ||
+        label.length > 63 ||
+        label.startsWith("-") ||
+        label.endsWith("-")
+    )
+  ) {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+  return parsed.origin;
+}
+
+/** Recognizes statuses that have an exact local response-schema mapping. */
+function isGatewayStatus(value: unknown): value is number {
+  return (
+    value === 200 ||
+    Object.values(GATEWAY_ERROR_STATUS).some((status) => status === value)
+  );
+}
+
+/** Maps every stable client code to one non-secret HTTP boundary status. */
+function statusForClientError(code: GatewayClientErrorCode): number {
+  if (code in GATEWAY_ERROR_STATUS) {
+    return GATEWAY_ERROR_STATUS[code as GatewayRemoteErrorCode];
+  }
+  const localStatus: Readonly<
+    Record<Exclude<GatewayClientErrorCode, GatewayRemoteErrorCode>, number>
+  > = {
+    authorization_unavailable: 404,
+    gateway_client_configuration_invalid: 500,
+    gateway_response_invalid: 502,
+    gateway_unavailable: 503,
+    response_too_large: 502,
+  };
+  return localStatus[code as keyof typeof localStatus];
+}
+
+/** Requires an object to expose exactly the server client's narrow fields. */
+function hasExactKeys(value: object, expectedKeys: readonly string[]): boolean {
+  const actualKeys = Object.keys(value).sort();
+  const expected = [...expectedKeys].sort();
+  return (
+    actualKeys.length === expected.length &&
+    actualKeys.every((key, index) => key === expected[index])
   );
 }
 
@@ -705,22 +994,23 @@ function clientError(code: GatewayClientErrorCode): GatewayClientError {
 }
 
 export {
-  type AuthenticatedGatewayContext,
+  type AuthorizeGatewayIntentInput,
   createFetchGatewayTransport,
   createGatewayServerClient,
   type FetchImplementation,
   type GatewayAssertionSigner,
+  type GatewayAuthorityResolver,
   GatewayClientError,
   type GatewayClientErrorCode,
   type GatewayClientRequest,
-  type GatewayConnectionResolver,
   type GatewayRemoteErrorCode,
+  type GatewayResourceIntent,
+  type GatewayResponseBody,
+  type GatewayResponseBodyReader,
   type GatewayServerClient,
   type GatewayServerClientOptions,
   type GatewayTransport,
   type GatewayTransportRequest,
   type GatewayTransportResponse,
-  type ResolveConnectionInput,
-  type ResolvedGatewayConnection,
   type SignAssertionInput,
 };

--- a/lib/gateway/server-client.ts
+++ b/lib/gateway/server-client.ts
@@ -1,0 +1,726 @@
+import "server-only";
+
+import { z } from "zod";
+
+import type { ControlPlaneOperationContext } from "../../services/agent-gateway/control-plane.ts";
+import {
+  GATEWAY_OPERATIONS,
+  type GatewayOperation,
+} from "../../services/agent-gateway/internal-auth.ts";
+
+const GATEWAY_BASE_PATH = "/internal/v1";
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_RESOLVER_TIMEOUT_MS = 1_000;
+const DEFAULT_SIGNER_TIMEOUT_MS = 1_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1_024;
+const DEFAULT_MAX_RESPONSE_CHUNKS = 1_024;
+const MAX_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const MAX_CONTROL_PLANE_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 4 * 1_024 * 1_024;
+const MAX_RESPONSE_CHUNKS = 4_096;
+const MAX_IDENTIFIER_LENGTH = 256;
+
+const OPERATION_PATHS: Readonly<Record<GatewayOperation, string>> =
+  Object.freeze({
+    chat: "operations/chat",
+    "mind-map-generation": "operations/mind-map-generation",
+    "node-editing": "operations/node-editing",
+  });
+
+const GATEWAY_ERROR_STATUS = Object.freeze({
+  gateway_configuration_unavailable: 503,
+  invalid_request: 400,
+  method_not_allowed: 405,
+  not_found: 404,
+  operation_failed: 502,
+  payload_too_large: 413,
+  rate_limit_unavailable: 503,
+  rate_limited: 429,
+  replay_defense_unavailable: 503,
+  request_aborted: 499,
+  request_timeout: 504,
+  unauthorized: 401,
+  unsupported_media_type: 415,
+} as const);
+
+const gatewayErrorCodeSchema = z.enum([
+  "gateway_configuration_unavailable",
+  "invalid_request",
+  "method_not_allowed",
+  "not_found",
+  "operation_failed",
+  "payload_too_large",
+  "rate_limit_unavailable",
+  "rate_limited",
+  "replay_defense_unavailable",
+  "request_aborted",
+  "request_timeout",
+  "unauthorized",
+  "unsupported_media_type",
+]);
+const gatewaySuccessSchema = z
+  .object({ ok: z.literal(true), data: z.unknown() })
+  .strict();
+const gatewayFailureSchema = z
+  .object({
+    ok: z.literal(false),
+    error: z.object({ code: gatewayErrorCodeSchema }).strict(),
+  })
+  .strict();
+
+type GatewayRemoteErrorCode = z.infer<typeof gatewayErrorCodeSchema>;
+type GatewayClientErrorCode =
+  | GatewayRemoteErrorCode
+  | "connection_unavailable"
+  | "gateway_client_configuration_invalid"
+  | "gateway_response_invalid"
+  | "gateway_unavailable"
+  | "request_aborted"
+  | "request_timeout"
+  | "response_too_large";
+
+type AuthenticatedGatewayContext = Readonly<{
+  ownerId: string;
+  resource: Readonly<{
+    type: "mindmap";
+    id: string;
+  }>;
+}>;
+
+type GatewayClientRequest = Readonly<{
+  context: AuthenticatedGatewayContext;
+  connectionId: string;
+  operation: GatewayOperation;
+  requestId: string;
+  signal?: AbortSignal;
+}>;
+
+type ResolveConnectionInput = Readonly<{
+  ownerId: string;
+  connectionId: string;
+  provider: "codex";
+  requireDefault: true;
+}>;
+
+type ResolvedGatewayConnection = Readonly<{
+  ownerId: string;
+  connectionId: string;
+  provider: "codex";
+  status: "connected" | "expired" | "pending" | "revoked" | "error";
+  isDefault: boolean;
+}>;
+
+interface GatewayConnectionResolver {
+  resolve(
+    input: ResolveConnectionInput,
+    context: ControlPlaneOperationContext
+  ):
+    | ResolvedGatewayConnection
+    | null
+    | Promise<ResolvedGatewayConnection | null>;
+}
+
+type SignAssertionInput = Readonly<{
+  issuer: string;
+  audience: string;
+  subject: string;
+  connectionId: string;
+  provider: "codex";
+  operation: GatewayOperation;
+  requestId: string;
+}>;
+
+interface GatewayAssertionSigner {
+  sign(
+    input: SignAssertionInput,
+    context: ControlPlaneOperationContext
+  ): string | Promise<string>;
+}
+
+type GatewayTransportRequest = Readonly<{
+  url: string;
+  method: "POST";
+  headers: Readonly<Record<string, string>>;
+  body: string;
+  redirect: "error";
+  signal: AbortSignal;
+}>;
+
+type GatewayTransportResponse = Readonly<{
+  status: number;
+  redirected: boolean;
+  url: string;
+  headers: Pick<Headers, "get">;
+  body: ReadableStream<Uint8Array> | null;
+}>;
+
+interface GatewayTransport {
+  send(request: GatewayTransportRequest): Promise<GatewayTransportResponse>;
+}
+
+type FetchImplementation = (
+  input: string,
+  init: RequestInit
+) => Promise<Response>;
+
+type GatewayServerClientOptions = Readonly<{
+  gatewayOrigin: string;
+  issuer: string;
+  audience: string;
+  connectionResolver: GatewayConnectionResolver;
+  assertionSigner: GatewayAssertionSigner;
+  transport: GatewayTransport;
+  requestTimeoutMs?: number;
+  resolverTimeoutMs?: number;
+  signerTimeoutMs?: number;
+  maxResponseBytes?: number;
+  maxResponseChunks?: number;
+}>;
+
+type GatewayServerClient = Readonly<{
+  execute(request: GatewayClientRequest): Promise<unknown>;
+}>;
+
+/** Stable, secret-free client failure suitable for a server route mapping. */
+class GatewayClientError extends Error {
+  readonly code: GatewayClientErrorCode;
+
+  constructor(code: GatewayClientErrorCode) {
+    super("Gateway client request failed");
+    this.name = "GatewayClientError";
+    this.code = code;
+  }
+}
+
+/** Adapts an explicitly injected fetch implementation without using global fetch. */
+function createFetchGatewayTransport(
+  fetchImplementation: FetchImplementation
+): GatewayTransport {
+  if (typeof fetchImplementation !== "function") {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+
+  return Object.freeze({
+    async send(request: GatewayTransportRequest) {
+      return fetchImplementation(request.url, {
+        method: request.method,
+        headers: request.headers,
+        body: request.body,
+        redirect: request.redirect,
+        signal: request.signal,
+      });
+    },
+  });
+}
+
+/**
+ * Creates a server-only gateway client whose caller cannot choose transport,
+ * route, assertion authority, provider runtime, command, model, or credentials.
+ */
+function createGatewayServerClient(
+  options: GatewayServerClientOptions
+): GatewayServerClient {
+  let configuration: ReturnType<typeof readConfiguration>;
+  try {
+    configuration = readConfiguration(options);
+  } catch (error) {
+    if (error instanceof GatewayClientError) throw error;
+    throw clientError("gateway_client_configuration_invalid");
+  }
+
+  return Object.freeze({
+    async execute(request: GatewayClientRequest): Promise<unknown> {
+      let parsedRequest: GatewayClientRequest;
+      try {
+        parsedRequest = readRequest(request);
+      } catch (error) {
+        if (error instanceof GatewayClientError) throw error;
+        throw clientError("gateway_client_configuration_invalid");
+      }
+      if (parsedRequest.signal?.aborted) {
+        throw clientError("request_aborted");
+      }
+
+      const requestController = new AbortController();
+      const handleCallerAbort = (): void => requestController.abort();
+      parsedRequest.signal?.addEventListener("abort", handleCallerAbort, {
+        once: true,
+      });
+      // Close the check/listener race without forwarding the caller's reason.
+      if (parsedRequest.signal?.aborted) handleCallerAbort();
+      const requestTimer = setTimeout(
+        () => requestController.abort(),
+        configuration.requestTimeoutMs
+      );
+
+      try {
+        const connection = await runControlPlaneStage(
+          (context) =>
+            configuration.connectionResolver.resolve(
+              Object.freeze({
+                ownerId: parsedRequest.context.ownerId,
+                connectionId: parsedRequest.connectionId,
+                provider: "codex",
+                requireDefault: true,
+              }),
+              context
+            ),
+          configuration.resolverTimeoutMs,
+          requestController.signal,
+          parsedRequest.signal
+        );
+        requireUsableConnection(connection, parsedRequest);
+
+        const assertion = await runControlPlaneStage(
+          (context) =>
+            configuration.assertionSigner.sign(
+              Object.freeze({
+                issuer: configuration.issuer,
+                audience: configuration.audience,
+                subject: parsedRequest.context.ownerId,
+                connectionId: parsedRequest.connectionId,
+                provider: "codex",
+                operation: parsedRequest.operation,
+                requestId: parsedRequest.requestId,
+              }),
+              context
+            ),
+          configuration.signerTimeoutMs,
+          requestController.signal,
+          parsedRequest.signal
+        );
+        requireAssertion(assertion);
+
+        const url = buildOperationUrl(
+          configuration.gatewayOrigin,
+          parsedRequest.operation
+        );
+        const body = JSON.stringify({
+          input: {
+            resource: parsedRequest.context.resource,
+          },
+        });
+        const transportPromise = Promise.resolve().then(() => {
+          // A queued transport handoff must not start after cancellation wins.
+          if (requestController.signal.aborted) {
+            throw cancellationError(
+              requestController.signal,
+              parsedRequest.signal
+            );
+          }
+          return configuration.transport.send(
+            Object.freeze({
+              url,
+              method: "POST",
+              headers: Object.freeze({
+                authorization: `Bearer ${assertion}`,
+                "content-type": "application/json",
+                "x-request-id": parsedRequest.requestId,
+              }),
+              body,
+              redirect: "error",
+              signal: requestController.signal,
+            })
+          );
+        });
+        const response = await awaitObserved(
+          transportPromise,
+          requestController.signal,
+          parsedRequest.signal
+        );
+        return await readGatewayResponse(
+          response,
+          url,
+          configuration.maxResponseBytes,
+          configuration.maxResponseChunks,
+          requestController.signal,
+          parsedRequest.signal
+        );
+      } catch (error) {
+        if (error instanceof GatewayClientError) throw error;
+        throw cancellationError(requestController.signal, parsedRequest.signal);
+      } finally {
+        clearTimeout(requestTimer);
+        parsedRequest.signal?.removeEventListener("abort", handleCallerAbort);
+        requestController.abort();
+      }
+    },
+  });
+}
+
+/** Snapshots and validates all construction-time policy. */
+function readConfiguration(
+  options: GatewayServerClientOptions
+): Required<
+  Omit<GatewayServerClientOptions, "gatewayOrigin" | "issuer" | "audience">
+> &
+  Readonly<{ gatewayOrigin: string; issuer: string; audience: string }> {
+  const requestTimeoutMs =
+    options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const resolverTimeoutMs =
+    options.resolverTimeoutMs ?? DEFAULT_RESOLVER_TIMEOUT_MS;
+  const signerTimeoutMs = options.signerTimeoutMs ?? DEFAULT_SIGNER_TIMEOUT_MS;
+  const maxResponseBytes =
+    options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+  const maxResponseChunks =
+    options.maxResponseChunks ?? DEFAULT_MAX_RESPONSE_CHUNKS;
+  let parsedOrigin: URL;
+  try {
+    parsedOrigin = new URL(options.gatewayOrigin);
+  } catch {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+
+  if (
+    parsedOrigin.protocol !== "https:" ||
+    parsedOrigin.username !== "" ||
+    parsedOrigin.password !== "" ||
+    parsedOrigin.pathname !== "/" ||
+    parsedOrigin.search !== "" ||
+    parsedOrigin.hash !== "" ||
+    parsedOrigin.origin !== options.gatewayOrigin ||
+    !isIdentifier(options.issuer) ||
+    !isIdentifier(options.audience) ||
+    typeof options.connectionResolver?.resolve !== "function" ||
+    typeof options.assertionSigner?.sign !== "function" ||
+    typeof options.transport?.send !== "function" ||
+    !isBoundedInteger(requestTimeoutMs, MAX_REQUEST_TIMEOUT_MS) ||
+    !isBoundedInteger(resolverTimeoutMs, MAX_CONTROL_PLANE_TIMEOUT_MS) ||
+    resolverTimeoutMs > requestTimeoutMs ||
+    !isBoundedInteger(signerTimeoutMs, MAX_CONTROL_PLANE_TIMEOUT_MS) ||
+    signerTimeoutMs > requestTimeoutMs ||
+    !isBoundedInteger(maxResponseBytes, MAX_RESPONSE_BYTES) ||
+    !isBoundedInteger(maxResponseChunks, MAX_RESPONSE_CHUNKS)
+  ) {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+
+  return Object.freeze({
+    gatewayOrigin: parsedOrigin.origin,
+    issuer: options.issuer,
+    audience: options.audience,
+    connectionResolver: options.connectionResolver,
+    assertionSigner: options.assertionSigner,
+    transport: options.transport,
+    requestTimeoutMs,
+    resolverTimeoutMs,
+    signerTimeoutMs,
+    maxResponseBytes,
+    maxResponseChunks,
+  });
+}
+
+/** Validates the narrow server-derived invocation boundary. */
+function readRequest(request: GatewayClientRequest): GatewayClientRequest {
+  if (
+    typeof request !== "object" ||
+    request === null ||
+    !isIdentifier(request.context?.ownerId) ||
+    request.context.resource?.type !== "mindmap" ||
+    !isIdentifier(request.context.resource.id) ||
+    !isIdentifier(request.connectionId) ||
+    !GATEWAY_OPERATIONS.includes(request.operation) ||
+    !isIdentifier(request.requestId) ||
+    (request.signal !== undefined && !(request.signal instanceof AbortSignal))
+  ) {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+
+  return Object.freeze({
+    context: Object.freeze({
+      ownerId: request.context.ownerId,
+      resource: Object.freeze({ ...request.context.resource }),
+    }),
+    connectionId: request.connectionId,
+    operation: request.operation,
+    requestId: request.requestId,
+    signal: request.signal,
+  });
+}
+
+/** Executes a resolver or signer behind its own bound and the request deadline. */
+async function runControlPlaneStage<T>(
+  operation: (context: ControlPlaneOperationContext) => T | PromiseLike<T>,
+  timeoutMs: number,
+  requestSignal: AbortSignal,
+  callerSignal?: AbortSignal
+): Promise<T> {
+  const stageController = new AbortController();
+  const handleRequestAbort = (): void => stageController.abort();
+  requestSignal.addEventListener("abort", handleRequestAbort, { once: true });
+  if (requestSignal.aborted) handleRequestAbort();
+  const timer = setTimeout(() => stageController.abort(), timeoutMs);
+  try {
+    const promise = Promise.resolve().then(() => {
+      // Do not invoke a control-plane dependency after abort or timeout wins.
+      if (stageController.signal.aborted) {
+        throw cancellationError(requestSignal, callerSignal);
+      }
+      return operation(
+        Object.freeze({
+          signal: stageController.signal,
+          deadlineAtMilliseconds: Date.now() + timeoutMs,
+        })
+      );
+    });
+    return await awaitObserved(promise, stageController.signal, callerSignal);
+  } catch {
+    if (callerSignal?.aborted) throw clientError("request_aborted");
+    if (requestSignal.aborted) throw clientError("request_timeout");
+    throw clientError("gateway_unavailable");
+  } finally {
+    clearTimeout(timer);
+    requestSignal.removeEventListener("abort", handleRequestAbort);
+    stageController.abort();
+  }
+}
+
+/** Rejects all missing, mismatched, non-default, or unusable connection state alike. */
+function requireUsableConnection(
+  connection: ResolvedGatewayConnection | null,
+  request: GatewayClientRequest
+): asserts connection is ResolvedGatewayConnection {
+  if (
+    connection === null ||
+    connection.ownerId !== request.context.ownerId ||
+    connection.connectionId !== request.connectionId ||
+    connection.provider !== "codex" ||
+    connection.status !== "connected" ||
+    connection.isDefault !== true
+  ) {
+    throw clientError("connection_unavailable");
+  }
+}
+
+/** Requires a bounded opaque assertion without parsing or reflecting it. */
+function requireAssertion(assertion: string): void {
+  if (
+    typeof assertion !== "string" ||
+    assertion.length === 0 ||
+    assertion.length > 8_192 ||
+    /[\r\n]/.test(assertion)
+  ) {
+    throw clientError("gateway_unavailable");
+  }
+}
+
+/** Builds the only allowed gateway endpoint for a compile-time operation. */
+function buildOperationUrl(
+  origin: string,
+  operation: GatewayOperation
+): string {
+  const path = OPERATION_PATHS[operation];
+  if (!path) throw clientError("gateway_client_configuration_invalid");
+  return `${origin}${GATEWAY_BASE_PATH}/${path}`;
+}
+
+/** Reads, bounds, and strictly validates one JSON gateway response. */
+async function readGatewayResponse(
+  response: GatewayTransportResponse,
+  expectedUrl: string,
+  maxBytes: number,
+  maxChunks: number,
+  requestSignal: AbortSignal,
+  callerSignal?: AbortSignal
+): Promise<unknown> {
+  if (
+    typeof response !== "object" ||
+    response === null ||
+    !Number.isInteger(response.status) ||
+    response.redirected !== false ||
+    response.url !== expectedUrl ||
+    typeof response.headers?.get !== "function" ||
+    !isJsonContentType(response.headers.get("content-type")) ||
+    response.body === null
+  ) {
+    throw clientError("gateway_response_invalid");
+  }
+
+  const body = await readBoundedBody(
+    response.body,
+    maxBytes,
+    maxChunks,
+    requestSignal,
+    callerSignal
+  );
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body));
+  } catch {
+    throw clientError("gateway_response_invalid");
+  }
+
+  const success = gatewaySuccessSchema.safeParse(value);
+  if (response.status === 200 && success.success) return success.data.data;
+
+  const failure = gatewayFailureSchema.safeParse(value);
+  if (!failure.success) throw clientError("gateway_response_invalid");
+  const expectedStatus = GATEWAY_ERROR_STATUS[failure.data.error.code];
+  if (response.status !== expectedStatus) {
+    throw clientError("gateway_response_invalid");
+  }
+  throw clientError(failure.data.error.code);
+}
+
+/** Reads a response stream with hard byte/chunk limits and observed cancellation. */
+async function readBoundedBody(
+  body: ReadableStream<Uint8Array>,
+  maxBytes: number,
+  maxChunks: number,
+  requestSignal: AbortSignal,
+  callerSignal?: AbortSignal
+): Promise<Uint8Array> {
+  if (requestSignal.aborted) {
+    throw cancellationError(requestSignal, callerSignal);
+  }
+  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  try {
+    reader = body.getReader();
+  } catch {
+    throw clientError("gateway_response_invalid");
+  }
+
+  const chunks: Uint8Array[] = [];
+  let byteCount = 0;
+  let chunkCount = 0;
+  let completed = false;
+  try {
+    while (true) {
+      const result = await awaitObserved(
+        reader.read(),
+        requestSignal,
+        callerSignal
+      );
+      if (result.done) {
+        completed = true;
+        break;
+      }
+      if (!(result.value instanceof Uint8Array)) {
+        throw clientError("gateway_response_invalid");
+      }
+      chunkCount += 1;
+      byteCount += result.value.byteLength;
+      if (chunkCount > maxChunks || byteCount > maxBytes) {
+        throw clientError("response_too_large");
+      }
+      chunks.push(result.value);
+    }
+  } finally {
+    if (!completed) {
+      // Cancellation is deliberately fire-and-observe: a hostile stream cannot
+      // hold the request open or create an unhandled late rejection.
+      try {
+        void Promise.resolve(reader.cancel()).catch(() => undefined);
+      } catch {
+        // A non-conforming reader cannot replace the stable client failure.
+      }
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // A non-conforming transport cannot leak its cleanup error to callers.
+    }
+  }
+
+  const combined = new Uint8Array(byteCount);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return combined;
+}
+
+/** Awaits a promise while retaining both late fulfillment and rejection handlers. */
+function awaitObserved<T>(
+  promise: PromiseLike<T>,
+  signal: AbortSignal,
+  callerSignal?: AbortSignal
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", handleAbort);
+      callback();
+    };
+    const handleAbort = (): void => {
+      finish(() => reject(cancellationError(signal, callerSignal)));
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+    if (signal.aborted) handleAbort();
+
+    Promise.resolve(promise).then(
+      (value) => finish(() => resolve(value)),
+      () => finish(() => reject(clientError("gateway_unavailable")))
+    );
+  });
+}
+
+/** Distinguishes a caller abort from the server-owned deadline. */
+function cancellationError(
+  requestSignal: AbortSignal,
+  callerSignal?: AbortSignal
+): GatewayClientError {
+  return clientError(
+    callerSignal?.aborted
+      ? "request_aborted"
+      : requestSignal.aborted
+        ? "request_timeout"
+        : "gateway_unavailable"
+  );
+}
+
+/** Accepts JSON with only an optional UTF-8 charset parameter. */
+function isJsonContentType(value: string | null): boolean {
+  return (
+    value !== null &&
+    /^application\/json(?:\s*;\s*charset=utf-8)?$/i.test(value.trim())
+  );
+}
+
+/** Recognizes one nonblank bounded identifier with no control characters. */
+function isIdentifier(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_IDENTIFIER_LENGTH &&
+    value.trim() === value &&
+    !Array.from(value).some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 31 || codePoint === 127;
+    })
+  );
+}
+
+/** Recognizes a positive safe integer below a hard limit. */
+function isBoundedInteger(value: number, maximum: number): boolean {
+  return Number.isSafeInteger(value) && value > 0 && value <= maximum;
+}
+
+/** Constructs a fresh generic client failure. */
+function clientError(code: GatewayClientErrorCode): GatewayClientError {
+  return new GatewayClientError(code);
+}
+
+export {
+  type AuthenticatedGatewayContext,
+  createFetchGatewayTransport,
+  createGatewayServerClient,
+  type FetchImplementation,
+  type GatewayAssertionSigner,
+  GatewayClientError,
+  type GatewayClientErrorCode,
+  type GatewayClientRequest,
+  type GatewayConnectionResolver,
+  type GatewayRemoteErrorCode,
+  type GatewayServerClient,
+  type GatewayServerClientOptions,
+  type GatewayTransport,
+  type GatewayTransportRequest,
+  type GatewayTransportResponse,
+  type ResolveConnectionInput,
+  type ResolvedGatewayConnection,
+  type SignAssertionInput,
+};


### PR DESCRIPTION
## Feature

Adds the Codex-first, server-only Next.js-to-agent-gateway client boundary. The
public execution API accepts only authenticated server-derived owner/resource
context, a connection id, an allowlisted operation, a request id, and an abort
signal. It has no URL, issuer/audience, provider, command, model, environment,
token, credential, generic-body, API-key, or operator-login input.

## Architecture

```text
authenticated server context
  { owner, mindmap, connection, operation, request }
                    |
                    v
        owner-scoped connection resolver
     (Codex + connected + selected default)
                    |
                    v
       fixed-context assertion signer
 (issuer + audience + exact request binding)
                    |
                    v
 https://allowlisted-origin/internal/v1/operations/<allowlisted operation>
                    |
                    v
 injected fetch transport (POST, redirect=error, derived abort signal)
                    |
                    v
 bounded JSON stream -> exact status/schema map -> secret-free result/error
```

Construction-time policy validates and snapshots the canonical HTTPS origin,
issuer/audience, injected owner-scoped resolver, signer, transport, deadlines,
and response bounds. The operation route map and base path are fixed in code.
The fetch adapter accepts an explicitly injected fetch implementation and never
captures global `fetch`.

## Security and failure behavior

- Rejects missing, cross-owner, wrong-provider, mismatched, pending, expired,
  revoked, errored, or non-default connection state before signing.
- Binds assertions to exact issuer, audience, owner, connection, Codex provider,
  operation, and request id.
- Uses server-owned resolver/signer/request deadlines and reason-free derived
  abort signals; late dependency and transport settlement remains observed.
- Forces POST, JSON, redirect-error, fixed origin/path, and resource-only body.
- Rejects redirects, cross-origin/path responses, status/schema ambiguity,
  malformed JSON/content types, stalled streams, chunk floods, and oversized
  bodies.
- Returns stable secret-free error codes and never reflects dependency messages,
  assertion bytes, response bodies, or abort reasons.
- Provides no API-key, operator-login, alternate-provider, or credential fallback.

## Validation

- `pnpm typegen`
- `pnpm typecheck`
- `pnpm test` (72 files, 815 tests)
- `pnpm lint` (0 errors; 5 pre-existing warnings)
- `pnpm format:check`
- `git diff --cached --check`

Focused coverage adds 40 adversarial gateway-client tests.

## Human gates

This PR performs no network request, deployment, credential operation, database
write, or migration. Live wiring remains blocked on explicit human approval of:

1. persistent gateway host and canonical HTTPS origin;
2. assertion issuer/audience plus signing-key custody, rotation, and backup;
3. the owner-scoped server resolver implementation;
4. private routing, certificate, redirect, timeout, and response-size policy;
5. real Codex account ceremony and credential-isolation validation; and
6. deployment and any database operation.

Claude remains deferred and is not a fallback.
