### PR TITLE
feat(gateway): add lifecycle evidence protocol

### DIFF
--- a/docs/LIFECYCLE_EVIDENCE.md
+++ b/docs/LIFECYCLE_EVIDENCE.md
@@ -1,0 +1,123 @@
+# Gateway lifecycle evidence protocol
+
+Status: Phase 1 Codex-first protocol primitive; not wired to HTTP, Convex, a
+credential store, environment configuration, or deployment.
+
+## Boundary and flow
+
+`services/agent-gateway/lifecycle-evidence.ts` defines a dependency-free,
+versioned Ed25519 envelope for a gateway to prove one exact connection
+lifecycle result to a trusted server reconciliation path.
+
+```text
+authenticated gateway operation
+  + server-derived owner / connection / request / transition / revision
+  + safe Codex account projection
+                           |
+                           v
+             Ed25519 lifecycle signer
+       (fixed v1 schema, <= 60 second expiry)
+                           |
+                           v
+          opaque three-segment evidence bytes
+                           |
+                           v
+ trusted server: authenticate current/previous key
+                           |
+                           v
+ canonical schema + time -> durable replay consume
+                           |
+                           v
+ exact expected owner / connection / request /
+ provider / transition / credential revision
+                           |
+                           v
+          atomic metadata reconciliation
+                 (future integration)
+```
+
+This module does not accept a provider selector. The provider is always
+`codex`. Claude remains deferred. The protected header fixes the algorithm,
+type, version, and key identifier. Claims bind issuer, audience, Clerk owner
+subject, connection, originating request, independent evidence and nonce
+identifiers, issue/expiry seconds, one allowed lifecycle transition, and a
+positive credential revision.
+
+## Safe metadata contract
+
+Evidence can contain only:
+
+- an opaque gateway credential identifier;
+- an explicit `{ type: "chatgpt", present: true }` subscription projection;
+- an optional display-only plan label; and
+- one stable error code from the closed protocol vocabulary.
+
+Connected transitions require the opaque credential id and ChatGPT presence,
+and forbid an error. Error transitions require a stable error. Expired
+transitions require `credential_expired`. Revoked transitions carry no
+credential, account, plan, or error metadata. API-key account types fail closed.
+
+The signer validates exact own data properties without invoking getters.
+Unexpected fields are rejected, so raw provider output, tokens, filesystem
+paths, commands, environment values, serialized homes, and arbitrary error
+messages cannot enter the envelope. All identifiers and display labels are
+bounded before signing. The verifier bounds the complete envelope before
+signature work and accepts only canonical unpadded base64url plus fixed-order
+JSON. Authenticated whitespace, reordered keys, duplicate keys, extension
+fields, and equivalent encodings are noncanonical and rejected.
+
+## Replay and rotation contract
+
+The verifier authenticates against only an explicit current Ed25519 public key
+and optional previous key. Both the header and claims key id must name a key
+that authenticated the exact bytes. This gives a bounded current/previous
+rotation window without accepting caller-selected algorithms or arbitrary
+keys.
+
+After authentic signature, canonical schema, and temporal validation, the
+verifier consumes `evidenceId`, `nonce`, and `requestId` in the injected replay
+defense. Consumption occurs before comparing issuer, audience, owner,
+connection, provider, request, transition, or credential revision. Therefore a
+valid signed envelope presented in the wrong context is burned and cannot be
+retried against the intended context.
+
+The replay mutation has a finite server-owned deadline and a derived,
+reason-free abort signal. Timeout, caller abort, unknown rejection, and any
+non-void or otherwise ambiguous store result fail closed. Late fulfillment or
+rejection remains observed after the verifier settles. A production replay
+store must atomically reject a duplicate evidence id or nonce across every
+gateway/server process and retain that decision through evidence expiry.
+
+## Allowed transitions
+
+Version 1 recognizes only these exact transitions:
+
+- `pending_to_connected`, `pending_to_error`, `pending_to_expired`;
+- `connected_to_error`, `connected_to_expired`, `connected_to_revoked`;
+- `error_to_connected`, `error_to_revoked`; and
+- `expired_to_connected`, `expired_to_revoked`.
+
+The signer accepts a closed `ServerLifecycleDecision`, not generic status
+strings or caller-defined metadata. Integration code must construct that
+decision only after an authenticated gateway operation reaches a server-owned
+terminal transition. A browser request may initiate work but is never a
+trusted lifecycle decision.
+
+## Human gates before integration
+
+This protocol does not authorize live wiring. The following still require
+explicit human decisions and approval:
+
+1. signing-key custody, generation, current/previous rotation, backup, and
+   incident-recovery procedure;
+2. issuer, audience, key identifier, and finite timeout configuration;
+3. a durable, cross-process replay store with atomic consume semantics;
+4. the trusted server reconciliation transaction and credential-revision
+   compare-and-set policy;
+5. the persistent gateway host, private transport, deployment, and monitoring;
+6. any Convex schema write, migration, or production database operation; and
+7. live Codex account, revocation, rotation, restart, and recovery validation.
+
+Until those gates are approved, this file and its tests are protocol evidence
+only. They do not create keys, read credentials, access provider accounts, open
+network connections, mutate a database, or deploy infrastructure.

--- a/docs/LIFECYCLE_EVIDENCE.md
+++ b/docs/LIFECYCLE_EVIDENCE.md
@@ -47,24 +47,39 @@ positive credential revision.
 
 Evidence can contain only:
 
-- an opaque gateway credential identifier;
+- an opaque gateway credential identifier shaped as
+  `gwcred_v1_<canonical UUID v4>`;
 - an explicit `{ type: "chatgpt", present: true }` subscription projection;
-- an optional display-only plan label; and
+- an optional display-only plan label from `ChatGPT`, `ChatGPT Plus`, `ChatGPT
+  Pro`, `ChatGPT Business`, `ChatGPT Enterprise`, or `ChatGPT Edu`; and
 - one stable error code from the closed protocol vocabulary.
 
-Connected transitions require the opaque credential id and ChatGPT presence,
-and forbid an error. Error transitions require a stable error. Expired
-transitions require `credential_expired`. Revoked transitions carry no
-credential, account, plan, or error metadata. API-key account types fail closed.
+Only `pending_to_connected` establishes a validated connection. It requires the
+opaque credential id and ChatGPT presence, allows a plan enum, and forbids an
+error. Every later transition forbids credential/account/plan metadata, so
+evidence cannot introduce or replace a credential handle after establishment.
+Error transitions require a non-expiry stable error; expiry transitions require
+`credential_expired`; revoking, revoked, and deleted transitions require all
+metadata fields to be explicit nulls. API-key account types fail closed.
 
-The signer validates exact own data properties without invoking getters.
+The signer validates exact enumerable own data descriptors without invoking
+getters. Fresh snapshots have null prototypes; symbols, hostile prototypes,
+accessors, hidden properties, and the magic keys `__proto__`, `prototype`, and
+`constructor` are rejected at the decision, metadata, and account boundaries.
 Unexpected fields are rejected, so raw provider output, tokens, filesystem
 paths, commands, environment values, serialized homes, and arbitrary error
-messages cannot enter the envelope. All identifiers and display labels are
-bounded before signing. The verifier bounds the complete envelope before
-signature work and accepts only canonical unpadded base64url plus fixed-order
-JSON. Authenticated whitespace, reordered keys, duplicate keys, extension
-fields, and equivalent encodings are noncanonical and rejected.
+messages cannot enter the envelope.
+
+Issuer and audience are exact protocol constants. Clerk subjects have the
+closed Clerk user-id grammar. Connection, request, evidence, nonce, and gateway
+credential identifiers each have a distinct versioned canonical UUID-v4
+grammar. Key ids have a small lifecycle-v1 hex grammar. The plan projection is
+an enum rather than text. Token prefixes, paths, URLs, environment assignments,
+control characters, percent-encoded paths, Unicode confusables, and alternate
+encodings therefore fail before signing. The verifier bounds the complete
+envelope before signature work and accepts only canonical unpadded base64url
+plus fixed-order JSON. Authenticated whitespace, reordered keys, duplicate
+keys, extension fields, and equivalent encodings are noncanonical and rejected.
 
 ## Replay and rotation contract
 
@@ -81,21 +96,38 @@ connection, provider, request, transition, or credential revision. Therefore a
 valid signed envelope presented in the wrong context is burned and cannot be
 retried against the intended context.
 
-The replay mutation has a finite server-owned deadline and a derived,
-reason-free abort signal. Timeout, caller abort, unknown rejection, and any
-non-void or otherwise ambiguous store result fail closed. Late fulfillment or
-rejection remains observed after the verifier settles. A production replay
-store must atomically reject a duplicate evidence id or nonce across every
-gateway/server process and retain that decision through evidence expiry.
+The replay mutation has a finite server-owned deadline from an injected
+monotonic clock and a derived, reason-free abort signal. The clock is checked
+before invocation and immediately after synchronous or asynchronous settlement,
+so a store that blocks the event loop past its deadline cannot be accepted even
+if its fulfillment microtask beats the delayed timer. Timeout, caller abort,
+clock ambiguity, unknown rejection, and any non-void or otherwise ambiguous
+store result fail closed. Late fulfillment or rejection remains observed after
+the verifier settles.
+
+A production replay store must atomically reject a duplicate evidence id,
+nonce, **or originating request id** across every gateway/server process and
+retain all three decisions through evidence expiry. One request therefore has
+exactly one terminal lifecycle evidence result; concurrent distinct envelopes
+for the same request cannot both verify.
 
 ## Allowed transitions
 
-Version 1 recognizes only these exact transitions:
+Version 1 recognizes only the following explicit transition/metadata matrix:
 
-- `pending_to_connected`, `pending_to_error`, `pending_to_expired`;
-- `connected_to_error`, `connected_to_expired`, `connected_to_revoked`;
-- `error_to_connected`, `error_to_revoked`; and
-- `expired_to_connected`, `expired_to_revoked`.
+| Transition | Credential | Account | Plan | Error |
+| --- | --- | --- | --- | --- |
+| `pending_to_connected` | required | required ChatGPT presence | enum or null | null |
+| `pending_to_error` | null | null | null | required non-expiry code |
+| `pending_to_expired` | null | null | null | `credential_expired` |
+| `pending_to_revoking` | null | null | null | null |
+| `connected_to_error` | null | null | null | required non-expiry code |
+| `connected_to_expired` | null | null | null | `credential_expired` |
+| `connected_to_revoking` | null | null | null | null |
+| `error_to_revoking` | null | null | null | null |
+| `expired_to_revoking` | null | null | null | null |
+| `revoking_to_revoked` | null | null | null | null |
+| `revoked_to_deleted` | null | null | null | null |
 
 The signer accepts a closed `ServerLifecycleDecision`, not generic status
 strings or caller-defined metadata. Integration code must construct that

--- a/services/agent-gateway/lifecycle-evidence.test.ts
+++ b/services/agent-gateway/lifecycle-evidence.test.ts
@@ -1,0 +1,781 @@
+import { generateKeyPairSync, sign as signBytes } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import type { ControlPlaneOperationContext } from "./control-plane.ts";
+import {
+  type ExpectedLifecycleEvidenceContext,
+  issueLifecycleEvidence,
+  type LifecycleEvidenceClock,
+  LifecycleEvidenceError,
+  type LifecycleEvidenceMetadata,
+  type LifecycleEvidenceReplayDefense,
+  type LifecycleEvidenceSigningKey,
+  type LifecycleEvidenceVerificationKeys,
+  LifecycleReplayDefenseError,
+  type LifecycleReplayEntry,
+  type LifecycleTransition,
+  type ServerLifecycleDecision,
+  verifyLifecycleEvidence,
+} from "./lifecycle-evidence.ts";
+
+const BASE_TIME = 1_800_000_000;
+
+/** Mutable deterministic clock for exact validity-boundary tests. */
+class TestClock implements LifecycleEvidenceClock {
+  constructor(private current = BASE_TIME) {}
+
+  nowSeconds(): number {
+    return this.current;
+  }
+
+  set(nowSeconds: number): void {
+    this.current = nowSeconds;
+  }
+}
+
+/** Minimal atomic replay store used to prove identifier consumption order. */
+class MemoryReplayDefense implements LifecycleEvidenceReplayDefense {
+  readonly entries: LifecycleReplayEntry[] = [];
+
+  consume(entry: LifecycleReplayEntry): void {
+    if (
+      this.entries.some(
+        (existing) =>
+          existing.evidenceId === entry.evidenceId ||
+          existing.nonce === entry.nonce
+      )
+    ) {
+      throw new LifecycleReplayDefenseError("replay_detected");
+    }
+    this.entries.push(entry);
+  }
+}
+
+/** Creates an isolated Ed25519 key pair with a stable identifier. */
+function createKeyPair(keyId: string) {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  return {
+    signing: { keyId, privateKey } satisfies LifecycleEvidenceSigningKey,
+    verification: { keyId, publicKey },
+  };
+}
+
+/** Builds one fully isolated signer/verifier fixture. */
+function createFixture() {
+  const clock = new TestClock();
+  const current = createKeyPair("lifecycle-current");
+  const previous = createKeyPair("lifecycle-previous");
+  const expected: ExpectedLifecycleEvidenceContext = {
+    issuer: "sprig-agent-gateway",
+    audience: "sprig-trusted-server",
+    subject: "user_owner_a",
+    connectionId: "connection_a",
+    provider: "codex",
+    requestId: "request_a",
+    transition: "pending_to_connected",
+    credentialRevision: 1,
+  };
+  const verificationKeys: LifecycleEvidenceVerificationKeys = {
+    current: current.verification,
+    previous: previous.verification,
+  };
+  return { clock, current, expected, previous, verificationKeys };
+}
+
+/** Returns the safe successful-account projection required by connected evidence. */
+function connectedMetadata(
+  overrides: Partial<LifecycleEvidenceMetadata> = {}
+): LifecycleEvidenceMetadata {
+  return {
+    gatewayCredentialId: "gateway_opaque_a",
+    account: { type: "chatgpt", present: true },
+    planLabel: "Plus",
+    errorCode: null,
+    ...overrides,
+  };
+}
+
+/** Returns a complete signer decision with unique replay identifiers. */
+function decision(
+  fixture: ReturnType<typeof createFixture>,
+  overrides: Partial<ServerLifecycleDecision> = {}
+): ServerLifecycleDecision {
+  return {
+    issuer: fixture.expected.issuer,
+    audience: fixture.expected.audience,
+    subject: fixture.expected.subject,
+    connectionId: fixture.expected.connectionId,
+    requestId: fixture.expected.requestId,
+    evidenceId: "evidence_a",
+    nonce: "nonce_a",
+    transition: fixture.expected.transition,
+    credentialRevision: fixture.expected.credentialRevision,
+    metadata: connectedMetadata(),
+    ...overrides,
+  };
+}
+
+/** Issues evidence through the production signer. */
+function issue(
+  fixture: ReturnType<typeof createFixture>,
+  overrides: Partial<ServerLifecycleDecision> = {},
+  signingKey = fixture.current.signing
+): string {
+  return issueLifecycleEvidence(
+    decision(fixture, overrides),
+    signingKey,
+    fixture.clock
+  );
+}
+
+/** Verifies evidence with a fresh replay store unless one is supplied. */
+function verify(
+  fixture: ReturnType<typeof createFixture>,
+  token: string | null | undefined,
+  overrides: Partial<{
+    expected: ExpectedLifecycleEvidenceContext;
+    replayDefense: LifecycleEvidenceReplayDefense;
+    replayDefenseTimeoutMs: number;
+    signal: AbortSignal;
+    verificationKeys: LifecycleEvidenceVerificationKeys;
+  }> = {}
+) {
+  return verifyLifecycleEvidence(token, {
+    clock: fixture.clock,
+    expected: overrides.expected ?? fixture.expected,
+    replayDefense: overrides.replayDefense ?? new MemoryReplayDefense(),
+    verificationKeys: overrides.verificationKeys ?? fixture.verificationKeys,
+    replayDefenseTimeoutMs: overrides.replayDefenseTimeoutMs,
+    signal: overrides.signal,
+  });
+}
+
+/** Signs pre-encoded segments to test authenticated malformed payloads. */
+function signSegments(
+  encodedHeader: string,
+  encodedClaims: string,
+  signingKey: LifecycleEvidenceSigningKey
+): string {
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const signature = signBytes(
+    null,
+    Buffer.from(signingInput),
+    signingKey.privateKey
+  ).toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+/** Re-signs a controlled payload mutation in original property order. */
+function resignClaims(
+  token: string,
+  signingKey: LifecycleEvidenceSigningKey,
+  mutate: (claims: Record<string, unknown>) => void
+): string {
+  const [encodedHeader, encodedClaims] = token.split(".");
+  const claims = JSON.parse(
+    Buffer.from(encodedClaims, "base64url").toString("utf8")
+  ) as Record<string, unknown>;
+  mutate(claims);
+  return signSegments(
+    encodedHeader,
+    Buffer.from(JSON.stringify(claims)).toString("base64url"),
+    signingKey
+  );
+}
+
+/** Re-signs a controlled protected-header mutation. */
+function resignHeader(
+  token: string,
+  signingKey: LifecycleEvidenceSigningKey,
+  mutate: (header: Record<string, unknown>) => void
+): string {
+  const [encodedHeader, encodedClaims] = token.split(".");
+  const header = JSON.parse(
+    Buffer.from(encodedHeader, "base64url").toString("utf8")
+  ) as Record<string, unknown>;
+  mutate(header);
+  return signSegments(
+    Buffer.from(JSON.stringify(header)).toString("base64url"),
+    encodedClaims,
+    signingKey
+  );
+}
+
+/** Captures one stable protocol error and rejects unrelated failures. */
+async function expectCode(
+  action: () => unknown | Promise<unknown>,
+  code: LifecycleEvidenceError["code"]
+): Promise<LifecycleEvidenceError> {
+  try {
+    await action();
+    throw new Error("Expected LifecycleEvidenceError");
+  } catch (error) {
+    expect(error).toBeInstanceOf(LifecycleEvidenceError);
+    expect((error as LifecycleEvidenceError).code).toBe(code);
+    return error as LifecycleEvidenceError;
+  }
+}
+
+describe("gateway lifecycle evidence", () => {
+  it("issues and verifies the exact Codex-first v1 projection", async () => {
+    const fixture = createFixture();
+    const replayDefense = new MemoryReplayDefense();
+    const claims = await verify(fixture, issue(fixture), { replayDefense });
+
+    expect(claims).toEqual({
+      version: 1,
+      issuer: "sprig-agent-gateway",
+      audience: "sprig-trusted-server",
+      subject: "user_owner_a",
+      connectionId: "connection_a",
+      provider: "codex",
+      requestId: "request_a",
+      evidenceId: "evidence_a",
+      nonce: "nonce_a",
+      issuedAt: BASE_TIME,
+      expiresAt: BASE_TIME + 60,
+      transition: "pending_to_connected",
+      credentialRevision: 1,
+      metadata: connectedMetadata(),
+      kid: "lifecycle-current",
+    });
+    expect(replayDefense.entries).toEqual([
+      {
+        evidenceId: "evidence_a",
+        nonce: "nonce_a",
+        requestId: "request_a",
+        expiresAt: BASE_TIME + 60,
+      },
+    ]);
+  });
+
+  it("rejects missing, malformed, claim-tampered, and signature-tampered evidence", async () => {
+    const fixture = createFixture();
+    await expectCode(() => verify(fixture, undefined), "missing_evidence");
+    await expectCode(() => verify(fixture, "not.evidence"), "invalid_evidence");
+
+    const token = issue(fixture);
+    const [header, claims, signature] = token.split(".");
+    const tamperedClaims = Buffer.from(
+      Buffer.from(claims, "base64url")
+        .toString("utf8")
+        .replace("user_owner_a", "user_owner_b")
+    ).toString("base64url");
+    await expectCode(
+      () => verify(fixture, `${header}.${tamperedClaims}.${signature}`),
+      "invalid_signature"
+    );
+
+    const signatureBytes = Buffer.from(signature, "base64url");
+    signatureBytes[0] ^= 0x01;
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          `${header}.${claims}.${signatureBytes.toString("base64url")}`
+        ),
+      "invalid_signature"
+    );
+  });
+
+  it("rejects authenticated whitespace, reordered, duplicate-key, and padded encodings", async () => {
+    const fixture = createFixture();
+    const token = issue(fixture);
+    const [header, claims] = token.split(".");
+    const claimsText = Buffer.from(claims, "base64url").toString("utf8");
+    const whitespaceClaims = Buffer.from(
+      JSON.stringify(JSON.parse(claimsText), null, 2)
+    ).toString("base64url");
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          signSegments(header, whitespaceClaims, fixture.current.signing)
+        ),
+      "noncanonical_evidence"
+    );
+
+    const parsed = JSON.parse(claimsText) as Record<string, unknown>;
+    const reordered = Object.fromEntries(Object.entries(parsed).reverse());
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          signSegments(
+            header,
+            Buffer.from(JSON.stringify(reordered)).toString("base64url"),
+            fixture.current.signing
+          )
+        ),
+      "noncanonical_evidence"
+    );
+
+    const duplicateClaims = Buffer.from(
+      claimsText.replace(
+        '"subject":"user_owner_a"',
+        '"subject":"user_owner_a","subject":"user_owner_a"'
+      )
+    ).toString("base64url");
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          signSegments(header, duplicateClaims, fixture.current.signing)
+        ),
+      "noncanonical_evidence"
+    );
+
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          signSegments(header, `${claims}=`, fixture.current.signing)
+        ),
+      "noncanonical_evidence"
+    );
+  });
+
+  it("enforces strict expiry, future, and maximum-lifetime boundaries", async () => {
+    const fixture = createFixture();
+    await expectCode(
+      () => issue(fixture, { lifetimeSeconds: 61 }),
+      "evidence_lifetime_invalid"
+    );
+    const token = issue(fixture, { lifetimeSeconds: 10 });
+
+    fixture.clock.set(BASE_TIME - 1);
+    await expectCode(() => verify(fixture, token), "evidence_from_future");
+    fixture.clock.set(BASE_TIME + 9);
+    expect((await verify(fixture, token)).expiresAt).toBe(BASE_TIME + 10);
+    fixture.clock.set(BASE_TIME + 10);
+    await expectCode(() => verify(fixture, token), "evidence_expired");
+
+    fixture.clock.set(BASE_TIME);
+    const overlong = resignClaims(token, fixture.current.signing, (claims) => {
+      claims.expiresAt = BASE_TIME + 61;
+    });
+    await expectCode(
+      () => verify(fixture, overlong),
+      "evidence_lifetime_invalid"
+    );
+  });
+
+  it("accepts current and previous rotation keys but no unknown key", async () => {
+    const fixture = createFixture();
+    expect((await verify(fixture, issue(fixture))).kid).toBe(
+      "lifecycle-current"
+    );
+    expect(
+      (await verify(fixture, issue(fixture, {}, fixture.previous.signing))).kid
+    ).toBe("lifecycle-previous");
+
+    const unknown = createKeyPair("lifecycle-unknown");
+    await expectCode(
+      () => verify(fixture, issue(fixture, {}, unknown.signing)),
+      "invalid_signature"
+    );
+    await expectCode(
+      () =>
+        verify(fixture, issue(fixture), {
+          verificationKeys: {
+            current: fixture.current.verification,
+            previous: {
+              ...fixture.previous.verification,
+              keyId: fixture.current.verification.keyId,
+            },
+          },
+        }),
+      "internal_evidence_configuration_invalid"
+    );
+  });
+
+  it("pins the algorithm, protocol version, and authenticated key id", async () => {
+    const fixture = createFixture();
+    const token = issue(fixture);
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          resignHeader(token, fixture.current.signing, (header) => {
+            header.algorithm = "HS256";
+          })
+        ),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          resignHeader(token, fixture.current.signing, (header) => {
+            header.version = 2;
+          })
+        ),
+      "unsupported_evidence_version"
+    );
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          resignHeader(token, fixture.current.signing, (header) => {
+            header.kid = "lifecycle-previous";
+          })
+        ),
+      "invalid_signature"
+    );
+  });
+
+  it("consumes signed owner, connection, request, transition, revision, and provider mismatches", async () => {
+    const fixture = createFixture();
+    const cases: ReadonlyArray<
+      readonly [
+        Partial<ExpectedLifecycleEvidenceContext>,
+        LifecycleEvidenceError["code"],
+      ]
+    > = [
+      [{ subject: "user_owner_b" }, "subject_mismatch"],
+      [{ connectionId: "connection_b" }, "connection_mismatch"],
+      [{ requestId: "request_b" }, "request_id_mismatch"],
+      [{ transition: "connected_to_error" }, "transition_mismatch"],
+      [{ credentialRevision: 2 }, "credential_revision_mismatch"],
+    ];
+
+    for (const [mismatch, code] of cases) {
+      const token = issue(fixture);
+      const replayDefense = new MemoryReplayDefense();
+      await expectCode(
+        () =>
+          verify(fixture, token, {
+            replayDefense,
+            expected: { ...fixture.expected, ...mismatch },
+          }),
+        code
+      );
+      expect(replayDefense.entries).toHaveLength(1);
+      await expectCode(
+        () => verify(fixture, token, { replayDefense }),
+        "replay_detected"
+      );
+    }
+
+    const providerToken = resignClaims(
+      issue(fixture),
+      fixture.current.signing,
+      (claims) => {
+        claims.provider = "claude";
+      }
+    );
+    const providerReplay = new MemoryReplayDefense();
+    await expectCode(
+      () => verify(fixture, providerToken, { replayDefense: providerReplay }),
+      "provider_mismatch"
+    );
+    expect(providerReplay.entries).toHaveLength(1);
+  });
+
+  it("rejects replay by either evidence id or nonce", async () => {
+    const fixture = createFixture();
+    const replayDefense = new MemoryReplayDefense();
+    await verify(fixture, issue(fixture), { replayDefense });
+    await expectCode(
+      () => verify(fixture, issue(fixture), { replayDefense }),
+      "replay_detected"
+    );
+    await expectCode(
+      () =>
+        verify(fixture, issue(fixture, { evidenceId: "evidence_b" }), {
+          replayDefense,
+        }),
+      "replay_detected"
+    );
+  });
+
+  it("accepts only allowed transition shapes and rejects API-key accounts", async () => {
+    const fixture = createFixture();
+    const transitionCases: ReadonlyArray<
+      readonly [LifecycleTransition, LifecycleEvidenceMetadata]
+    > = [
+      ["pending_to_connected", connectedMetadata()],
+      [
+        "pending_to_error",
+        {
+          gatewayCredentialId: null,
+          account: null,
+          planLabel: null,
+          errorCode: "provider_denied",
+        },
+      ],
+      [
+        "pending_to_expired",
+        {
+          gatewayCredentialId: null,
+          account: null,
+          planLabel: null,
+          errorCode: "credential_expired",
+        },
+      ],
+      [
+        "connected_to_revoked",
+        {
+          gatewayCredentialId: null,
+          account: null,
+          planLabel: null,
+          errorCode: null,
+        },
+      ],
+    ];
+    for (const [transition, metadata] of transitionCases) {
+      expect(issue(fixture, { transition, metadata }).split(".")).toHaveLength(
+        3
+      );
+    }
+
+    await expectCode(
+      () =>
+        issue(fixture, {
+          metadata: {
+            ...connectedMetadata(),
+            account: { type: "api_key", present: true },
+          } as unknown as LifecycleEvidenceMetadata,
+        }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () =>
+        issue(fixture, {
+          transition: "pending_to_connected",
+          metadata: connectedMetadata({ gatewayCredentialId: null }),
+        }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () =>
+        issue(fixture, {
+          transition: "connected_to_revoked",
+          metadata: connectedMetadata(),
+        }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () =>
+        issue(fixture, {
+          transition: "pending_to_error",
+          metadata: connectedMetadata({ errorCode: null }),
+        }),
+      "invalid_evidence"
+    );
+  });
+
+  it("rejects secret-bearing extension fields and never serializes secret canaries", async () => {
+    const fixture = createFixture();
+    const secretCanaries = [
+      "sk-secret-canary",
+      "/Users/secret/.codex/auth.json",
+      "CODEX_HOME=/credential/home",
+      "codex app-server --dangerous",
+      "raw-provider-output-canary",
+    ];
+    for (const [field, canary] of [
+      ["token", secretCanaries[0]],
+      ["path", secretCanaries[1]],
+      ["environment", secretCanaries[2]],
+      ["command", secretCanaries[3]],
+      ["providerOutput", secretCanaries[4]],
+    ]) {
+      await expectCode(
+        () =>
+          issueLifecycleEvidence(
+            {
+              ...decision(fixture),
+              [field]: canary,
+            } as ServerLifecycleDecision,
+            fixture.current.signing,
+            fixture.clock
+          ),
+        "invalid_evidence"
+      );
+      await expectCode(
+        () =>
+          issue(fixture, {
+            metadata: {
+              ...connectedMetadata(),
+              [field]: canary,
+            } as LifecycleEvidenceMetadata,
+          }),
+        "invalid_evidence"
+      );
+    }
+
+    const token = issue(fixture);
+    for (const canary of secretCanaries) {
+      expect(token).not.toContain(canary);
+      expect(
+        Buffer.from(token.split(".")[1], "base64url").toString("utf8")
+      ).not.toContain(canary);
+    }
+  });
+
+  it("rejects huge tokens, identifiers, labels, getters, and invented fields", async () => {
+    const fixture = createFixture();
+    await expectCode(
+      () => verify(fixture, `a.${"b".repeat(8_193)}.c`),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () => issue(fixture, { evidenceId: "x".repeat(257) }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () => issue(fixture, { evidenceId: "🙂".repeat(100) }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () => issue(fixture, { evidenceId: "same", nonce: "same" }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () =>
+        issue(fixture, {
+          metadata: connectedMetadata({ planLabel: "x".repeat(129) }),
+        }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () =>
+        issue(fixture, {
+          metadata: connectedMetadata({ planLabel: "Plus\nsecret" }),
+        }),
+      "invalid_evidence"
+    );
+    await expectCode(
+      () =>
+        issue(fixture, {
+          transition: "pending_to_destroyed" as LifecycleTransition,
+        }),
+      "invalid_evidence"
+    );
+
+    let getterInvoked = false;
+    const hostile = Object.defineProperty(decision(fixture), "token", {
+      enumerable: true,
+      get() {
+        getterInvoked = true;
+        return "secret";
+      },
+    });
+    await expectCode(
+      () =>
+        issueLifecycleEvidence(hostile, fixture.current.signing, fixture.clock),
+      "invalid_evidence"
+    );
+    expect(getterInvoked).toBe(false);
+
+    fixture.clock.set(Number.MAX_SAFE_INTEGER);
+    await expectCode(
+      () => issue(fixture),
+      "internal_evidence_configuration_invalid"
+    );
+  });
+
+  it("fails closed on replay timeout and abort while observing late settlement", async () => {
+    const fixture = createFixture();
+    let storeSignal: AbortSignal | undefined;
+    let settleStore: (() => void) | undefined;
+    const slowStore: LifecycleEvidenceReplayDefense = {
+      consume(
+        _entry: LifecycleReplayEntry,
+        context?: ControlPlaneOperationContext
+      ): Promise<void> {
+        storeSignal = context?.signal;
+        return new Promise<void>((resolve) => {
+          settleStore = resolve;
+        });
+      },
+    };
+    await expectCode(
+      () =>
+        verify(fixture, issue(fixture), {
+          replayDefense: slowStore,
+          replayDefenseTimeoutMs: 5,
+        }),
+      "replay_defense_unavailable"
+    );
+    expect(storeSignal?.aborted).toBe(true);
+    settleStore?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const controller = new AbortController();
+    const neverCalled: LifecycleEvidenceReplayDefense = {
+      consume(): void {
+        throw new Error("pre-aborted verification called the store");
+      },
+    };
+    controller.abort("secret abort reason");
+    const error = await expectCode(
+      () =>
+        verify(fixture, issue(fixture), {
+          replayDefense: neverCalled,
+          signal: controller.signal,
+        }),
+      "replay_defense_unavailable"
+    );
+    expect(error.message).not.toContain("secret abort reason");
+
+    let rejectStore: ((error: Error) => void) | undefined;
+    let abortSignal: AbortSignal | undefined;
+    const controllerDuringStore = new AbortController();
+    const lateRejectingStore: LifecycleEvidenceReplayDefense = {
+      consume(
+        _entry: LifecycleReplayEntry,
+        context?: ControlPlaneOperationContext
+      ): Promise<void> {
+        abortSignal = context?.signal;
+        return new Promise<void>((_resolve, reject) => {
+          rejectStore = reject;
+        });
+      },
+    };
+    const verification = verify(fixture, issue(fixture), {
+      replayDefense: lateRejectingStore,
+      signal: controllerDuringStore.signal,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    controllerDuringStore.abort("another secret reason");
+    await expectCode(() => verification, "replay_defense_unavailable");
+    expect(abortSignal?.aborted).toBe(true);
+    rejectStore?.(new Error("late secret store rejection"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it("normalizes store rejection, ambiguous success, and configuration failures", async () => {
+    const fixture = createFixture();
+    const rejecting: LifecycleEvidenceReplayDefense = {
+      consume(): Promise<void> {
+        return Promise.reject(new Error("secret store failure"));
+      },
+    };
+    const error = await expectCode(
+      () => verify(fixture, issue(fixture), { replayDefense: rejecting }),
+      "replay_defense_unavailable"
+    );
+    expect(error.message).not.toContain("secret store failure");
+
+    const ambiguous = {
+      consume(): unknown {
+        return { committed: "maybe" };
+      },
+    } as LifecycleEvidenceReplayDefense;
+    await expectCode(
+      () => verify(fixture, issue(fixture), { replayDefense: ambiguous }),
+      "replay_defense_unavailable"
+    );
+    await expectCode(
+      () =>
+        verify(fixture, issue(fixture), {
+          replayDefenseTimeoutMs: 0,
+        }),
+      "internal_evidence_configuration_invalid"
+    );
+  });
+});

--- a/services/agent-gateway/lifecycle-evidence.test.ts
+++ b/services/agent-gateway/lifecycle-evidence.test.ts
@@ -12,6 +12,8 @@ import {
   type LifecycleEvidenceReplayDefense,
   type LifecycleEvidenceSigningKey,
   type LifecycleEvidenceVerificationKeys,
+  type LifecycleMonotonicClock,
+  type LifecyclePlanLabel,
   LifecycleReplayDefenseError,
   type LifecycleReplayEntry,
   type LifecycleTransition,
@@ -20,6 +22,17 @@ import {
 } from "./lifecycle-evidence.ts";
 
 const BASE_TIME = 1_800_000_000;
+const OWNER_A = "user_2abcDEF3456789xyz";
+const OWNER_B = "user_3abcDEF3456789xyz";
+const CONNECTION_A = "connection_v1_11111111-1111-4111-8111-111111111111";
+const CONNECTION_B = "connection_v1_22222222-2222-4222-8222-222222222222";
+const REQUEST_A = "request_v1_33333333-3333-4333-8333-333333333333";
+const REQUEST_B = "request_v1_44444444-4444-4444-8444-444444444444";
+const EVIDENCE_A = "evidence_v1_55555555-5555-4555-8555-555555555555";
+const EVIDENCE_B = "evidence_v1_66666666-6666-4666-8666-666666666666";
+const NONCE_A = "nonce_v1_88888888-8888-4888-8888-888888888888";
+const NONCE_B = "nonce_v1_99999999-9999-4999-8999-999999999999";
+const GATEWAY_CREDENTIAL_A = "gwcred_v1_bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
 /** Mutable deterministic clock for exact validity-boundary tests. */
 class TestClock implements LifecycleEvidenceClock {
@@ -34,6 +47,13 @@ class TestClock implements LifecycleEvidenceClock {
   }
 }
 
+/** Real monotonic clock for replay timeout behavior. */
+class TestMonotonicClock implements LifecycleMonotonicClock {
+  nowMilliseconds(): number {
+    return performance.now();
+  }
+}
+
 /** Minimal atomic replay store used to prove identifier consumption order. */
 class MemoryReplayDefense implements LifecycleEvidenceReplayDefense {
   readonly entries: LifecycleReplayEntry[] = [];
@@ -43,7 +63,8 @@ class MemoryReplayDefense implements LifecycleEvidenceReplayDefense {
       this.entries.some(
         (existing) =>
           existing.evidenceId === entry.evidenceId ||
-          existing.nonce === entry.nonce
+          existing.nonce === entry.nonce ||
+          existing.requestId === entry.requestId
       )
     ) {
       throw new LifecycleReplayDefenseError("replay_detected");
@@ -64,15 +85,15 @@ function createKeyPair(keyId: string) {
 /** Builds one fully isolated signer/verifier fixture. */
 function createFixture() {
   const clock = new TestClock();
-  const current = createKeyPair("lifecycle-current");
-  const previous = createKeyPair("lifecycle-previous");
+  const current = createKeyPair("lifecycle-v1-a1b2c3d4");
+  const previous = createKeyPair("lifecycle-v1-b1c2d3e4");
   const expected: ExpectedLifecycleEvidenceContext = {
     issuer: "sprig-agent-gateway",
     audience: "sprig-trusted-server",
-    subject: "user_owner_a",
-    connectionId: "connection_a",
+    subject: OWNER_A,
+    connectionId: CONNECTION_A,
     provider: "codex",
-    requestId: "request_a",
+    requestId: REQUEST_A,
     transition: "pending_to_connected",
     credentialRevision: 1,
   };
@@ -88,9 +109,9 @@ function connectedMetadata(
   overrides: Partial<LifecycleEvidenceMetadata> = {}
 ): LifecycleEvidenceMetadata {
   return {
-    gatewayCredentialId: "gateway_opaque_a",
+    gatewayCredentialId: GATEWAY_CREDENTIAL_A,
     account: { type: "chatgpt", present: true },
-    planLabel: "Plus",
+    planLabel: "ChatGPT Plus",
     errorCode: null,
     ...overrides,
   };
@@ -107,8 +128,8 @@ function decision(
     subject: fixture.expected.subject,
     connectionId: fixture.expected.connectionId,
     requestId: fixture.expected.requestId,
-    evidenceId: "evidence_a",
-    nonce: "nonce_a",
+    evidenceId: EVIDENCE_A,
+    nonce: NONCE_A,
     transition: fixture.expected.transition,
     credentialRevision: fixture.expected.credentialRevision,
     metadata: connectedMetadata(),
@@ -135,6 +156,7 @@ function verify(
   token: string | null | undefined,
   overrides: Partial<{
     expected: ExpectedLifecycleEvidenceContext;
+    monotonicClock: LifecycleMonotonicClock;
     replayDefense: LifecycleEvidenceReplayDefense;
     replayDefenseTimeoutMs: number;
     signal: AbortSignal;
@@ -143,6 +165,7 @@ function verify(
 ) {
   return verifyLifecycleEvidence(token, {
     clock: fixture.clock,
+    monotonicClock: overrides.monotonicClock ?? new TestMonotonicClock(),
     expected: overrides.expected ?? fixture.expected,
     replayDefense: overrides.replayDefense ?? new MemoryReplayDefense(),
     verificationKeys: overrides.verificationKeys ?? fixture.verificationKeys,
@@ -227,24 +250,24 @@ describe("gateway lifecycle evidence", () => {
       version: 1,
       issuer: "sprig-agent-gateway",
       audience: "sprig-trusted-server",
-      subject: "user_owner_a",
-      connectionId: "connection_a",
+      subject: OWNER_A,
+      connectionId: CONNECTION_A,
       provider: "codex",
-      requestId: "request_a",
-      evidenceId: "evidence_a",
-      nonce: "nonce_a",
+      requestId: REQUEST_A,
+      evidenceId: EVIDENCE_A,
+      nonce: NONCE_A,
       issuedAt: BASE_TIME,
       expiresAt: BASE_TIME + 60,
       transition: "pending_to_connected",
       credentialRevision: 1,
       metadata: connectedMetadata(),
-      kid: "lifecycle-current",
+      kid: "lifecycle-v1-a1b2c3d4",
     });
     expect(replayDefense.entries).toEqual([
       {
-        evidenceId: "evidence_a",
-        nonce: "nonce_a",
-        requestId: "request_a",
+        evidenceId: EVIDENCE_A,
+        nonce: NONCE_A,
+        requestId: REQUEST_A,
         expiresAt: BASE_TIME + 60,
       },
     ]);
@@ -260,7 +283,7 @@ describe("gateway lifecycle evidence", () => {
     const tamperedClaims = Buffer.from(
       Buffer.from(claims, "base64url")
         .toString("utf8")
-        .replace("user_owner_a", "user_owner_b")
+        .replace(OWNER_A, OWNER_B)
     ).toString("base64url");
     await expectCode(
       () => verify(fixture, `${header}.${tamperedClaims}.${signature}`),
@@ -313,8 +336,8 @@ describe("gateway lifecycle evidence", () => {
 
     const duplicateClaims = Buffer.from(
       claimsText.replace(
-        '"subject":"user_owner_a"',
-        '"subject":"user_owner_a","subject":"user_owner_a"'
+        `"subject":"${OWNER_A}"`,
+        `"subject":"${OWNER_A}","subject":"${OWNER_A}"`
       )
     ).toString("base64url");
     await expectCode(
@@ -364,13 +387,13 @@ describe("gateway lifecycle evidence", () => {
   it("accepts current and previous rotation keys but no unknown key", async () => {
     const fixture = createFixture();
     expect((await verify(fixture, issue(fixture))).kid).toBe(
-      "lifecycle-current"
+      "lifecycle-v1-a1b2c3d4"
     );
     expect(
       (await verify(fixture, issue(fixture, {}, fixture.previous.signing))).kid
-    ).toBe("lifecycle-previous");
+    ).toBe("lifecycle-v1-b1c2d3e4");
 
-    const unknown = createKeyPair("lifecycle-unknown");
+    const unknown = createKeyPair("lifecycle-v1-c1d2e3f4");
     await expectCode(
       () => verify(fixture, issue(fixture, {}, unknown.signing)),
       "invalid_signature"
@@ -418,7 +441,7 @@ describe("gateway lifecycle evidence", () => {
         verify(
           fixture,
           resignHeader(token, fixture.current.signing, (header) => {
-            header.kid = "lifecycle-previous";
+            header.kid = "lifecycle-v1-b1c2d3e4";
           })
         ),
       "invalid_signature"
@@ -433,9 +456,9 @@ describe("gateway lifecycle evidence", () => {
         LifecycleEvidenceError["code"],
       ]
     > = [
-      [{ subject: "user_owner_b" }, "subject_mismatch"],
-      [{ connectionId: "connection_b" }, "connection_mismatch"],
-      [{ requestId: "request_b" }, "request_id_mismatch"],
+      [{ subject: OWNER_B }, "subject_mismatch"],
+      [{ connectionId: CONNECTION_B }, "connection_mismatch"],
+      [{ requestId: REQUEST_B }, "request_id_mismatch"],
       [{ transition: "connected_to_error" }, "transition_mismatch"],
       [{ credentialRevision: 2 }, "credential_revision_mismatch"],
     ];
@@ -473,7 +496,7 @@ describe("gateway lifecycle evidence", () => {
     expect(providerReplay.entries).toHaveLength(1);
   });
 
-  it("rejects replay by either evidence id or nonce", async () => {
+  it("atomically rejects replay by evidence id, nonce, or originating request id", async () => {
     const fixture = createFixture();
     const replayDefense = new MemoryReplayDefense();
     await verify(fixture, issue(fixture), { replayDefense });
@@ -483,51 +506,291 @@ describe("gateway lifecycle evidence", () => {
     );
     await expectCode(
       () =>
-        verify(fixture, issue(fixture, { evidenceId: "evidence_b" }), {
-          replayDefense,
-        }),
+        verify(
+          fixture,
+          issue(fixture, {
+            evidenceId: EVIDENCE_B,
+            nonce: NONCE_A,
+            requestId: REQUEST_B,
+          }),
+          {
+            expected: { ...fixture.expected, requestId: REQUEST_B },
+            replayDefense,
+          }
+        ),
+      "replay_detected"
+    );
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          issue(fixture, {
+            evidenceId: EVIDENCE_A,
+            nonce: NONCE_B,
+            requestId: REQUEST_B,
+          }),
+          {
+            expected: { ...fixture.expected, requestId: REQUEST_B },
+            replayDefense,
+          }
+        ),
+      "replay_detected"
+    );
+    await expectCode(
+      () =>
+        verify(
+          fixture,
+          issue(fixture, { evidenceId: EVIDENCE_B, nonce: NONCE_B }),
+          { replayDefense }
+        ),
       "replay_detected"
     );
   });
 
-  it("accepts only allowed transition shapes and rejects API-key accounts", async () => {
+  it("allows only one concurrent result for the same originating request", async () => {
     const fixture = createFixture();
+    const replayDefense = new MemoryReplayDefense();
+    const first = issue(fixture);
+    const second = issue(fixture, {
+      evidenceId: EVIDENCE_B,
+      nonce: NONCE_B,
+    });
+    const outcomes = await Promise.allSettled([
+      verify(fixture, first, { replayDefense }),
+      verify(fixture, second, { replayDefense }),
+    ]);
+
+    expect(
+      outcomes.filter((outcome) => outcome.status === "fulfilled")
+    ).toHaveLength(1);
+    const rejected = outcomes.find((outcome) => outcome.status === "rejected");
+    expect(rejected).toBeDefined();
+    expect((rejected as PromiseRejectedResult).reason).toBeInstanceOf(
+      LifecycleEvidenceError
+    );
+    expect(
+      ((rejected as PromiseRejectedResult).reason as LifecycleEvidenceError)
+        .code
+    ).toBe("replay_detected");
+    expect(replayDefense.entries).toHaveLength(1);
+  });
+
+  it("enforces required keys and forbids extensions for every exact transition", async () => {
+    const fixture = createFixture();
+    const errorMetadata: LifecycleEvidenceMetadata = {
+      gatewayCredentialId: null,
+      account: null,
+      planLabel: null,
+      errorCode: "provider_denied",
+    };
+    const expiredMetadata: LifecycleEvidenceMetadata = {
+      gatewayCredentialId: null,
+      account: null,
+      planLabel: null,
+      errorCode: "credential_expired",
+    };
+    const emptyMetadata: LifecycleEvidenceMetadata = {
+      gatewayCredentialId: null,
+      account: null,
+      planLabel: null,
+      errorCode: null,
+    };
     const transitionCases: ReadonlyArray<
-      readonly [LifecycleTransition, LifecycleEvidenceMetadata]
+      Readonly<{
+        transition: LifecycleTransition;
+        policy: "connected" | "error" | "expired" | "empty";
+        metadata: LifecycleEvidenceMetadata;
+      }>
     > = [
-      ["pending_to_connected", connectedMetadata()],
-      [
-        "pending_to_error",
-        {
-          gatewayCredentialId: null,
-          account: null,
-          planLabel: null,
-          errorCode: "provider_denied",
-        },
-      ],
-      [
-        "pending_to_expired",
-        {
-          gatewayCredentialId: null,
-          account: null,
-          planLabel: null,
-          errorCode: "credential_expired",
-        },
-      ],
-      [
-        "connected_to_revoked",
-        {
-          gatewayCredentialId: null,
-          account: null,
-          planLabel: null,
-          errorCode: null,
-        },
-      ],
+      {
+        transition: "pending_to_connected",
+        policy: "connected",
+        metadata: connectedMetadata(),
+      },
+      {
+        transition: "pending_to_error",
+        policy: "error",
+        metadata: errorMetadata,
+      },
+      {
+        transition: "pending_to_expired",
+        policy: "expired",
+        metadata: expiredMetadata,
+      },
+      {
+        transition: "pending_to_revoking",
+        policy: "empty",
+        metadata: emptyMetadata,
+      },
+      {
+        transition: "connected_to_error",
+        policy: "error",
+        metadata: errorMetadata,
+      },
+      {
+        transition: "connected_to_expired",
+        policy: "expired",
+        metadata: expiredMetadata,
+      },
+      {
+        transition: "connected_to_revoking",
+        policy: "empty",
+        metadata: emptyMetadata,
+      },
+      {
+        transition: "error_to_revoking",
+        policy: "empty",
+        metadata: emptyMetadata,
+      },
+      {
+        transition: "expired_to_revoking",
+        policy: "empty",
+        metadata: emptyMetadata,
+      },
+      {
+        transition: "revoking_to_revoked",
+        policy: "empty",
+        metadata: emptyMetadata,
+      },
+      {
+        transition: "revoked_to_deleted",
+        policy: "empty",
+        metadata: emptyMetadata,
+      },
     ];
-    for (const [transition, metadata] of transitionCases) {
+
+    for (const { transition, metadata } of transitionCases) {
       expect(issue(fixture, { transition, metadata }).split(".")).toHaveLength(
         3
       );
+      for (const key of Object.keys(metadata)) {
+        const missing = { ...metadata } as Record<string, unknown>;
+        delete missing[key];
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: missing as LifecycleEvidenceMetadata,
+            }),
+          "invalid_evidence"
+        );
+      }
+      await expectCode(
+        () =>
+          issue(fixture, {
+            transition,
+            metadata: {
+              ...metadata,
+              rawProviderOutput: "safe-looking-extension",
+            } as LifecycleEvidenceMetadata,
+          }),
+        "invalid_evidence"
+      );
+    }
+
+    for (const { transition, policy } of transitionCases) {
+      if (policy === "connected") {
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: connectedMetadata({ gatewayCredentialId: null }),
+            }),
+          "invalid_evidence"
+        );
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: connectedMetadata({ account: null }),
+            }),
+          "invalid_evidence"
+        );
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: connectedMetadata({
+                errorCode: "provider_unavailable",
+              }),
+            }),
+          "invalid_evidence"
+        );
+        expect(
+          issue(fixture, {
+            transition,
+            metadata: connectedMetadata({ planLabel: null }),
+          })
+        ).toContain(".");
+        continue;
+      }
+
+      const requiredError =
+        policy === "error"
+          ? "provider_unavailable"
+          : policy === "expired"
+            ? "credential_expired"
+            : null;
+      for (const forbidden of [
+        { gatewayCredentialId: GATEWAY_CREDENTIAL_A },
+        { account: { type: "chatgpt" as const, present: true as const } },
+        { planLabel: "ChatGPT Plus" as LifecyclePlanLabel },
+      ]) {
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: {
+                gatewayCredentialId: null,
+                account: null,
+                planLabel: null,
+                errorCode: requiredError,
+                ...forbidden,
+              },
+            }),
+          "invalid_evidence"
+        );
+      }
+      if (policy === "error" || policy === "expired") {
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: emptyMetadata,
+            }),
+          "invalid_evidence"
+        );
+      }
+      if (policy === "error") {
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: expiredMetadata,
+            }),
+          "invalid_evidence"
+        );
+      }
+      if (policy === "expired") {
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: errorMetadata,
+            }),
+          "invalid_evidence"
+        );
+      }
+      if (policy === "empty") {
+        await expectCode(
+          () =>
+            issue(fixture, {
+              transition,
+              metadata: errorMetadata,
+            }),
+          "invalid_evidence"
+        );
+      }
     }
 
     await expectCode(
@@ -537,30 +800,6 @@ describe("gateway lifecycle evidence", () => {
             ...connectedMetadata(),
             account: { type: "api_key", present: true },
           } as unknown as LifecycleEvidenceMetadata,
-        }),
-      "invalid_evidence"
-    );
-    await expectCode(
-      () =>
-        issue(fixture, {
-          transition: "pending_to_connected",
-          metadata: connectedMetadata({ gatewayCredentialId: null }),
-        }),
-      "invalid_evidence"
-    );
-    await expectCode(
-      () =>
-        issue(fixture, {
-          transition: "connected_to_revoked",
-          metadata: connectedMetadata(),
-        }),
-      "invalid_evidence"
-    );
-    await expectCode(
-      () =>
-        issue(fixture, {
-          transition: "pending_to_error",
-          metadata: connectedMetadata({ errorCode: null }),
         }),
       "invalid_evidence"
     );
@@ -615,6 +854,72 @@ describe("gateway lifecycle evidence", () => {
     }
   });
 
+  it("rejects secret, path, env, URL, encoded, control, and confusable values in allowed fields", async () => {
+    const fixture = createFixture();
+    const canaries = [
+      "sk-secret-canary",
+      "sess-secret-canary",
+      "gwcred_v1_sk-secret-canary",
+      "gwcred_v1_CODEX_HOME_secret",
+      "gwcred_v1_..%2F..%2Fauth.json",
+      "gwcred_v1_https_example_com_token",
+      "/Users/secret/.codex/auth.json",
+      "..%2F..%2Fauth.json",
+      "CODEX_HOME=/credential/home",
+      "https://example.com/token",
+      "line-one\nline-two",
+      "gwcred_v1_／confusable-slash",
+    ];
+
+    for (const canary of canaries) {
+      const credentialError = await expectCode(
+        () =>
+          issue(fixture, {
+            metadata: connectedMetadata({ gatewayCredentialId: canary }),
+          }),
+        "invalid_evidence"
+      );
+      expect(credentialError.message).not.toContain(canary);
+
+      const planError = await expectCode(
+        () =>
+          issue(fixture, {
+            metadata: connectedMetadata({
+              planLabel: canary as LifecyclePlanLabel,
+            }),
+          }),
+        "invalid_evidence"
+      );
+      expect(planError.message).not.toContain(canary);
+
+      for (const field of [
+        "issuer",
+        "audience",
+        "subject",
+        "connectionId",
+        "requestId",
+        "evidenceId",
+        "nonce",
+      ] as const) {
+        const identifierError = await expectCode(
+          () => issue(fixture, { [field]: canary }),
+          "invalid_evidence"
+        );
+        expect(identifierError.message).not.toContain(canary);
+      }
+    }
+
+    await expectCode(
+      () =>
+        issue(fixture, {
+          metadata: connectedMetadata({
+            planLabel: "ChatGPT Plуs" as LifecyclePlanLabel,
+          }),
+        }),
+      "invalid_evidence"
+    );
+  });
+
   it("rejects huge tokens, identifiers, labels, getters, and invented fields", async () => {
     const fixture = createFixture();
     await expectCode(
@@ -636,14 +941,18 @@ describe("gateway lifecycle evidence", () => {
     await expectCode(
       () =>
         issue(fixture, {
-          metadata: connectedMetadata({ planLabel: "x".repeat(129) }),
+          metadata: connectedMetadata({
+            planLabel: "x".repeat(129) as LifecyclePlanLabel,
+          }),
         }),
       "invalid_evidence"
     );
     await expectCode(
       () =>
         issue(fixture, {
-          metadata: connectedMetadata({ planLabel: "Plus\nsecret" }),
+          metadata: connectedMetadata({
+            planLabel: "Plus\nsecret" as LifecyclePlanLabel,
+          }),
         }),
       "invalid_evidence"
     );
@@ -670,6 +979,123 @@ describe("gateway lifecycle evidence", () => {
     );
     expect(getterInvoked).toBe(false);
 
+    for (const magicKey of ["__proto__", "prototype", "constructor"]) {
+      const hostileDecision = Object.defineProperty(
+        decision(fixture),
+        magicKey,
+        {
+          enumerable: true,
+          value: { lifetimeSeconds: 1 },
+        }
+      );
+      await expectCode(
+        () =>
+          issueLifecycleEvidence(
+            hostileDecision,
+            fixture.current.signing,
+            fixture.clock
+          ),
+        "invalid_evidence"
+      );
+
+      const hostileMetadata = Object.defineProperty(
+        connectedMetadata(),
+        magicKey,
+        { enumerable: true, value: "sk-secret-canary" }
+      );
+      await expectCode(
+        () =>
+          issue(fixture, {
+            metadata: hostileMetadata,
+          }),
+        "invalid_evidence"
+      );
+
+      const hostileAccount = Object.defineProperty(
+        { type: "chatgpt", present: true },
+        magicKey,
+        { enumerable: true, value: "sk-secret-canary" }
+      );
+      await expectCode(
+        () =>
+          issue(fixture, {
+            metadata: connectedMetadata({
+              account: hostileAccount as {
+                readonly type: "chatgpt";
+                readonly present: true;
+              },
+            }),
+          }),
+        "invalid_evidence"
+      );
+    }
+
+    const inheritedLifetime = Object.create({ lifetimeSeconds: 1 }) as Record<
+      string,
+      unknown
+    >;
+    Object.defineProperties(
+      inheritedLifetime,
+      Object.getOwnPropertyDescriptors(decision(fixture))
+    );
+    await expectCode(
+      () =>
+        issueLifecycleEvidence(
+          inheritedLifetime as ServerLifecycleDecision,
+          fixture.current.signing,
+          fixture.clock
+        ),
+      "invalid_evidence"
+    );
+
+    const symbolDecision = decision(fixture) as ServerLifecycleDecision &
+      Record<symbol, unknown>;
+    Object.defineProperty(symbolDecision, Symbol("secret"), {
+      enumerable: true,
+      value: "sk-secret-canary",
+    });
+    await expectCode(
+      () =>
+        issueLifecycleEvidence(
+          symbolDecision,
+          fixture.current.signing,
+          fixture.clock
+        ),
+      "invalid_evidence"
+    );
+
+    const hiddenExtension = Object.defineProperty(decision(fixture), "token", {
+      enumerable: false,
+      value: "sk-secret-canary",
+    });
+    await expectCode(
+      () =>
+        issueLifecycleEvidence(
+          hiddenExtension,
+          fixture.current.signing,
+          fixture.clock
+        ),
+      "invalid_evidence"
+    );
+
+    let nestedGetterInvoked = false;
+    const accessorMetadata = Object.defineProperty(
+      connectedMetadata(),
+      "token",
+      {
+        enumerable: true,
+        get() {
+          nestedGetterInvoked = true;
+          return "sk-secret-canary";
+        },
+      }
+    );
+    await expectCode(
+      () => issue(fixture, { metadata: accessorMetadata }),
+      "invalid_evidence"
+    );
+    expect(nestedGetterInvoked).toBe(false);
+
     fixture.clock.set(Number.MAX_SAFE_INTEGER);
     await expectCode(
       () => issue(fixture),
@@ -679,6 +1105,52 @@ describe("gateway lifecycle evidence", () => {
 
   it("fails closed on replay timeout and abort while observing late settlement", async () => {
     const fixture = createFixture();
+    let preflightReads = 0;
+    const alreadyLateClock: LifecycleMonotonicClock = {
+      nowMilliseconds(): number {
+        preflightReads += 1;
+        return preflightReads === 1 ? 100 : 106;
+      },
+    };
+    const preflightStore: LifecycleEvidenceReplayDefense = {
+      consume(): void {
+        throw new Error("late preflight called replay store");
+      },
+    };
+    await expectCode(
+      () =>
+        verify(fixture, issue(fixture), {
+          monotonicClock: alreadyLateClock,
+          replayDefense: preflightStore,
+          replayDefenseTimeoutMs: 5,
+        }),
+      "replay_defense_unavailable"
+    );
+
+    let blockingSignal: AbortSignal | undefined;
+    const blockingStore: LifecycleEvidenceReplayDefense = {
+      consume(
+        _entry: LifecycleReplayEntry,
+        context?: ControlPlaneOperationContext
+      ): void {
+        blockingSignal = context?.signal;
+        const releaseAt = performance.now() + 30;
+        while (performance.now() < releaseAt) {
+          // Deliberately block to prove the post-settlement deadline check is
+          // authoritative even when the timer callback cannot run on time.
+        }
+      },
+    };
+    await expectCode(
+      () =>
+        verify(fixture, issue(fixture), {
+          replayDefense: blockingStore,
+          replayDefenseTimeoutMs: 5,
+        }),
+      "replay_defense_unavailable"
+    );
+    expect(blockingSignal?.aborted).toBe(true);
+
     let storeSignal: AbortSignal | undefined;
     let settleStore: (() => void) | undefined;
     const slowStore: LifecycleEvidenceReplayDefense = {
@@ -774,6 +1246,13 @@ describe("gateway lifecycle evidence", () => {
       () =>
         verify(fixture, issue(fixture), {
           replayDefenseTimeoutMs: 0,
+        }),
+      "internal_evidence_configuration_invalid"
+    );
+    await expectCode(
+      () =>
+        verify(fixture, issue(fixture), {
+          monotonicClock: { nowMilliseconds: () => Number.NaN },
         }),
       "internal_evidence_configuration_invalid"
     );

--- a/services/agent-gateway/lifecycle-evidence.ts
+++ b/services/agent-gateway/lifecycle-evidence.ts
@@ -1,0 +1,940 @@
+import {
+  type KeyObject,
+  sign as signBytes,
+  verify as verifyBytes,
+} from "node:crypto";
+
+import {
+  awaitControlPlaneOperation,
+  type ControlPlaneOperationContext,
+} from "./control-plane.ts";
+
+const LIFECYCLE_EVIDENCE_ALGORITHM = "EdDSA";
+const LIFECYCLE_EVIDENCE_TYPE = "sprig-lifecycle-evidence";
+const LIFECYCLE_EVIDENCE_VERSION = 1;
+const MAX_LIFECYCLE_EVIDENCE_LIFETIME_SECONDS = 60;
+const MAX_LIFECYCLE_EVIDENCE_LENGTH = 8_192;
+const MAX_IDENTIFIER_LENGTH = 256;
+const MAX_PLAN_LABEL_LENGTH = 128;
+const DEFAULT_LIFECYCLE_REPLAY_TIMEOUT_MS = 1_000;
+const MAX_LIFECYCLE_REPLAY_TIMEOUT_MS = 10_000;
+
+const LIFECYCLE_TRANSITIONS = [
+  "pending_to_connected",
+  "pending_to_error",
+  "pending_to_expired",
+  "connected_to_error",
+  "connected_to_expired",
+  "connected_to_revoked",
+  "error_to_connected",
+  "error_to_revoked",
+  "expired_to_connected",
+  "expired_to_revoked",
+] as const;
+
+const LIFECYCLE_ERROR_CODES = [
+  "account_type_unsupported",
+  "credential_expired",
+  "credential_invalid",
+  "credential_unavailable",
+  "provider_denied",
+  "provider_unavailable",
+] as const;
+
+type LifecycleTransition = (typeof LIFECYCLE_TRANSITIONS)[number];
+type LifecycleErrorCode = (typeof LIFECYCLE_ERROR_CODES)[number];
+
+type LifecycleEvidenceErrorCode =
+  | "audience_mismatch"
+  | "connection_mismatch"
+  | "credential_revision_mismatch"
+  | "evidence_expired"
+  | "evidence_from_future"
+  | "evidence_lifetime_invalid"
+  | "internal_evidence_configuration_invalid"
+  | "invalid_evidence"
+  | "invalid_signature"
+  | "issuer_mismatch"
+  | "missing_evidence"
+  | "noncanonical_evidence"
+  | "provider_mismatch"
+  | "replay_defense_unavailable"
+  | "replay_detected"
+  | "request_id_mismatch"
+  | "subject_mismatch"
+  | "transition_mismatch"
+  | "unsupported_evidence_version";
+
+type LifecycleEvidenceAccount = Readonly<{
+  type: "chatgpt";
+  present: true;
+}>;
+
+type LifecycleEvidenceMetadata = Readonly<{
+  gatewayCredentialId: string | null;
+  account: LifecycleEvidenceAccount | null;
+  planLabel: string | null;
+  errorCode: LifecycleErrorCode | null;
+}>;
+
+type LifecycleEvidenceClaims = Readonly<{
+  version: typeof LIFECYCLE_EVIDENCE_VERSION;
+  issuer: string;
+  audience: string;
+  subject: string;
+  connectionId: string;
+  provider: "codex";
+  requestId: string;
+  evidenceId: string;
+  nonce: string;
+  issuedAt: number;
+  expiresAt: number;
+  transition: LifecycleTransition;
+  credentialRevision: number;
+  metadata: LifecycleEvidenceMetadata;
+  kid: string;
+}>;
+
+type LifecycleEvidenceHeader = Readonly<{
+  algorithm: typeof LIFECYCLE_EVIDENCE_ALGORITHM;
+  type: typeof LIFECYCLE_EVIDENCE_TYPE;
+  version: typeof LIFECYCLE_EVIDENCE_VERSION;
+  kid: string;
+}>;
+
+type LifecycleEvidenceClock = Readonly<{
+  nowSeconds: () => number;
+}>;
+
+type LifecycleEvidenceSigningKey = Readonly<{
+  keyId: string;
+  privateKey: KeyObject;
+}>;
+
+type LifecycleEvidenceVerificationKey = Readonly<{
+  keyId: string;
+  publicKey: KeyObject;
+}>;
+
+type LifecycleEvidenceVerificationKeys = Readonly<{
+  current: LifecycleEvidenceVerificationKey;
+  previous?: LifecycleEvidenceVerificationKey;
+}>;
+
+/**
+ * A closed server-side decision accepted by the gateway signer.
+ *
+ * Callers must derive every field from authenticated server state. Runtime
+ * exact-key validation prevents browser-shaped extensions from smuggling raw
+ * provider output, tokens, commands, paths, or environment values into evidence.
+ */
+type ServerLifecycleDecision = Readonly<{
+  issuer: string;
+  audience: string;
+  subject: string;
+  connectionId: string;
+  requestId: string;
+  evidenceId: string;
+  nonce: string;
+  transition: LifecycleTransition;
+  credentialRevision: number;
+  metadata: LifecycleEvidenceMetadata;
+  lifetimeSeconds?: number;
+}>;
+
+type ExpectedLifecycleEvidenceContext = Readonly<{
+  issuer: string;
+  audience: string;
+  subject: string;
+  connectionId: string;
+  provider: "codex";
+  requestId: string;
+  transition: LifecycleTransition;
+  credentialRevision: number;
+}>;
+
+type LifecycleReplayEntry = Readonly<{
+  evidenceId: string;
+  nonce: string;
+  requestId: string;
+  expiresAt: number;
+}>;
+
+interface LifecycleEvidenceReplayDefense {
+  consume(
+    entry: LifecycleReplayEntry,
+    context?: ControlPlaneOperationContext
+  ): void | Promise<void>;
+}
+
+type VerifyLifecycleEvidenceOptions = Readonly<{
+  clock: LifecycleEvidenceClock;
+  expected: ExpectedLifecycleEvidenceContext;
+  replayDefense: LifecycleEvidenceReplayDefense;
+  verificationKeys: LifecycleEvidenceVerificationKeys;
+  replayDefenseTimeoutMs?: number;
+  signal?: AbortSignal;
+}>;
+
+type LifecycleReplayDefenseErrorCode =
+  | "replay_defense_unavailable"
+  | "replay_detected";
+
+/** Stable evidence failure whose message contains no signed or provider data. */
+class LifecycleEvidenceError extends Error {
+  readonly code: LifecycleEvidenceErrorCode;
+
+  constructor(code: LifecycleEvidenceErrorCode, message: string) {
+    super(message);
+    this.name = "LifecycleEvidenceError";
+    this.code = code;
+  }
+}
+
+/** Explicit replay-store rejection normalized by the verifier. */
+class LifecycleReplayDefenseError extends Error {
+  readonly code: LifecycleReplayDefenseErrorCode;
+
+  constructor(code: LifecycleReplayDefenseErrorCode) {
+    super("Lifecycle evidence replay defense rejected the entry");
+    this.name = "LifecycleReplayDefenseError";
+    this.code = code;
+  }
+}
+
+/**
+ * Issues one short-lived, Codex-only lifecycle evidence envelope.
+ *
+ * The signer accepts only the closed transition and metadata vocabulary. It
+ * never accepts a provider, account token, raw response, command, path, or
+ * environment field.
+ */
+function issueLifecycleEvidence(
+  rawDecision: ServerLifecycleDecision,
+  signingKey: LifecycleEvidenceSigningKey,
+  clock: LifecycleEvidenceClock
+): string {
+  assertKeyObject(signingKey.privateKey, "private", "signing key");
+  const decision = parseServerDecision(rawDecision);
+  const issuedAt = readClock(clock);
+  const lifetimeSeconds =
+    decision.lifetimeSeconds ?? MAX_LIFECYCLE_EVIDENCE_LIFETIME_SECONDS;
+  if (
+    !Number.isSafeInteger(lifetimeSeconds) ||
+    lifetimeSeconds <= 0 ||
+    lifetimeSeconds > MAX_LIFECYCLE_EVIDENCE_LIFETIME_SECONDS
+  ) {
+    throw new LifecycleEvidenceError(
+      "evidence_lifetime_invalid",
+      "Lifecycle evidence lifetime is invalid"
+    );
+  }
+
+  const header: LifecycleEvidenceHeader = {
+    algorithm: LIFECYCLE_EVIDENCE_ALGORITHM,
+    type: LIFECYCLE_EVIDENCE_TYPE,
+    version: LIFECYCLE_EVIDENCE_VERSION,
+    kid: assertConfiguredKeyId(signingKey.keyId),
+  };
+  const claims: LifecycleEvidenceClaims = {
+    version: LIFECYCLE_EVIDENCE_VERSION,
+    issuer: decision.issuer,
+    audience: decision.audience,
+    subject: decision.subject,
+    connectionId: decision.connectionId,
+    provider: "codex",
+    requestId: decision.requestId,
+    evidenceId: decision.evidenceId,
+    nonce: decision.nonce,
+    issuedAt,
+    expiresAt: issuedAt + lifetimeSeconds,
+    transition: decision.transition,
+    credentialRevision: decision.credentialRevision,
+    metadata: decision.metadata,
+    kid: header.kid,
+  };
+
+  const signingInput = `${encodeJson(header)}.${encodeJson(claims)}`;
+  const signature = signBytes(
+    null,
+    Buffer.from(signingInput),
+    signingKey.privateKey
+  );
+  const evidence = `${signingInput}.${signature.toString("base64url")}`;
+  if (evidence.length > MAX_LIFECYCLE_EVIDENCE_LENGTH) {
+    throw invalidEvidence();
+  }
+  return evidence;
+}
+
+/**
+ * Authenticates, validates, consumes, and context-binds lifecycle evidence.
+ *
+ * Replay identifiers are consumed after authentic signature and time/schema
+ * validation but before every expected-context comparison. A signed token used
+ * against the wrong owner, connection, request, transition, or revision cannot
+ * subsequently be replayed against its intended context.
+ */
+async function verifyLifecycleEvidence(
+  token: string | null | undefined,
+  options: VerifyLifecycleEvidenceOptions
+): Promise<LifecycleEvidenceClaims> {
+  const authenticated = authenticateEvidence(token, options.verificationKeys);
+  const header = parseHeader(authenticated.encodedHeader);
+  const claims = parseClaims(authenticated.encodedClaims);
+  assertCanonicalSegment(authenticated.encodedHeader, header);
+  assertCanonicalSegment(authenticated.encodedClaims, claims);
+  if (
+    header.kid !== claims.kid ||
+    !authenticated.authenticatedKeyIds.includes(header.kid)
+  ) {
+    throw new LifecycleEvidenceError(
+      "invalid_signature",
+      "Lifecycle evidence key identifiers do not match"
+    );
+  }
+
+  const nowSeconds = readClock(options.clock);
+  assertTemporalValidity(claims, nowSeconds);
+  const replayDefenseTimeoutMs =
+    options.replayDefenseTimeoutMs ?? DEFAULT_LIFECYCLE_REPLAY_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(replayDefenseTimeoutMs) ||
+    replayDefenseTimeoutMs <= 0 ||
+    replayDefenseTimeoutMs > MAX_LIFECYCLE_REPLAY_TIMEOUT_MS
+  ) {
+    throw configurationError();
+  }
+
+  const replayOutcome = await awaitControlPlaneOperation(
+    (context) =>
+      options.replayDefense.consume(
+        {
+          evidenceId: claims.evidenceId,
+          nonce: claims.nonce,
+          requestId: claims.requestId,
+          expiresAt: claims.expiresAt,
+        },
+        context
+      ),
+    replayDefenseTimeoutMs,
+    options.signal
+  );
+  if (
+    replayOutcome.status === "aborted" ||
+    replayOutcome.status === "timed_out"
+  ) {
+    throw replayError("replay_defense_unavailable");
+  }
+  if (replayOutcome.status === "rejected") {
+    const code =
+      replayOutcome.error instanceof LifecycleReplayDefenseError
+        ? replayOutcome.error.code
+        : "replay_defense_unavailable";
+    throw replayError(code);
+  }
+  // A consume method has no success payload. Treating any returned value as
+  // success could make an ambiguous custom-store API fail open.
+  if (replayOutcome.value !== undefined) {
+    throw replayError("replay_defense_unavailable");
+  }
+
+  assertExpectedContext(claims, options.expected);
+  return claims;
+}
+
+type AuthenticatedEvidence = Readonly<{
+  encodedHeader: string;
+  encodedClaims: string;
+  authenticatedKeyIds: readonly string[];
+}>;
+
+/** Authenticates raw bytes against every configured rotation key before parsing. */
+function authenticateEvidence(
+  token: string | null | undefined,
+  keys: LifecycleEvidenceVerificationKeys
+): AuthenticatedEvidence {
+  if (!token) {
+    throw new LifecycleEvidenceError(
+      "missing_evidence",
+      "Lifecycle evidence is required"
+    );
+  }
+  if (token.length > MAX_LIFECYCLE_EVIDENCE_LENGTH) {
+    throw invalidEvidence();
+  }
+  const segments = token.split(".");
+  if (
+    segments.length !== 3 ||
+    segments.some((segment) => segment.length === 0)
+  ) {
+    throw invalidEvidence();
+  }
+
+  const [encodedHeader, encodedClaims, encodedSignature] = segments;
+  const signature = decodeCanonicalBase64Url(encodedSignature);
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const authenticatedKeyIds = authenticateSignature(
+    signingInput,
+    signature,
+    keys
+  );
+  return {
+    encodedHeader,
+    encodedClaims,
+    authenticatedKeyIds,
+  };
+}
+
+/** Authenticates against only an explicit current key and optional previous key. */
+function authenticateSignature(
+  signingInput: string,
+  signature: Buffer,
+  keys: LifecycleEvidenceVerificationKeys
+): readonly string[] {
+  assertKeyObject(keys.current.publicKey, "public", "current verification key");
+  assertConfiguredKeyId(keys.current.keyId);
+  if (keys.previous) {
+    assertKeyObject(
+      keys.previous.publicKey,
+      "public",
+      "previous verification key"
+    );
+    assertConfiguredKeyId(keys.previous.keyId);
+    if (keys.current.keyId === keys.previous.keyId) {
+      throw configurationError();
+    }
+  }
+  const candidates = keys.previous
+    ? [keys.current, keys.previous]
+    : [keys.current];
+  const authenticatedKeyIds = candidates
+    .filter((candidate) =>
+      verifyBytes(
+        null,
+        Buffer.from(signingInput),
+        candidate.publicKey,
+        signature
+      )
+    )
+    .map((candidate) => candidate.keyId);
+  if (authenticatedKeyIds.length === 0) {
+    throw new LifecycleEvidenceError(
+      "invalid_signature",
+      "Lifecycle evidence signature is invalid"
+    );
+  }
+  return authenticatedKeyIds;
+}
+
+/** Parses the fixed v1 protected header. */
+function parseHeader(segment: string): LifecycleEvidenceHeader {
+  const value = parseJsonObject(segment);
+  assertExactKeys(value, ["algorithm", "kid", "type", "version"]);
+  if (value.version !== LIFECYCLE_EVIDENCE_VERSION) {
+    throw new LifecycleEvidenceError(
+      "unsupported_evidence_version",
+      "Lifecycle evidence version is unsupported"
+    );
+  }
+  if (
+    value.algorithm !== LIFECYCLE_EVIDENCE_ALGORITHM ||
+    value.type !== LIFECYCLE_EVIDENCE_TYPE
+  ) {
+    throw invalidEvidence();
+  }
+  return {
+    algorithm: LIFECYCLE_EVIDENCE_ALGORITHM,
+    type: LIFECYCLE_EVIDENCE_TYPE,
+    version: LIFECYCLE_EVIDENCE_VERSION,
+    kid: assertIdentifier(value.kid),
+  };
+}
+
+/** Parses the exact v1 claim and safe-metadata schema after authentication. */
+function parseClaims(segment: string): LifecycleEvidenceClaims {
+  const value = parseJsonObject(segment);
+  assertExactKeys(value, [
+    "audience",
+    "connectionId",
+    "credentialRevision",
+    "evidenceId",
+    "expiresAt",
+    "issuedAt",
+    "issuer",
+    "kid",
+    "metadata",
+    "nonce",
+    "provider",
+    "requestId",
+    "subject",
+    "transition",
+    "version",
+  ]);
+  if (value.version !== LIFECYCLE_EVIDENCE_VERSION) {
+    throw new LifecycleEvidenceError(
+      "unsupported_evidence_version",
+      "Lifecycle evidence version is unsupported"
+    );
+  }
+  if (
+    !Number.isSafeInteger(value.issuedAt) ||
+    !Number.isSafeInteger(value.expiresAt) ||
+    !Number.isSafeInteger(value.credentialRevision) ||
+    (value.credentialRevision as number) <= 0
+  ) {
+    throw invalidEvidence();
+  }
+  const transition = assertTransition(value.transition);
+  const evidenceId = assertIdentifier(value.evidenceId);
+  const nonce = assertIdentifier(value.nonce);
+  if (evidenceId === nonce) throw invalidEvidence();
+  const metadata = parseMetadata(value.metadata, transition);
+  return {
+    version: LIFECYCLE_EVIDENCE_VERSION,
+    issuer: assertIdentifier(value.issuer),
+    audience: assertIdentifier(value.audience),
+    subject: assertIdentifier(value.subject),
+    connectionId: assertIdentifier(value.connectionId),
+    // Provider remains a string until replay consumption precedes context match.
+    provider: assertIdentifier(value.provider) as "codex",
+    requestId: assertIdentifier(value.requestId),
+    evidenceId,
+    nonce,
+    issuedAt: value.issuedAt as number,
+    expiresAt: value.expiresAt as number,
+    transition,
+    credentialRevision: value.credentialRevision as number,
+    metadata,
+    kid: assertIdentifier(value.kid),
+  };
+}
+
+/** Copies and validates a closed signer decision without invoking accessors. */
+function parseServerDecision(
+  rawDecision: ServerLifecycleDecision
+): ServerLifecycleDecision {
+  const value = readPlainDataObject(rawDecision);
+  const requiredKeys = [
+    "audience",
+    "connectionId",
+    "credentialRevision",
+    "evidenceId",
+    "issuer",
+    "metadata",
+    "nonce",
+    "requestId",
+    "subject",
+    "transition",
+  ];
+  const allowedKeys = [...requiredKeys, "lifetimeSeconds"];
+  assertRequiredAndAllowedKeys(value, requiredKeys, allowedKeys);
+  if (
+    !Number.isSafeInteger(value.credentialRevision) ||
+    (value.credentialRevision as number) <= 0
+  ) {
+    throw invalidEvidence();
+  }
+  if (
+    value.lifetimeSeconds !== undefined &&
+    !Number.isSafeInteger(value.lifetimeSeconds)
+  ) {
+    throw invalidEvidence();
+  }
+  const transition = assertTransition(value.transition);
+  const evidenceId = assertIdentifier(value.evidenceId);
+  const nonce = assertIdentifier(value.nonce);
+  if (evidenceId === nonce) throw invalidEvidence();
+  return {
+    issuer: assertIdentifier(value.issuer),
+    audience: assertIdentifier(value.audience),
+    subject: assertIdentifier(value.subject),
+    connectionId: assertIdentifier(value.connectionId),
+    requestId: assertIdentifier(value.requestId),
+    evidenceId,
+    nonce,
+    transition,
+    credentialRevision: value.credentialRevision as number,
+    metadata: parseMetadata(value.metadata, transition),
+    lifetimeSeconds: value.lifetimeSeconds as number | undefined,
+  };
+}
+
+/** Validates the only safe gateway metadata allowed for a transition. */
+function parseMetadata(
+  rawMetadata: unknown,
+  transition: LifecycleTransition
+): LifecycleEvidenceMetadata {
+  const value = readPlainDataObject(rawMetadata);
+  assertExactKeys(value, [
+    "account",
+    "errorCode",
+    "gatewayCredentialId",
+    "planLabel",
+  ]);
+  const gatewayCredentialId = assertNullableIdentifier(
+    value.gatewayCredentialId
+  );
+  const planLabel = assertNullablePlanLabel(value.planLabel);
+  const errorCode = assertNullableErrorCode(value.errorCode);
+  const account = parseNullableAccount(value.account);
+  const metadata = { gatewayCredentialId, account, planLabel, errorCode };
+
+  const target = transition.split("_to_")[1];
+  if (target === "connected") {
+    if (
+      gatewayCredentialId === null ||
+      account === null ||
+      errorCode !== null
+    ) {
+      throw invalidEvidence();
+    }
+  } else if (target === "error") {
+    if (errorCode === null || (account === null && planLabel !== null)) {
+      throw invalidEvidence();
+    }
+  } else if (target === "expired") {
+    if (errorCode !== "credential_expired") {
+      throw invalidEvidence();
+    }
+  } else if (
+    gatewayCredentialId !== null ||
+    account !== null ||
+    planLabel !== null ||
+    errorCode !== null
+  ) {
+    // Revocation evidence confirms a terminal state, not credential metadata.
+    throw invalidEvidence();
+  }
+  return Object.freeze(metadata);
+}
+
+/** Accepts only the subscription account projection; API-key accounts fail closed. */
+function parseNullableAccount(value: unknown): LifecycleEvidenceAccount | null {
+  if (value === null) return null;
+  const account = readPlainDataObject(value);
+  assertExactKeys(account, ["present", "type"]);
+  if (account.type !== "chatgpt" || account.present !== true) {
+    throw invalidEvidence();
+  }
+  return Object.freeze({ type: "chatgpt", present: true });
+}
+
+/** Consumes every context mismatch only after replay state is committed. */
+function assertExpectedContext(
+  claims: LifecycleEvidenceClaims,
+  expected: ExpectedLifecycleEvidenceContext
+): void {
+  const comparisons: ReadonlyArray<
+    readonly [boolean, LifecycleEvidenceErrorCode]
+  > = [
+    [claims.issuer === expected.issuer, "issuer_mismatch"],
+    [claims.audience === expected.audience, "audience_mismatch"],
+    [claims.subject === expected.subject, "subject_mismatch"],
+    [claims.connectionId === expected.connectionId, "connection_mismatch"],
+    [claims.provider === expected.provider, "provider_mismatch"],
+    [claims.requestId === expected.requestId, "request_id_mismatch"],
+    [claims.transition === expected.transition, "transition_mismatch"],
+    [
+      claims.credentialRevision === expected.credentialRevision,
+      "credential_revision_mismatch",
+    ],
+  ];
+  for (const [matches, code] of comparisons) {
+    if (!matches) {
+      throw new LifecycleEvidenceError(
+        code,
+        "Lifecycle evidence does not match the expected server context"
+      );
+    }
+  }
+}
+
+/** Enforces a strict no-skew validity window of at most 60 seconds. */
+function assertTemporalValidity(
+  claims: LifecycleEvidenceClaims,
+  nowSeconds: number
+): void {
+  const lifetime = claims.expiresAt - claims.issuedAt;
+  if (lifetime <= 0 || lifetime > MAX_LIFECYCLE_EVIDENCE_LIFETIME_SECONDS) {
+    throw new LifecycleEvidenceError(
+      "evidence_lifetime_invalid",
+      "Lifecycle evidence lifetime is invalid"
+    );
+  }
+  if (claims.issuedAt > nowSeconds) {
+    throw new LifecycleEvidenceError(
+      "evidence_from_future",
+      "Lifecycle evidence was issued in the future"
+    );
+  }
+  if (claims.expiresAt <= nowSeconds) {
+    throw new LifecycleEvidenceError(
+      "evidence_expired",
+      "Lifecycle evidence has expired"
+    );
+  }
+}
+
+/** Reads an injected integer epoch clock. */
+function readClock(clock: LifecycleEvidenceClock): number {
+  const nowSeconds = clock.nowSeconds();
+  if (
+    !Number.isSafeInteger(nowSeconds) ||
+    nowSeconds < 0 ||
+    nowSeconds >
+      Number.MAX_SAFE_INTEGER - MAX_LIFECYCLE_EVIDENCE_LIFETIME_SECONDS
+  ) {
+    throw configurationError();
+  }
+  return nowSeconds;
+}
+
+/** Restricts keys to Ed25519 and their required role. */
+function assertKeyObject(
+  key: KeyObject,
+  expectedType: "private" | "public",
+  label: string
+): void {
+  if (key.type !== expectedType || key.asymmetricKeyType !== "ed25519") {
+    throw new LifecycleEvidenceError(
+      "internal_evidence_configuration_invalid",
+      `${label} must be an Ed25519 ${expectedType} key`
+    );
+  }
+}
+
+/** Validates an exact, bounded lifecycle transition. */
+function assertTransition(value: unknown): LifecycleTransition {
+  if (
+    typeof value !== "string" ||
+    !LIFECYCLE_TRANSITIONS.includes(value as LifecycleTransition)
+  ) {
+    throw invalidEvidence();
+  }
+  return value as LifecycleTransition;
+}
+
+/** Validates a stable, bounded lifecycle error code. */
+function assertNullableErrorCode(value: unknown): LifecycleErrorCode | null {
+  if (value === null) return null;
+  if (
+    typeof value !== "string" ||
+    !LIFECYCLE_ERROR_CODES.includes(value as LifecycleErrorCode)
+  ) {
+    throw invalidEvidence();
+  }
+  return value as LifecycleErrorCode;
+}
+
+/** Validates one required non-empty identifier without returning input values. */
+function assertIdentifier(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_IDENTIFIER_LENGTH ||
+    Buffer.byteLength(value, "utf8") > MAX_IDENTIFIER_LENGTH
+  ) {
+    throw invalidEvidence();
+  }
+  return value;
+}
+
+/** Validates a bounded configured key identifier as configuration, not input. */
+function assertConfiguredKeyId(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_IDENTIFIER_LENGTH ||
+    Buffer.byteLength(value, "utf8") > MAX_IDENTIFIER_LENGTH
+  ) {
+    throw configurationError();
+  }
+  return value;
+}
+
+/** Validates one nullable opaque identifier. */
+function assertNullableIdentifier(value: unknown): string | null {
+  return value === null ? null : assertIdentifier(value);
+}
+
+/** Validates one display-only plan label. */
+function assertNullablePlanLabel(value: unknown): string | null {
+  if (value === null) return null;
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_PLAN_LABEL_LENGTH ||
+    Buffer.byteLength(value, "utf8") > MAX_PLAN_LABEL_LENGTH ||
+    containsControlCharacter(value)
+  ) {
+    throw invalidEvidence();
+  }
+  return value;
+}
+
+/** Rejects C0 and DEL characters from display-only metadata. */
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Reads a plain data object without invoking getters or accepting prototypes. */
+function readPlainDataObject(value: unknown): Record<string, unknown> {
+  try {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      (Object.getPrototypeOf(value) !== Object.prototype &&
+        Object.getPrototypeOf(value) !== null)
+    ) {
+      throw invalidEvidence();
+    }
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.length > 20 || ownKeys.some((key) => typeof key !== "string")) {
+      throw invalidEvidence();
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const result: Record<string, unknown> = {};
+    for (const [key, descriptor] of Object.entries(descriptors)) {
+      if (!("value" in descriptor) || typeof descriptor.value === "function") {
+        throw invalidEvidence();
+      }
+      result[key] = descriptor.value;
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof LifecycleEvidenceError) throw error;
+    throw invalidEvidence();
+  }
+}
+
+/** Encodes fixed-order JSON as canonical unpadded base64url. */
+function encodeJson(value: object): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+/** Rejects duplicate keys, whitespace, reordering, and equivalent encodings. */
+function assertCanonicalSegment(segment: string, value: object): void {
+  if (segment !== encodeJson(value)) {
+    throw new LifecycleEvidenceError(
+      "noncanonical_evidence",
+      "Lifecycle evidence encoding is not canonical"
+    );
+  }
+}
+
+/** Decodes only canonical unpadded base64url input. */
+function decodeCanonicalBase64Url(segment: string): Buffer {
+  if (!/^[A-Za-z0-9_-]+$/.test(segment)) {
+    throw invalidEvidence();
+  }
+  const decoded = Buffer.from(segment, "base64url");
+  if (decoded.toString("base64url") !== segment) {
+    throw invalidEvidence();
+  }
+  return decoded;
+}
+
+/** Decodes a bounded base64url JSON object after signature authentication. */
+function parseJsonObject(segment: string): Record<string, unknown> {
+  try {
+    if (!/^[A-Za-z0-9_-]+={0,2}$/.test(segment)) {
+      throw invalidEvidence();
+    }
+    const decoded = Buffer.from(segment, "base64url");
+    if (decoded.byteLength > MAX_LIFECYCLE_EVIDENCE_LENGTH) {
+      throw invalidEvidence();
+    }
+    const parsed: unknown = JSON.parse(decoded.toString("utf8"));
+    return readPlainDataObject(parsed);
+  } catch (error) {
+    if (error instanceof LifecycleEvidenceError) throw error;
+    throw invalidEvidence();
+  }
+}
+
+/** Rejects omitted and extension fields. */
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[]
+): void {
+  assertRequiredAndAllowedKeys(value, expectedKeys, expectedKeys);
+}
+
+/** Rejects missing required fields and all fields outside the allowlist. */
+function assertRequiredAndAllowedKeys(
+  value: Record<string, unknown>,
+  requiredKeys: readonly string[],
+  allowedKeys: readonly string[]
+): void {
+  const actual = Object.keys(value).sort();
+  const allowed = new Set(allowedKeys);
+  if (
+    actual.some((key) => !allowed.has(key)) ||
+    requiredKeys.some((key) => !Object.hasOwn(value, key))
+  ) {
+    throw invalidEvidence();
+  }
+}
+
+/** Maps replay outcomes to stable secret-free failures. */
+function replayError(
+  code: LifecycleReplayDefenseErrorCode
+): LifecycleEvidenceError {
+  return new LifecycleEvidenceError(
+    code,
+    code === "replay_detected"
+      ? "Lifecycle evidence was already consumed"
+      : "Lifecycle evidence replay defense is unavailable"
+  );
+}
+
+/** Creates a stable invalid-evidence rejection. */
+function invalidEvidence(): LifecycleEvidenceError {
+  return new LifecycleEvidenceError(
+    "invalid_evidence",
+    "Lifecycle evidence is invalid"
+  );
+}
+
+/** Creates a stable invalid-configuration rejection. */
+function configurationError(): LifecycleEvidenceError {
+  return new LifecycleEvidenceError(
+    "internal_evidence_configuration_invalid",
+    "Lifecycle evidence configuration is invalid"
+  );
+}
+
+export {
+  DEFAULT_LIFECYCLE_REPLAY_TIMEOUT_MS,
+  type ExpectedLifecycleEvidenceContext,
+  issueLifecycleEvidence,
+  LIFECYCLE_ERROR_CODES,
+  LIFECYCLE_EVIDENCE_VERSION,
+  LIFECYCLE_TRANSITIONS,
+  type LifecycleErrorCode,
+  type LifecycleEvidenceAccount,
+  type LifecycleEvidenceClaims,
+  type LifecycleEvidenceClock,
+  LifecycleEvidenceError,
+  type LifecycleEvidenceErrorCode,
+  type LifecycleEvidenceMetadata,
+  type LifecycleEvidenceReplayDefense,
+  type LifecycleEvidenceSigningKey,
+  type LifecycleEvidenceVerificationKey,
+  type LifecycleEvidenceVerificationKeys,
+  LifecycleReplayDefenseError,
+  type LifecycleReplayDefenseErrorCode,
+  type LifecycleReplayEntry,
+  type LifecycleTransition,
+  MAX_LIFECYCLE_EVIDENCE_LIFETIME_SECONDS,
+  MAX_LIFECYCLE_REPLAY_TIMEOUT_MS,
+  type ServerLifecycleDecision,
+  verifyLifecycleEvidence,
+  type VerifyLifecycleEvidenceOptions,
+};

--- a/services/agent-gateway/lifecycle-evidence.ts
+++ b/services/agent-gateway/lifecycle-evidence.ts
@@ -4,32 +4,42 @@ import {
   verify as verifyBytes,
 } from "node:crypto";
 
-import {
-  awaitControlPlaneOperation,
-  type ControlPlaneOperationContext,
-} from "./control-plane.ts";
+import type { ControlPlaneOperationContext } from "./control-plane.ts";
 
 const LIFECYCLE_EVIDENCE_ALGORITHM = "EdDSA";
 const LIFECYCLE_EVIDENCE_TYPE = "sprig-lifecycle-evidence";
 const LIFECYCLE_EVIDENCE_VERSION = 1;
 const MAX_LIFECYCLE_EVIDENCE_LIFETIME_SECONDS = 60;
 const MAX_LIFECYCLE_EVIDENCE_LENGTH = 8_192;
-const MAX_IDENTIFIER_LENGTH = 256;
-const MAX_PLAN_LABEL_LENGTH = 128;
 const DEFAULT_LIFECYCLE_REPLAY_TIMEOUT_MS = 1_000;
 const MAX_LIFECYCLE_REPLAY_TIMEOUT_MS = 10_000;
+const LIFECYCLE_EVIDENCE_ISSUER = "sprig-agent-gateway";
+const LIFECYCLE_EVIDENCE_AUDIENCE = "sprig-trusted-server";
+
+const UUID_V4_PATTERN =
+  "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+const CLERK_SUBJECT_PATTERN = /^user_[A-Za-z0-9]{16,64}$/;
+const CONNECTION_ID_PATTERN = new RegExp(`^connection_v1_${UUID_V4_PATTERN}$`);
+const REQUEST_ID_PATTERN = new RegExp(`^request_v1_${UUID_V4_PATTERN}$`);
+const EVIDENCE_ID_PATTERN = new RegExp(`^evidence_v1_${UUID_V4_PATTERN}$`);
+const NONCE_PATTERN = new RegExp(`^nonce_v1_${UUID_V4_PATTERN}$`);
+const GATEWAY_CREDENTIAL_ID_PATTERN = new RegExp(
+  `^gwcred_v1_${UUID_V4_PATTERN}$`
+);
+const KEY_ID_PATTERN = /^lifecycle-v1-[0-9a-f]{8}$/;
 
 const LIFECYCLE_TRANSITIONS = [
   "pending_to_connected",
   "pending_to_error",
   "pending_to_expired",
+  "pending_to_revoking",
   "connected_to_error",
   "connected_to_expired",
-  "connected_to_revoked",
-  "error_to_connected",
-  "error_to_revoked",
-  "expired_to_connected",
-  "expired_to_revoked",
+  "connected_to_revoking",
+  "error_to_revoking",
+  "expired_to_revoking",
+  "revoking_to_revoked",
+  "revoked_to_deleted",
 ] as const;
 
 const LIFECYCLE_ERROR_CODES = [
@@ -41,8 +51,38 @@ const LIFECYCLE_ERROR_CODES = [
   "provider_unavailable",
 ] as const;
 
+const LIFECYCLE_PLAN_LABELS = [
+  "ChatGPT",
+  "ChatGPT Plus",
+  "ChatGPT Pro",
+  "ChatGPT Business",
+  "ChatGPT Enterprise",
+  "ChatGPT Edu",
+] as const;
+
 type LifecycleTransition = (typeof LIFECYCLE_TRANSITIONS)[number];
 type LifecycleErrorCode = (typeof LIFECYCLE_ERROR_CODES)[number];
+type LifecyclePlanLabel = (typeof LIFECYCLE_PLAN_LABELS)[number];
+
+type LifecycleMetadataPolicy =
+  | "establish_connection"
+  | "record_error"
+  | "record_expiry"
+  | "empty_terminal";
+
+const LIFECYCLE_TRANSITION_METADATA_POLICIES = {
+  pending_to_connected: "establish_connection",
+  pending_to_error: "record_error",
+  pending_to_expired: "record_expiry",
+  pending_to_revoking: "empty_terminal",
+  connected_to_error: "record_error",
+  connected_to_expired: "record_expiry",
+  connected_to_revoking: "empty_terminal",
+  error_to_revoking: "empty_terminal",
+  expired_to_revoking: "empty_terminal",
+  revoking_to_revoked: "empty_terminal",
+  revoked_to_deleted: "empty_terminal",
+} as const satisfies Record<LifecycleTransition, LifecycleMetadataPolicy>;
 
 type LifecycleEvidenceErrorCode =
   | "audience_mismatch"
@@ -73,7 +113,7 @@ type LifecycleEvidenceAccount = Readonly<{
 type LifecycleEvidenceMetadata = Readonly<{
   gatewayCredentialId: string | null;
   account: LifecycleEvidenceAccount | null;
-  planLabel: string | null;
+  planLabel: LifecyclePlanLabel | null;
   errorCode: LifecycleErrorCode | null;
 }>;
 
@@ -104,6 +144,10 @@ type LifecycleEvidenceHeader = Readonly<{
 
 type LifecycleEvidenceClock = Readonly<{
   nowSeconds: () => number;
+}>;
+
+type LifecycleMonotonicClock = Readonly<{
+  nowMilliseconds: () => number;
 }>;
 
 type LifecycleEvidenceSigningKey = Readonly<{
@@ -161,6 +205,7 @@ type LifecycleReplayEntry = Readonly<{
 }>;
 
 interface LifecycleEvidenceReplayDefense {
+  /** Atomically consumes all three identifiers through the entry expiry. */
   consume(
     entry: LifecycleReplayEntry,
     context?: ControlPlaneOperationContext
@@ -172,6 +217,7 @@ type VerifyLifecycleEvidenceOptions = Readonly<{
   expected: ExpectedLifecycleEvidenceContext;
   replayDefense: LifecycleEvidenceReplayDefense;
   verificationKeys: LifecycleEvidenceVerificationKeys;
+  monotonicClock: LifecycleMonotonicClock;
   replayDefenseTimeoutMs?: number;
   signal?: AbortSignal;
 }>;
@@ -179,6 +225,14 @@ type VerifyLifecycleEvidenceOptions = Readonly<{
 type LifecycleReplayDefenseErrorCode =
   | "replay_defense_unavailable"
   | "replay_detected";
+
+type ReplayConsumeOutcome =
+  | Readonly<{ status: "fulfilled"; value: unknown }>
+  | Readonly<{ status: "rejected"; error: unknown }>
+  | Readonly<{ status: "aborted" }>
+  | Readonly<{ status: "timed_out" }>;
+
+const SKIPPED_REPLAY_CONSUME = Symbol("skipped replay consume");
 
 /** Stable evidence failure whose message contains no signed or provider data. */
 class LifecycleEvidenceError extends Error {
@@ -306,7 +360,10 @@ async function verifyLifecycleEvidence(
     throw configurationError();
   }
 
-  const replayOutcome = await awaitControlPlaneOperation(
+  const replayStartedAtMilliseconds = readMonotonicClock(
+    options.monotonicClock
+  );
+  const replayOutcome = await awaitReplayConsume(
     (context) =>
       options.replayDefense.consume(
         {
@@ -318,6 +375,8 @@ async function verifyLifecycleEvidence(
         context
       ),
     replayDefenseTimeoutMs,
+    options.monotonicClock,
+    replayStartedAtMilliseconds,
     options.signal
   );
   if (
@@ -341,6 +400,100 @@ async function verifyLifecycleEvidence(
 
   assertExpectedContext(claims, options.expected);
   return claims;
+}
+
+/**
+ * Awaits one atomic replay consume behind an authoritative monotonic deadline.
+ *
+ * The clock is checked immediately before invocation and after both synchronous
+ * and asynchronous settlement. Therefore a blocking consume cannot win merely
+ * because its fulfillment microtask runs before a delayed timer callback.
+ */
+function awaitReplayConsume(
+  operation: (
+    context: ControlPlaneOperationContext
+  ) => unknown | PromiseLike<unknown>,
+  timeoutMs: number,
+  monotonicClock: LifecycleMonotonicClock,
+  startedAtMilliseconds: number,
+  requestSignal?: AbortSignal
+): Promise<ReplayConsumeOutcome> {
+  const operationController = new AbortController();
+  const deadlineAtMilliseconds = startedAtMilliseconds + timeoutMs;
+
+  return new Promise<ReplayConsumeOutcome>((resolve) => {
+    let settled = false;
+    const finish = (
+      outcome: ReplayConsumeOutcome,
+      cancelOperation: boolean
+    ): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      requestSignal?.removeEventListener("abort", handleRequestAbort);
+      if (cancelOperation) operationController.abort();
+      resolve(outcome);
+    };
+    const handleRequestAbort = (): void => {
+      finish({ status: "aborted" }, true);
+    };
+    const readSettlementTime = (): number | null => {
+      try {
+        const nowMilliseconds = readMonotonicClock(monotonicClock);
+        return nowMilliseconds < startedAtMilliseconds ? null : nowMilliseconds;
+      } catch {
+        return null;
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      finish({ status: "timed_out" }, true);
+    }, timeoutMs);
+    requestSignal?.addEventListener("abort", handleRequestAbort, {
+      once: true,
+    });
+    if (requestSignal?.aborted) handleRequestAbort();
+
+    Promise.resolve()
+      .then(() => {
+        if (settled) return SKIPPED_REPLAY_CONSUME;
+        const beforeInvocation = readSettlementTime();
+        if (
+          beforeInvocation === null ||
+          beforeInvocation >= deadlineAtMilliseconds
+        ) {
+          finish({ status: "timed_out" }, true);
+          return SKIPPED_REPLAY_CONSUME;
+        }
+        return operation(
+          Object.freeze({
+            signal: operationController.signal,
+            deadlineAtMilliseconds,
+          })
+        );
+      })
+      .then(
+        (value) => {
+          if (value === SKIPPED_REPLAY_CONSUME) return;
+          const settledAt = readSettlementTime();
+          if (settledAt === null || settledAt >= deadlineAtMilliseconds) {
+            finish({ status: "timed_out" }, true);
+            return;
+          }
+          finish({ status: "fulfilled", value }, false);
+        },
+        (error: unknown) => {
+          // Keep this handler attached after timeout/abort so late rejection is
+          // observed, but let an exceeded deadline dominate a store error.
+          const settledAt = readSettlementTime();
+          if (settledAt === null || settledAt >= deadlineAtMilliseconds) {
+            finish({ status: "timed_out" }, true);
+            return;
+          }
+          finish({ status: "rejected", error }, false);
+        }
+      );
+  });
 }
 
 type AuthenticatedEvidence = Readonly<{
@@ -443,12 +596,12 @@ function parseHeader(segment: string): LifecycleEvidenceHeader {
   ) {
     throw invalidEvidence();
   }
-  return {
+  return Object.freeze({
     algorithm: LIFECYCLE_EVIDENCE_ALGORITHM,
     type: LIFECYCLE_EVIDENCE_TYPE,
     version: LIFECYCLE_EVIDENCE_VERSION,
-    kid: assertIdentifier(value.kid),
-  };
+    kid: assertKeyIdClaim(value.kid),
+  });
 }
 
 /** Parses the exact v1 claim and safe-metadata schema after authentication. */
@@ -486,19 +639,20 @@ function parseClaims(segment: string): LifecycleEvidenceClaims {
     throw invalidEvidence();
   }
   const transition = assertTransition(value.transition);
-  const evidenceId = assertIdentifier(value.evidenceId);
-  const nonce = assertIdentifier(value.nonce);
+  const evidenceId = assertOpaqueId(value.evidenceId, EVIDENCE_ID_PATTERN);
+  const nonce = assertOpaqueId(value.nonce, NONCE_PATTERN);
   if (evidenceId === nonce) throw invalidEvidence();
   const metadata = parseMetadata(value.metadata, transition);
-  return {
+  return Object.freeze({
     version: LIFECYCLE_EVIDENCE_VERSION,
-    issuer: assertIdentifier(value.issuer),
-    audience: assertIdentifier(value.audience),
-    subject: assertIdentifier(value.subject),
-    connectionId: assertIdentifier(value.connectionId),
-    // Provider remains a string until replay consumption precedes context match.
-    provider: assertIdentifier(value.provider) as "codex",
-    requestId: assertIdentifier(value.requestId),
+    issuer: assertIssuer(value.issuer),
+    audience: assertAudience(value.audience),
+    subject: assertClerkSubject(value.subject),
+    connectionId: assertOpaqueId(value.connectionId, CONNECTION_ID_PATTERN),
+    // A known alternate provider remains parseable so its signed evidence is
+    // consumed before the exact Codex expected-context comparison.
+    provider: assertProviderClaim(value.provider),
+    requestId: assertOpaqueId(value.requestId, REQUEST_ID_PATTERN),
     evidenceId,
     nonce,
     issuedAt: value.issuedAt as number,
@@ -506,8 +660,8 @@ function parseClaims(segment: string): LifecycleEvidenceClaims {
     transition,
     credentialRevision: value.credentialRevision as number,
     metadata,
-    kid: assertIdentifier(value.kid),
-  };
+    kid: assertKeyIdClaim(value.kid),
+  });
 }
 
 /** Copies and validates a closed signer decision without invoking accessors. */
@@ -542,22 +696,22 @@ function parseServerDecision(
     throw invalidEvidence();
   }
   const transition = assertTransition(value.transition);
-  const evidenceId = assertIdentifier(value.evidenceId);
-  const nonce = assertIdentifier(value.nonce);
+  const evidenceId = assertOpaqueId(value.evidenceId, EVIDENCE_ID_PATTERN);
+  const nonce = assertOpaqueId(value.nonce, NONCE_PATTERN);
   if (evidenceId === nonce) throw invalidEvidence();
-  return {
-    issuer: assertIdentifier(value.issuer),
-    audience: assertIdentifier(value.audience),
-    subject: assertIdentifier(value.subject),
-    connectionId: assertIdentifier(value.connectionId),
-    requestId: assertIdentifier(value.requestId),
+  return Object.freeze({
+    issuer: assertIssuer(value.issuer),
+    audience: assertAudience(value.audience),
+    subject: assertClerkSubject(value.subject),
+    connectionId: assertOpaqueId(value.connectionId, CONNECTION_ID_PATTERN),
+    requestId: assertOpaqueId(value.requestId, REQUEST_ID_PATTERN),
     evidenceId,
     nonce,
     transition,
     credentialRevision: value.credentialRevision as number,
     metadata: parseMetadata(value.metadata, transition),
     lifetimeSeconds: value.lifetimeSeconds as number | undefined,
-  };
+  });
 }
 
 /** Validates the only safe gateway metadata allowed for a transition. */
@@ -572,7 +726,7 @@ function parseMetadata(
     "gatewayCredentialId",
     "planLabel",
   ]);
-  const gatewayCredentialId = assertNullableIdentifier(
+  const gatewayCredentialId = assertNullableGatewayCredentialId(
     value.gatewayCredentialId
   );
   const planLabel = assertNullablePlanLabel(value.planLabel);
@@ -580,30 +734,39 @@ function parseMetadata(
   const account = parseNullableAccount(value.account);
   const metadata = { gatewayCredentialId, account, planLabel, errorCode };
 
-  const target = transition.split("_to_")[1];
-  if (target === "connected") {
-    if (
-      gatewayCredentialId === null ||
-      account === null ||
-      errorCode !== null
-    ) {
-      throw invalidEvidence();
-    }
-  } else if (target === "error") {
-    if (errorCode === null || (account === null && planLabel !== null)) {
-      throw invalidEvidence();
-    }
-  } else if (target === "expired") {
-    if (errorCode !== "credential_expired") {
-      throw invalidEvidence();
-    }
-  } else if (
-    gatewayCredentialId !== null ||
-    account !== null ||
-    planLabel !== null ||
-    errorCode !== null
+  const policy = LIFECYCLE_TRANSITION_METADATA_POLICIES[transition];
+  if (
+    policy === "establish_connection" &&
+    (gatewayCredentialId === null || account === null || errorCode !== null)
   ) {
-    // Revocation evidence confirms a terminal state, not credential metadata.
+    throw invalidEvidence();
+  }
+  if (
+    policy === "record_error" &&
+    (gatewayCredentialId !== null ||
+      account !== null ||
+      planLabel !== null ||
+      errorCode === null ||
+      errorCode === "credential_expired")
+  ) {
+    throw invalidEvidence();
+  }
+  if (
+    policy === "record_expiry" &&
+    (gatewayCredentialId !== null ||
+      account !== null ||
+      planLabel !== null ||
+      errorCode !== "credential_expired")
+  ) {
+    throw invalidEvidence();
+  }
+  if (
+    policy === "empty_terminal" &&
+    (gatewayCredentialId !== null ||
+      account !== null ||
+      planLabel !== null ||
+      errorCode !== null)
+  ) {
     throw invalidEvidence();
   }
   return Object.freeze(metadata);
@@ -690,6 +853,19 @@ function readClock(clock: LifecycleEvidenceClock): number {
   return nowSeconds;
 }
 
+/** Reads a finite injected monotonic clock without accepting unsafe deadlines. */
+function readMonotonicClock(clock: LifecycleMonotonicClock): number {
+  const nowMilliseconds = clock.nowMilliseconds();
+  if (
+    !Number.isFinite(nowMilliseconds) ||
+    nowMilliseconds < 0 ||
+    nowMilliseconds > Number.MAX_SAFE_INTEGER - MAX_LIFECYCLE_REPLAY_TIMEOUT_MS
+  ) {
+    throw configurationError();
+  }
+  return nowMilliseconds;
+}
+
 /** Restricts keys to Ed25519 and their required role. */
 function assertKeyObject(
   key: KeyObject,
@@ -727,84 +903,121 @@ function assertNullableErrorCode(value: unknown): LifecycleErrorCode | null {
   return value as LifecycleErrorCode;
 }
 
-/** Validates one required non-empty identifier without returning input values. */
-function assertIdentifier(value: unknown): string {
-  if (
-    typeof value !== "string" ||
-    value.length === 0 ||
-    value.length > MAX_IDENTIFIER_LENGTH ||
-    Buffer.byteLength(value, "utf8") > MAX_IDENTIFIER_LENGTH
-  ) {
+/** Validates the sole protocol issuer. */
+function assertIssuer(value: unknown): string {
+  if (value !== LIFECYCLE_EVIDENCE_ISSUER) throw invalidEvidence();
+  return value;
+}
+
+/** Validates the sole trusted reconciliation audience. */
+function assertAudience(value: unknown): string {
+  if (value !== LIFECYCLE_EVIDENCE_AUDIENCE) throw invalidEvidence();
+  return value;
+}
+
+/** Validates a Clerk user subject without accepting arbitrary safe-looking text. */
+function assertClerkSubject(value: unknown): string {
+  if (typeof value !== "string" || !CLERK_SUBJECT_PATTERN.test(value)) {
     throw invalidEvidence();
   }
   return value;
 }
 
-/** Validates a bounded configured key identifier as configuration, not input. */
-function assertConfiguredKeyId(value: unknown): string {
-  if (
-    typeof value !== "string" ||
-    value.length === 0 ||
-    value.length > MAX_IDENTIFIER_LENGTH ||
-    Buffer.byteLength(value, "utf8") > MAX_IDENTIFIER_LENGTH
-  ) {
-    throw configurationError();
+/** Validates one versioned UUID-shaped server identifier. */
+function assertOpaqueId(value: unknown, pattern: RegExp): string {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw invalidEvidence();
   }
   return value;
 }
 
-/** Validates one nullable opaque identifier. */
-function assertNullableIdentifier(value: unknown): string | null {
-  return value === null ? null : assertIdentifier(value);
+/** Keeps known alternate-provider evidence consumable before context matching. */
+function assertProviderClaim(value: unknown): "codex" {
+  if (value !== "codex" && value !== "claude") throw invalidEvidence();
+  return value as "codex";
 }
 
-/** Validates one display-only plan label. */
-function assertNullablePlanLabel(value: unknown): string | null {
+/** Validates a signed key identifier before matching authenticated key bytes. */
+function assertKeyIdClaim(value: unknown): string {
+  if (typeof value !== "string" || !KEY_ID_PATTERN.test(value)) {
+    throw invalidEvidence();
+  }
+  return value;
+}
+
+/** Validates a configured key identifier as configuration, not signed input. */
+function assertConfiguredKeyId(value: unknown): string {
+  if (typeof value !== "string" || !KEY_ID_PATTERN.test(value))
+    throw configurationError();
+  return value;
+}
+
+/** Validates the only opaque credential-handle shape. */
+function assertNullableGatewayCredentialId(value: unknown): string | null {
+  return value === null
+    ? null
+    : assertOpaqueId(value, GATEWAY_CREDENTIAL_ID_PATTERN);
+}
+
+/** Validates one small server-owned display label enum. */
+function assertNullablePlanLabel(value: unknown): LifecyclePlanLabel | null {
   if (value === null) return null;
   if (
     typeof value !== "string" ||
-    value.length === 0 ||
-    value.length > MAX_PLAN_LABEL_LENGTH ||
-    Buffer.byteLength(value, "utf8") > MAX_PLAN_LABEL_LENGTH ||
-    containsControlCharacter(value)
+    !LIFECYCLE_PLAN_LABELS.includes(value as LifecyclePlanLabel)
   ) {
     throw invalidEvidence();
   }
-  return value;
-}
-
-/** Rejects C0 and DEL characters from display-only metadata. */
-function containsControlCharacter(value: string): boolean {
-  for (let index = 0; index < value.length; index += 1) {
-    const codeUnit = value.charCodeAt(index);
-    if (codeUnit <= 0x1f || codeUnit === 0x7f) return true;
-  }
-  return false;
+  return value as LifecyclePlanLabel;
 }
 
 /** Reads a plain data object without invoking getters or accepting prototypes. */
 function readPlainDataObject(value: unknown): Record<string, unknown> {
   try {
+    const prototype =
+      typeof value === "object" && value !== null
+        ? Object.getPrototypeOf(value)
+        : undefined;
     if (
       typeof value !== "object" ||
       value === null ||
       Array.isArray(value) ||
-      (Object.getPrototypeOf(value) !== Object.prototype &&
-        Object.getPrototypeOf(value) !== null)
+      (prototype !== Object.prototype && prototype !== null)
     ) {
       throw invalidEvidence();
     }
     const ownKeys = Reflect.ownKeys(value);
-    if (ownKeys.length > 20 || ownKeys.some((key) => typeof key !== "string")) {
+    if (
+      ownKeys.length > 20 ||
+      ownKeys.some(
+        (key) =>
+          typeof key !== "string" ||
+          key === "__proto__" ||
+          key === "prototype" ||
+          key === "constructor"
+      )
+    ) {
       throw invalidEvidence();
     }
-    const descriptors = Object.getOwnPropertyDescriptors(value);
-    const result: Record<string, unknown> = {};
-    for (const [key, descriptor] of Object.entries(descriptors)) {
-      if (!("value" in descriptor) || typeof descriptor.value === "function") {
+    const result = Object.create(null) as Record<string, unknown>;
+    for (const key of ownKeys as string[]) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        descriptor === undefined ||
+        !("value" in descriptor) ||
+        descriptor.enumerable !== true ||
+        typeof descriptor.value === "function"
+      ) {
         throw invalidEvidence();
       }
-      result[key] = descriptor.value;
+      // A null-prototype destination plus defineProperty prevents magic-key
+      // assignment from invoking Object.prototype setters.
+      Object.defineProperty(result, key, {
+        configurable: false,
+        enumerable: true,
+        value: descriptor.value,
+        writable: false,
+      });
     }
     return result;
   } catch (error) {
@@ -915,7 +1128,10 @@ export {
   type ExpectedLifecycleEvidenceContext,
   issueLifecycleEvidence,
   LIFECYCLE_ERROR_CODES,
+  LIFECYCLE_EVIDENCE_AUDIENCE,
+  LIFECYCLE_EVIDENCE_ISSUER,
   LIFECYCLE_EVIDENCE_VERSION,
+  LIFECYCLE_PLAN_LABELS,
   LIFECYCLE_TRANSITIONS,
   type LifecycleErrorCode,
   type LifecycleEvidenceAccount,
@@ -928,6 +1144,8 @@ export {
   type LifecycleEvidenceSigningKey,
   type LifecycleEvidenceVerificationKey,
   type LifecycleEvidenceVerificationKeys,
+  type LifecycleMonotonicClock,
+  type LifecyclePlanLabel,
   LifecycleReplayDefenseError,
   type LifecycleReplayDefenseErrorCode,
   type LifecycleReplayEntry,


### PR DESCRIPTION
## Feature

Adds a Codex-first, dependency-free Ed25519 lifecycle-evidence protocol for gateway to trusted-server reconciliation. This is a protocol primitive only: it does not wire HTTP, Convex, environment configuration, credentials, keys, or deployment.

## Architecture

    authenticated gateway result
                 |
                 v
      closed server decision
      + exact field grammars
      + explicit transition matrix
                 |
                 v
      Ed25519 v1 signer (<=60s)
                 |
                 v
      canonical evidence envelope
                 |
                 v
    current/previous key verification
                 |
                 v
      schema + temporal validation
                 |
                 v
    atomic evidence/nonce/request consume
    + authoritative monotonic deadline
                 |
                 v
    exact owner/connection/request/
    transition/revision reconciliation

Only pending_to_connected may establish a credential and subscription-account projection. Error, expiry, revoking, revoked, and deleted transitions have explicit required-null/required-error rules and cannot introduce or replace credential handles.

## Security architecture

- strict fixed-order JSON and canonical unpadded base64url
- exact issuer/audience and field-specific Clerk/versioned UUID/key-id grammars
- closed ChatGPT plan and stable error enums; API-key accounts rejected
- null-prototype descriptor snapshots reject hostile prototypes, magic keys, symbols, accessors, and hidden properties
- current/previous Ed25519 key rotation only
- replay consumption binds evidenceId, nonce, and originating requestId atomically
- injected monotonic clock is checked before replay invocation and after sync/async settlement
- timeout, abort, late settlement, ambiguous store results, and blocked event-loop deadlines fail closed
- direct canaries cover token prefixes, paths, env syntax, URLs, encoded controls, and Unicode confusables in allowed fields
- every transition has required/null/forbidden/extra-field coverage

## Validation

- pnpm exec vitest run services/agent-gateway/lifecycle-evidence.test.ts (15 tests)
- pnpm test (74 files, 957 tests)
- pnpm typecheck
- pnpm lint (0 errors; 5 pre-existing warnings)
- pnpm format:check
- git diff --check

## Human gates

Live signing-key custody and rotation, issuer/audience configuration, durable cross-process replay storage, reconciliation transaction policy, persistent gateway hosting, deployment, database changes, and live Codex account/recovery validation remain explicitly human-gated. Claude remains deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added signed lifecycle evidence for Codex connections, including short-lived tokens, strict validation, key rotation, and replay protection.
  - Added support for verifying evidence against expected connection, request, provider, credential, and lifecycle details.
  - Added stable, secret-free error reporting for invalid, expired, mismatched, or replayed evidence.

- **Documentation**
  - Documented the lifecycle evidence protocol, validation rules, replay safeguards, and approval requirements.

- **Tests**
  - Added comprehensive coverage for signing, verification, expiration, rotation, metadata rules, security validation, concurrency, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->