### PR TITLE
feat(gateway): add encrypted connection store

### DIFF
--- a/docs/ENCRYPTED_CONNECTION_STORE.md
+++ b/docs/ENCRYPTED_CONNECTION_STORE.md
@@ -44,11 +44,15 @@ provider-owned bytes
 The KEK never encrypts credential bytes directly and the contract never exports
 it. A fresh 256-bit data-encryption key (DEK) encrypts each credential; the KEK
 wraps only that DEK. Passing a credential `Buffer` to `store` transfers
-ownership: the caller must not retain or reuse it, and the same buffer is
-cleared synchronously after encryption and before persistence is called. The
-DEK and nonce buffers are cleared on the same boundary. Decryption is available
-only inside `use`'s callback lifetime and is cleared in `finally`; a callback
-must not retain an alias and must clear any copy it creates.
+ownership immediately after the Buffer type check and before payload bounds or
+hostile metadata are inspected. The caller must not retain or reuse it. One
+outer clearing scope covers invalid metadata, empty/oversized input, randomness
+failure, collision, encryption failure, adapter error, and success. Valid input
+is therefore cleared synchronously after encryption and before persistence is
+called. Buffers returned by the injected randomness source transfer ownership
+under the same rule and are cleared on wrong size, rejection, or later failure.
+Decryption is available only inside `use`'s callback lifetime and is cleared in
+`finally`; a callback must not retain an alias and must clear any copy it creates.
 
 ## Versioned envelope and authenticated metadata
 
@@ -111,6 +115,26 @@ both decrypted payloads and digests are cleared synchronously. A same-id,
 different-payload collision is a stable conflict with no write. A different
 creation operation cannot overwrite a credential. Delete is idempotent when the
 record is absent, but refuses to delete a record that changed after the read.
+
+A create response can be lost after the adapter commits. The store retains only
+the prepared encrypted candidate across that await. On a rejected or malformed
+create outcome, it performs one read using the immutable identity, snapshots
+and authenticates the winning envelope, and compares its creation id and exact
+payload with the encrypted candidate. An exact committed write returns
+`already_created`; a different lineage or payload is a stable conflict. A
+missing, malformed, or unavailable reconciliation returns
+`persistence_unavailable` rather than guessing.
+
+The adapter must therefore provide read-after-write consistency for a create
+that committed before returning an ambiguous outcome. This is part of the
+persistent-adapter human gate and must be verified against the selected store.
+
+The transferred Buffer is zeroed regardless of that outcome. If the process
+terminates or reconciliation is unavailable, a later process must reacquire a
+fresh provider-owned credential Buffer for an idempotent retry; it must never
+reuse the zeroed Buffer or retain a plaintext recovery copy. The immutable
+creation id and payload binding make that fresh retry safe, including after key
+rotation.
 
 ## Rotation
 

--- a/docs/ENCRYPTED_CONNECTION_STORE.md
+++ b/docs/ENCRYPTED_CONNECTION_STORE.md
@@ -51,6 +51,8 @@ failure, collision, encryption failure, adapter error, and success. Valid input
 is therefore cleared synchronously after encryption and before persistence is
 called. Buffers returned by the injected randomness source transfer ownership
 under the same rule and are cleared on wrong size, rejection, or later failure.
+Length checks and clearing use captured typed-array intrinsics, so hostile own
+`byteLength`, `length`, or `fill` overrides cannot bypass or intercept cleanup.
 Decryption is available only inside `use`'s callback lifetime and is cleared in
 `finally`; a callback must not retain an alias and must clear any copy it creates.
 

--- a/docs/ENCRYPTED_CONNECTION_STORE.md
+++ b/docs/ENCRYPTED_CONNECTION_STORE.md
@@ -10,51 +10,91 @@ connection, and does not acquire or use a real credential.
 ```text
 provider-owned bytes
         |
+        | transfer ownership
         v
- bounded temporary copy -- clear --> AES-256-GCM
-                                      |       ^
- canonical AAD -----------------------+       |
-                                              |
- encrypted v1 envelope -> atomic persistence-+
+ fresh random DEK -> AES-256-GCM payload -> ciphertext + tag
+        |                    ^
+        |                    +-- canonical payload AAD
+        v
+ current versioned KEK -> AES-256-GCM wrap -> wrapped DEK + tag
+                                      ^
+                                      +-- canonical wrap AAD
+        |
+        +-- clear payload, DEK, and random buffers before any await
+        v
+ encrypted v1 envelope -> atomic persistence
       create-if-absent / CAS replace / CAS delete
 
- read -> strict envelope validation -> current|previous key -> decrypt
-                                                          -> callback -> clear
+ read -> strict snapshot/validation -> current|previous KEK -> unwrap DEK
+                                                              -> decrypt
+                                                              -> callback
+                                                              -> clear
 ```
 
 `EncryptedConnectionStore` accepts three injected capabilities:
 
 1. An atomic `EncryptedCredentialPersistence` implementation.
-2. One current 256-bit Node secret `KeyObject` and, during rotation, at most one
-   previous key.
-3. A nonce/revision source. The default uses Node's cryptographic randomness;
-   deterministic sources exist only for tests.
+2. One current 256-bit Node secret key-encryption key (KEK) `KeyObject` and,
+   during rotation, at most one previous KEK.
+3. A DEK/nonce/revision source. The default uses Node's cryptographic
+   randomness. The injected form exists to test fail-closed randomness paths;
+   a production host must use the default and must not supply a deterministic
+   implementation.
 
-The contract never asks a key to export its bytes. Plaintext is copied into a
-bounded temporary buffer for encryption and cleared in `finally`. Decryption is
-available only inside `use`'s callback lifetime; that buffer is also cleared in
-`finally`. A callback must not retain an alias and must clear any copy it makes.
+The KEK never encrypts credential bytes directly and the contract never exports
+it. A fresh 256-bit data-encryption key (DEK) encrypts each credential; the KEK
+wraps only that DEK. Passing a credential `Buffer` to `store` transfers
+ownership: the caller must not retain or reuse it, and the same buffer is
+cleared synchronously after encryption and before persistence is called. The
+DEK and nonce buffers are cleared on the same boundary. Decryption is available
+only inside `use`'s callback lifetime and is cleared in `finally`; a callback
+must not retain an alias and must clear any copy it creates.
 
 ## Versioned envelope and authenticated metadata
 
-Envelope version 1 uses AES-256-GCM with a 96-bit nonce and 128-bit tag. It
-persists ciphertext plus closed scalar metadata. Canonical AAD authenticates:
+Envelope version 1 uses independent AES-256-GCM invocations with 96-bit nonces
+and 128-bit tags for the payload and DEK wrap. It persists ciphertext, the
+wrapped DEK, and closed scalar metadata. Both canonical AAD layers authenticate:
 
 - envelope and algorithm version;
 - exact owner id;
 - provider (`codex` only in this phase);
 - gateway credential id;
 - provider-owned credential format version;
-- encryption key version;
-- mutation id; and
+- KEK version;
+- immutable creation operation id;
+- rotation sequence and optional last rotation operation id; and
 - record revision.
+
+The wrap layer additionally authenticates the payload nonce, authentication
+tag, and ciphertext digest. This prevents a wrapped DEK from being spliced onto
+a different payload envelope.
 
 Every object is exact-key validated. IDs, versions, nonce, tag, ciphertext, and
 plaintext have fixed or explicit upper bounds. Equivalent padded or malformed
-base64url encodings, custom prototypes, symbols, omitted fields, and extension
-fields fail closed. Store-generated errors use a closed code/message set and do
-not include adapter failures, ciphertext, plaintext, identifiers, or provider
-details.
+base64url encodings, custom prototypes, proxies, accessors, symbols, hidden or
+omitted fields, and extension fields fail closed. Inputs, records, and adapter
+outcomes are read once from data descriptors into fresh frozen plain snapshots;
+untrusted objects are never spread or read again after validation.
+Store-generated errors use a closed code/message set and do not include adapter
+failures, ciphertext, plaintext, identifiers, or provider details.
+
+## Randomness and invocation bounds
+
+The production default uses Node's CSPRNG for every DEK and nonce. All-zero
+material and a duplicate payload/wrap nonce within one envelope are rejected.
+The store retains bounded in-memory fingerprints to reject a repeated DEK or a
+repeated wrap nonce under its current KEK, and permits at most 65,536 KEK-wrap
+encryptions per store instance. Failed attempts consume their material rather
+than making it reusable. A payload-nonce repeat across records is harmless only
+because every record has a unique DEK and therefore a separate nonce domain.
+
+The in-memory ledger cannot prove uniqueness across independent processes or a
+restart. A production host must allocate the fleet's invocation budget, prevent
+simultaneous uncoordinated use of one KEK, and rotate before any instance or
+fleet budget is exhausted. The final persistent topology and KEK policy are
+human gates; until they enforce this invariant, this contract must not be used
+with production credentials.
 
 ## Atomicity and idempotency
 
@@ -65,10 +105,12 @@ The persistence adapter owns the actual transaction mechanism. It must provide:
 - atomic delete only when `recordRevision` still matches.
 
 Create retries are idempotent only when the existing authenticated record has
-the same mutation id. A different mutation cannot overwrite a credential.
-Delete is idempotent when the record is absent, but refuses to delete a record
-that changed after the read. These rules prevent a stale operation from
-overwriting or deleting a concurrent winner.
+the same immutable creation operation id and exact credential bytes. Payloads
+are compared through short-lived SHA-256 digests using a constant-time compare;
+both decrypted payloads and digests are cleared synchronously. A same-id,
+different-payload collision is a stable conflict with no write. A different
+creation operation cannot overwrite a credential. Delete is idempotent when the
+record is absent, but refuses to delete a record that changed after the read.
 
 ## Rotation
 
@@ -76,15 +118,19 @@ Normal reads accept the current key and the explicitly configured previous key.
 No other key version is tried. Rotation follows this sequence:
 
 ```text
-read previous-key record -> authenticate/decrypt -> encrypt with current key
-                           -> CAS old revision -> clear plaintext
+read previous-KEK record -> unwrap/decrypt -> fresh DEK + current KEK wrap
+                          -> clear plaintext/DEK -> CAS old revision
 ```
 
-A current-key record is an authenticated no-op. If a concurrent writer already
-completed the same transition, its current-key envelope is authenticated and
-accepted as the idempotent outcome. Any other CAS conflict fails closed. The
-previous key can be removed only after every retained envelope has been
-re-encrypted and that fact has been independently verified.
+A record preserves `creationOperationId` forever. Rotation has a separate
+`lastRotationOperationId` and monotonic bounded sequence, so a delayed create
+retry remains valid after re-encryption or restart. Reusing the creation id as a
+rotation id is rejected. A current-KEK record is an
+authenticated no-op. If a concurrent writer completed the same payload
+transition, its current-KEK envelope is authenticated and accepted; a changed
+payload or other CAS conflict fails closed. Current and previous labels cannot
+refer to equal key material. The previous KEK can be removed only after every
+retained envelope has been re-encrypted and independently verified.
 
 ## Human-gated production work
 

--- a/docs/ENCRYPTED_CONNECTION_STORE.md
+++ b/docs/ENCRYPTED_CONNECTION_STORE.md
@@ -1,0 +1,103 @@
+# Encrypted connection store contract
+
+The agent gateway now has a pure, injected contract for storing opaque Codex
+credential bundles. This is a cryptographic and persistence boundary, not a
+deployment: it reads no environment variables, opens no database or network
+connection, and does not acquire or use a real credential.
+
+## Architecture
+
+```text
+provider-owned bytes
+        |
+        v
+ bounded temporary copy -- clear --> AES-256-GCM
+                                      |       ^
+ canonical AAD -----------------------+       |
+                                              |
+ encrypted v1 envelope -> atomic persistence-+
+      create-if-absent / CAS replace / CAS delete
+
+ read -> strict envelope validation -> current|previous key -> decrypt
+                                                          -> callback -> clear
+```
+
+`EncryptedConnectionStore` accepts three injected capabilities:
+
+1. An atomic `EncryptedCredentialPersistence` implementation.
+2. One current 256-bit Node secret `KeyObject` and, during rotation, at most one
+   previous key.
+3. A nonce/revision source. The default uses Node's cryptographic randomness;
+   deterministic sources exist only for tests.
+
+The contract never asks a key to export its bytes. Plaintext is copied into a
+bounded temporary buffer for encryption and cleared in `finally`. Decryption is
+available only inside `use`'s callback lifetime; that buffer is also cleared in
+`finally`. A callback must not retain an alias and must clear any copy it makes.
+
+## Versioned envelope and authenticated metadata
+
+Envelope version 1 uses AES-256-GCM with a 96-bit nonce and 128-bit tag. It
+persists ciphertext plus closed scalar metadata. Canonical AAD authenticates:
+
+- envelope and algorithm version;
+- exact owner id;
+- provider (`codex` only in this phase);
+- gateway credential id;
+- provider-owned credential format version;
+- encryption key version;
+- mutation id; and
+- record revision.
+
+Every object is exact-key validated. IDs, versions, nonce, tag, ciphertext, and
+plaintext have fixed or explicit upper bounds. Equivalent padded or malformed
+base64url encodings, custom prototypes, symbols, omitted fields, and extension
+fields fail closed. Store-generated errors use a closed code/message set and do
+not include adapter failures, ciphertext, plaintext, identifiers, or provider
+details.
+
+## Atomicity and idempotency
+
+The persistence adapter owns the actual transaction mechanism. It must provide:
+
+- atomic create-if-absent, returning the winning record on conflict;
+- atomic replace only when `recordRevision` still matches; and
+- atomic delete only when `recordRevision` still matches.
+
+Create retries are idempotent only when the existing authenticated record has
+the same mutation id. A different mutation cannot overwrite a credential.
+Delete is idempotent when the record is absent, but refuses to delete a record
+that changed after the read. These rules prevent a stale operation from
+overwriting or deleting a concurrent winner.
+
+## Rotation
+
+Normal reads accept the current key and the explicitly configured previous key.
+No other key version is tried. Rotation follows this sequence:
+
+```text
+read previous-key record -> authenticate/decrypt -> encrypt with current key
+                           -> CAS old revision -> clear plaintext
+```
+
+A current-key record is an authenticated no-op. If a concurrent writer already
+completed the same transition, its current-key envelope is authenticated and
+accepted as the idempotent outcome. Any other CAS conflict fails closed. The
+previous key can be removed only after every retained envelope has been
+re-encrypted and that fact has been independently verified.
+
+## Human-gated production work
+
+This change deliberately does not choose or configure:
+
+- a KMS/HSM or production key generation, custody, recovery, and destruction
+  policy;
+- key-version allocation, rotation scheduling, or completion audit procedure;
+- a persistent database, transaction schema, backup policy, or retention
+  policy;
+- a gateway host or deployment topology; or
+- real Codex login, credential capture, migration, or provider execution.
+
+Those choices require human approval. A production adapter must be reviewed for
+the exact atomic semantics above before any environment, key, database,
+credential, host, or deployment is changed.

--- a/services/agent-gateway/README.md
+++ b/services/agent-gateway/README.md
@@ -10,8 +10,8 @@ dependency-free contracts include:
 - explicit current/previous verification-key overlap; and
 - bounded, fail-closed replay defense that consumes signed requests before
   expected-context validation;
-- a strict AES-256-GCM credential envelope whose complete identity and version
-  metadata is authenticated as AAD; and
+- a strict AES-256-GCM envelope with a fresh per-credential DEK, a versioned KEK
+  that wraps only that DEK, and two canonical authenticated-metadata layers; and
 - injected atomic create/CAS-replace/CAS-delete persistence for idempotent
   credential creation, re-encryption, and deletion.
 
@@ -20,17 +20,23 @@ Next.js issuer -> signed v1 assertion -> signature + time -> replay consume
                                                          -> context match
                                                          -> later gateway work
 
-Codex bundle -> bounded plaintext copy -> AES-256-GCM + canonical AAD
-                                      -> encrypted envelope -> atomic adapter
+Codex Buffer -- ownership transfer --> fresh DEK -> encrypted payload
+                                          |
+                                    versioned KEK -> wrapped DEK
+                                          |
+                              clear sensitive buffers before await
+                                          |
+                              encrypted envelope -> atomic adapter
 ```
 
 There is no HTTP listener, concrete credential database, provider execution,
 environment configuration, or deployment in this slice. See
 [the encrypted-store contract](../../docs/ENCRYPTED_CONNECTION_STORE.md) for
-the storage and rotation invariants. The persistent host and adapter,
-production key custody/rotation mechanism, durable replay-state topology,
-backup policy, and deployment remain explicit human gates. `BoundedReplayCache` is a
-deterministic test/local primitive only. Any real deployment must inject an
-atomic `ReplayDefense` whose lifecycle prevents reuse across process restarts;
-a multi-process deployment also requires shared replay state. Verification
-awaits the injected replay contract before evaluating expected request context.
+the storage, buffer-ownership, nonce-budget, and rotation invariants. The
+persistent host and adapter, fleet-wide invocation accounting, production key
+custody/rotation mechanism, durable replay-state topology, backup policy, and
+deployment remain explicit human gates. `BoundedReplayCache` is a deterministic
+test/local primitive only. Any real deployment must inject an atomic
+`ReplayDefense` whose lifecycle prevents reuse across process restarts; a
+multi-process deployment also requires shared replay state. Verification awaits
+the injected replay contract before evaluating expected request context.

--- a/services/agent-gateway/README.md
+++ b/services/agent-gateway/README.md
@@ -1,27 +1,35 @@
 # Agent gateway service boundary
 
 This directory starts the separately deployable Node 24 gateway defined by
-[ADR 0002](../../docs/adr/0002-subscription-connection-gateway.md). The first
-slice is intentionally limited to dependency-free internal request
-authentication primitives:
+[ADR 0002](../../docs/adr/0002-subscription-connection-gateway.md). Its current
+dependency-free contracts include:
 
 - Ed25519-signed, versioned, Codex-only assertions with a maximum 60-second
   lifetime;
 - exact issuer, audience, owner, connection, provider, and operation matching;
 - explicit current/previous verification-key overlap; and
 - bounded, fail-closed replay defense that consumes signed requests before
-  expected-context validation.
+  expected-context validation;
+- a strict AES-256-GCM credential envelope whose complete identity and version
+  metadata is authenticated as AAD; and
+- injected atomic create/CAS-replace/CAS-delete persistence for idempotent
+  credential creation, re-encryption, and deletion.
 
 ```text
 Next.js issuer -> signed v1 assertion -> signature + time -> replay consume
                                                          -> context match
                                                          -> later gateway work
+
+Codex bundle -> bounded plaintext copy -> AES-256-GCM + canonical AAD
+                                      -> encrypted envelope -> atomic adapter
 ```
 
-There is no HTTP listener, credential storage, provider execution, environment
-configuration, or deployment in this slice. The persistent host, production
-key custody/rotation mechanism, durable replay-state topology, backup policy,
-and deployment remain explicit human gates. `BoundedReplayCache` is a
+There is no HTTP listener, concrete credential database, provider execution,
+environment configuration, or deployment in this slice. See
+[the encrypted-store contract](../../docs/ENCRYPTED_CONNECTION_STORE.md) for
+the storage and rotation invariants. The persistent host and adapter,
+production key custody/rotation mechanism, durable replay-state topology,
+backup policy, and deployment remain explicit human gates. `BoundedReplayCache` is a
 deterministic test/local primitive only. Any real deployment must inject an
 atomic `ReplayDefense` whose lifecycle prevents reuse across process restarts;
 a multi-process deployment also requires shared replay state. Verification

--- a/services/agent-gateway/README.md
+++ b/services/agent-gateway/README.md
@@ -7,7 +7,7 @@ dependency-free contracts include:
 - Ed25519-signed, versioned, Codex-only assertions with a maximum 60-second
   lifetime;
 - exact issuer, audience, owner, connection, provider, and operation matching;
-- explicit current/previous verification-key overlap; and
+- explicit current/previous verification-key overlap;
 - bounded, fail-closed replay defense that consumes signed requests before
   expected-context validation;
 - a strict AES-256-GCM envelope with a fresh per-credential DEK, a versioned KEK
@@ -27,6 +27,8 @@ Codex Buffer -- ownership transfer --> fresh DEK -> encrypted payload
                               clear sensitive buffers before await
                                           |
                               encrypted envelope -> atomic adapter
+                                          |
+                          lost response -> read/authenticate/reconcile
 ```
 
 There is no HTTP listener, concrete credential database, provider execution,

--- a/services/agent-gateway/encrypted-connection-store.test.ts
+++ b/services/agent-gateway/encrypted-connection-store.test.ts
@@ -154,6 +154,7 @@ function deferred<T>() {
 /** Atomic in-memory adapter used only to exercise the injected contract. */
 class MemoryPersistence implements EncryptedCredentialPersistence {
   record: StoredCredentialEnvelope | null = null;
+  readFailure?: Error;
   beforeReplace?: () => void;
   beforeDelete?: () => void;
   createImplementation?: (
@@ -165,6 +166,7 @@ class MemoryPersistence implements EncryptedCredentialPersistence {
   ) => Promise<ReplaceCredentialResult>;
 
   async read(identity: CredentialIdentity) {
+    if (this.readFailure) throw this.readFailure;
     return this.matches(identity) ? this.record : null;
   }
 
@@ -261,7 +263,7 @@ async function readBytes(
   return store.use(identity, (payload) => Uint8Array.from(payload));
 }
 
-/** Stores one fresh Buffer and returns its pre-transfer bytes separately. */
+/** Stores one fresh Buffer whose ownership transfers to the store. */
 async function storeText(
   store: EncryptedConnectionStore,
   text = SECRET_CANARY,
@@ -581,6 +583,83 @@ describe("EncryptedConnectionStore idempotency, lineage, and concurrency", () =>
     });
   });
 
+  it("reconciles commit-then-throw and malformed-after-commit outcomes", async () => {
+    for (const outcome of ["throw", "malformed"] as const) {
+      const persistence = new MemoryPersistence();
+      persistence.createImplementation = async (record) => {
+        persistence.record = record;
+        if (outcome === "throw") throw new Error(SECRET_CANARY);
+        return {
+          status: "created",
+          extension: SECRET_CANARY,
+        } as unknown as CreateCredentialResult;
+      };
+      const { store } = createFixture({ persistence, seed: 105 });
+      const transferred = Buffer.from(SECRET_CANARY);
+
+      await expect(
+        store.store(CREATE_MUTATION, transferred)
+      ).resolves.toMatchObject({
+        status: "already_created",
+        recordRevision: persistence.record?.recordRevision,
+      });
+      expect(Array.from(transferred)).toEqual(
+        Array(SECRET_CANARY.length).fill(0)
+      );
+    }
+  });
+
+  it("denies ambiguous-create collisions against a different payload", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({ persistence, seed: 106 }).store.store(
+      CREATE_MUTATION,
+      Buffer.from("existing")
+    );
+    persistence.createImplementation = async () => {
+      throw new Error(SECRET_CANARY);
+    };
+    const retrying = createFixture({ persistence, seed: 107 }).store;
+    const transferred = Buffer.from("different");
+
+    await expect(
+      retrying.store(CREATE_MUTATION, transferred)
+    ).rejects.toMatchObject({ code: "credential_already_exists" });
+    expect(Array.from(transferred)).toEqual(Array("different".length).fill(0));
+  });
+
+  it("fails honestly when reconciliation is unavailable, then accepts a fresh restarted retry", async () => {
+    const persistence = new MemoryPersistence();
+    persistence.createImplementation = async (record) => {
+      persistence.record = record;
+      throw new Error(SECRET_CANARY);
+    };
+    persistence.readFailure = new Error(SECRET_CANARY);
+    const firstProcess = createFixture({ persistence, seed: 108 }).store;
+    const transferred = Buffer.from(SECRET_CANARY);
+
+    await expect(
+      firstProcess.store(CREATE_MUTATION, transferred)
+    ).rejects.toMatchObject({
+      code: "persistence_unavailable",
+      message: "Credential persistence is unavailable",
+    });
+    expect(Array.from(transferred)).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+
+    // A restarted process must obtain fresh provider bytes; it never reuses the
+    // transferred and zeroed Buffer from the ambiguous attempt.
+    persistence.readFailure = undefined;
+    persistence.createImplementation = undefined;
+    const restarted = createFixture({ persistence, seed: 109 }).store;
+    await expect(
+      restarted.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY))
+    ).resolves.toMatchObject({ status: "already_created" });
+    await expect(
+      restarted.store(CREATE_MUTATION, Buffer.from("collision"))
+    ).rejects.toMatchObject({ code: "credential_already_exists" });
+  });
+
   it("resolves concurrent same-operation creates only when payloads match", async () => {
     const persistence = new MemoryPersistence();
     const first = createFixture({ persistence, seed: 110 }).store;
@@ -657,6 +736,34 @@ describe("EncryptedConnectionStore idempotency, lineage, and concurrency", () =>
     await expect(
       restarted.store(CREATE_MUTATION, Buffer.from("different"))
     ).rejects.toMatchObject({ code: "credential_already_exists" });
+  });
+
+  it("reads previous-KEK records and authenticates direct current rotations", async () => {
+    const persistence = new MemoryPersistence();
+    const previousStore = createFixture({
+      persistence,
+      current: PREVIOUS_KEK,
+      seed: 172,
+    }).store;
+    await previousStore.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    const overlapStore = createFixture({
+      persistence,
+      current: CURRENT_KEK,
+      previous: PREVIOUS_KEK,
+      seed: 173,
+    }).store;
+    expect(Buffer.from(await readBytes(overlapStore)).toString()).toBe(
+      SECRET_CANARY
+    );
+
+    const currentStore = createFixture({ seed: 174 }).store;
+    await currentStore.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    await expect(currentStore.rotate(ROTATION_MUTATION)).resolves.toMatchObject(
+      {
+        status: "already_current",
+        keyVersion: CURRENT_KEK.keyVersion,
+      }
+    );
   });
 
   it("rejects reuse of the creation identity as a rotation identity", async () => {
@@ -768,7 +875,7 @@ describe("EncryptedConnectionStore idempotency, lineage, and concurrency", () =>
 });
 
 describe("EncryptedConnectionStore closed snapshots and errors", () => {
-  it("rejects accessors, proxies, symbols, hidden fields, and extensions", async () => {
+  it("clears canaries before rejecting hostile or invalid metadata", async () => {
     let getterCalls = 0;
     const accessor = { ...CREATE_MUTATION } as Record<string, unknown>;
     Object.defineProperty(accessor, "creationOperationId", {
@@ -797,13 +904,18 @@ describe("EncryptedConnectionStore closed snapshots and errors", () => {
         ...CREATE_MUTATION,
         creationOperationId: `mutation_v1_${"a".repeat(4_096)}`,
       },
+      { ...CREATE_MUTATION, provider: "claude" },
     ];
 
     for (const input of inputs) {
       const { store } = createFixture();
+      const transferred = Buffer.from(SECRET_CANARY);
       await expect(
-        store.store(input as CredentialCreateMutation, Buffer.from("x"))
+        store.store(input as CredentialCreateMutation, transferred)
       ).rejects.toMatchObject({ code: "invalid_input" });
+      expect(Array.from(transferred)).toEqual(
+        Array(SECRET_CANARY.length).fill(0)
+      );
     }
     expect(getterCalls).toBe(0);
   });
@@ -813,17 +925,95 @@ describe("EncryptedConnectionStore closed snapshots and errors", () => {
     await expect(
       store.store(CREATE_MUTATION, new Uint8Array([1]) as unknown as Buffer)
     ).rejects.toMatchObject({ code: "invalid_input" });
-    await expect(
-      store.store(CREATE_MUTATION, Buffer.alloc(0))
-    ).rejects.toMatchObject({
+    const empty = Buffer.alloc(0);
+    await expect(store.store(CREATE_MUTATION, empty)).rejects.toMatchObject({
       code: "invalid_input",
     });
-    const oversized = Buffer.alloc(MAX_CREDENTIAL_BYTES + 1, 1);
+    expect(empty).toHaveLength(0);
+    const oversized = Buffer.alloc(MAX_CREDENTIAL_BYTES + 1, 7);
     await expect(store.store(CREATE_MUTATION, oversized)).rejects.toMatchObject(
       {
         code: "invalid_input",
       }
     );
+    expect(oversized.every((byte) => byte === 0)).toBe(true);
+  });
+
+  it("clears every Buffer returned with a wrong random-source size", async () => {
+    for (const badField of ["dataKey", "payloadNonce", "wrapNonce"] as const) {
+      const returned: Buffer[] = [];
+      const make = (length: number, fill: number) => {
+        const value = Buffer.alloc(length, fill);
+        returned.push(value);
+        return value;
+      };
+      const source: CredentialRandomSource = Object.freeze({
+        dataKey: () =>
+          make(
+            badField === "dataKey" ? 31 : 32,
+            badField === "dataKey" ? 7 : 1
+          ),
+        payloadNonce: () =>
+          make(
+            badField === "payloadNonce" ? 11 : 12,
+            badField === "payloadNonce" ? 7 : 2
+          ),
+        wrapNonce: () =>
+          make(
+            badField === "wrapNonce" ? 11 : 12,
+            badField === "wrapNonce" ? 7 : 3
+          ),
+        recordRevision: () =>
+          "revision_v1_00000000-0000-4000-8000-000000000001",
+      });
+      const store = new EncryptedConnectionStore(
+        new MemoryPersistence(),
+        { current: CURRENT_KEK },
+        source
+      );
+      const transferred = Buffer.from(SECRET_CANARY);
+      await expect(
+        store.store(CREATE_MUTATION, transferred)
+      ).rejects.toMatchObject({ code: "internal_configuration_invalid" });
+      expect(Array.from(transferred)).toEqual(
+        Array(SECRET_CANARY.length).fill(0)
+      );
+      for (const buffer of returned) {
+        expect(buffer.every((byte) => byte === 0)).toBe(true);
+      }
+    }
+  });
+
+  it("clears all returned random Buffers when a later source step fails", async () => {
+    const returned = [
+      Buffer.alloc(32, 1),
+      Buffer.alloc(12, 2),
+      Buffer.alloc(12, 3),
+    ];
+    const source: CredentialRandomSource = Object.freeze({
+      dataKey: () => returned[0],
+      payloadNonce: () => returned[1],
+      wrapNonce: () => returned[2],
+      recordRevision: () => {
+        throw new Error(SECRET_CANARY);
+      },
+    });
+    const store = new EncryptedConnectionStore(
+      new MemoryPersistence(),
+      { current: CURRENT_KEK },
+      source
+    );
+    const transferred = Buffer.from(SECRET_CANARY);
+
+    await expect(
+      store.store(CREATE_MUTATION, transferred)
+    ).rejects.toMatchObject({ code: "internal_configuration_invalid" });
+    expect(Array.from(transferred)).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+    for (const buffer of returned) {
+      expect(buffer.every((byte) => byte === 0)).toBe(true);
+    }
   });
 
   it("snapshots adapter records and rejects accessors, proxies, and extras", async () => {

--- a/services/agent-gateway/encrypted-connection-store.test.ts
+++ b/services/agent-gateway/encrypted-connection-store.test.ts
@@ -1,0 +1,604 @@
+import { createSecretKey } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type CreateCredentialResult,
+  type CredentialEncryptionKey,
+  type CredentialIdentity,
+  type CredentialMutation,
+  type CredentialRandomSource,
+  CredentialStoreError,
+  type DeleteCredentialResult,
+  EncryptedConnectionStore,
+  type EncryptedCredentialPersistence,
+  MAX_CREDENTIAL_BYTES,
+  type ReplaceCredentialResult,
+  type StoredCredentialEnvelope,
+} from "./encrypted-connection-store.ts";
+
+const OWNER_ID = "user_0123456789ABCDEF";
+const OTHER_OWNER_ID = "user_FEDCBA9876543210";
+const CREDENTIAL_ID = "gwcred_v1_00000000-0000-4000-8000-000000000001";
+const OTHER_CREDENTIAL_ID = "gwcred_v1_00000000-0000-4000-8000-000000000002";
+const OPERATION_ID = "mutation_v1_00000000-0000-4000-8000-000000000001";
+const OTHER_OPERATION_ID = "mutation_v1_00000000-0000-4000-8000-000000000002";
+const SECRET_CANARY = "sk-secret-never-reflect";
+
+const IDENTITY: CredentialIdentity = Object.freeze({
+  ownerId: OWNER_ID,
+  provider: "codex",
+  credentialId: CREDENTIAL_ID,
+  credentialFormatVersion: 1,
+});
+const MUTATION: CredentialMutation = Object.freeze({
+  ...IDENTITY,
+  operationId: OPERATION_ID,
+});
+
+/** Creates a 256-bit secret KeyObject, then clears its construction buffer. */
+function createEncryptionKey(
+  keyVersion: string,
+  fill: number
+): CredentialEncryptionKey {
+  const bytes = Buffer.alloc(32, fill);
+  try {
+    return Object.freeze({ keyVersion, key: createSecretKey(bytes) });
+  } finally {
+    bytes.fill(0);
+  }
+}
+
+/** Produces unique valid nonces and revisions without ambient randomness. */
+function createRandomSource(seed = 1): CredentialRandomSource {
+  let sequence = seed;
+  return Object.freeze({
+    nonce: () => {
+      const nonce = Buffer.alloc(12);
+      nonce.writeUInt32BE(sequence, 8);
+      sequence += 1;
+      return nonce;
+    },
+    recordRevision: () => {
+      const suffix = sequence.toString(16).padStart(12, "0");
+      sequence += 1;
+      return `revision_v1_00000000-0000-4000-8000-${suffix}`;
+    },
+  });
+}
+
+/** Atomic in-memory adapter used only to prove the injected persistence contract. */
+class MemoryPersistence implements EncryptedCredentialPersistence {
+  record: StoredCredentialEnvelope | null = null;
+  beforeReplace?: () => void;
+  beforeDelete?: () => void;
+
+  async read(identity: CredentialIdentity) {
+    return this.matches(identity) ? this.record : null;
+  }
+
+  async create(
+    record: StoredCredentialEnvelope
+  ): Promise<CreateCredentialResult> {
+    if (this.record !== null) return { status: "exists", record: this.record };
+    this.record = record;
+    return { status: "created" };
+  }
+
+  async replace(
+    record: StoredCredentialEnvelope,
+    expectedRecordRevision: string
+  ): Promise<ReplaceCredentialResult> {
+    this.beforeReplace?.();
+    this.beforeReplace = undefined;
+    if (this.record === null) return { status: "missing" };
+    if (this.record.recordRevision !== expectedRecordRevision) {
+      return { status: "conflict", record: this.record };
+    }
+    this.record = record;
+    return { status: "replaced" };
+  }
+
+  async delete(
+    identity: CredentialIdentity,
+    expectedRecordRevision: string
+  ): Promise<DeleteCredentialResult> {
+    this.beforeDelete?.();
+    this.beforeDelete = undefined;
+    if (!this.matches(identity)) return { status: "missing" };
+    if (this.record?.recordRevision !== expectedRecordRevision) {
+      return {
+        status: "conflict",
+        record: this.record as StoredCredentialEnvelope,
+      };
+    }
+    this.record = null;
+    return { status: "deleted" };
+  }
+
+  /** Simulates an atomic writer that wins between read and CAS. */
+  replaceOutOfBand(record: StoredCredentialEnvelope): void {
+    this.record = record;
+  }
+
+  private matches(identity: CredentialIdentity): boolean {
+    return (
+      this.record !== null &&
+      this.record.ownerId === identity.ownerId &&
+      this.record.provider === identity.provider &&
+      this.record.credentialId === identity.credentialId &&
+      this.record.credentialFormatVersion === identity.credentialFormatVersion
+    );
+  }
+}
+
+const CURRENT_KEY = createEncryptionKey("encryption-v1-00000002", 2);
+const PREVIOUS_KEY = createEncryptionKey("encryption-v1-00000001", 1);
+
+/** Creates an isolated store fixture with deterministic randomness. */
+function createFixture(
+  options: Readonly<{
+    persistence?: MemoryPersistence;
+    current?: CredentialEncryptionKey;
+    previous?: CredentialEncryptionKey;
+    seed?: number;
+  }> = {}
+) {
+  const persistence = options.persistence ?? new MemoryPersistence();
+  const store = new EncryptedConnectionStore(
+    persistence,
+    {
+      current: options.current ?? CURRENT_KEY,
+      ...(options.previous ? { previous: options.previous } : {}),
+    },
+    createRandomSource(options.seed)
+  );
+  return { persistence, store };
+}
+
+/** Reads plaintext inside the store's bounded callback lifetime. */
+async function readBytes(
+  store: EncryptedConnectionStore,
+  identity: CredentialIdentity = IDENTITY
+): Promise<Uint8Array> {
+  return store.use(identity, (payload) => Uint8Array.from(payload));
+}
+
+describe("EncryptedConnectionStore", () => {
+  it("encrypts an opaque Codex bundle and never persists plaintext", async () => {
+    const { persistence, store } = createFixture();
+    const payload = Buffer.from(`{"access_token":"${SECRET_CANARY}"}`);
+
+    const result = await store.store(MUTATION, payload);
+
+    expect(result.status).toBe("created");
+    expect(persistence.record?.algorithm).toBe("aes-256-gcm");
+    expect(persistence.record?.envelopeVersion).toBe(1);
+    expect(JSON.stringify(persistence.record)).not.toContain(SECRET_CANARY);
+    expect(Buffer.from(await readBytes(store)).toString("utf8")).toBe(
+      payload.toString("utf8")
+    );
+    // The store copies caller-owned bytes and therefore never mutates its input.
+    expect(payload.toString("utf8")).toContain(SECRET_CANARY);
+    payload.fill(0);
+  });
+
+  it("supports arbitrary non-text provider-owned bytes", async () => {
+    const { store } = createFixture();
+    const payload = Uint8Array.from([0, 255, 1, 128, 2]);
+    await store.store(MUTATION, payload);
+    expect(await readBytes(store)).toEqual(payload);
+  });
+
+  it("clears callback-scoped plaintext after success and rejection", async () => {
+    const { store } = createFixture();
+    await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    let successfulAlias: Uint8Array | undefined;
+    await store.use(IDENTITY, (payload) => {
+      successfulAlias = payload;
+    });
+    expect(Array.from(successfulAlias ?? [])).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+
+    let rejectedAlias: Uint8Array | undefined;
+    await expect(
+      store.use(IDENTITY, (payload) => {
+        rejectedAlias = payload;
+        throw new Error(SECRET_CANARY);
+      })
+    ).rejects.toThrow(SECRET_CANARY);
+    expect(Array.from(rejectedAlias ?? [])).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+  });
+
+  it("binds identity, format, key version, operation, and revision as AAD", async () => {
+    const tamperCases: ReadonlyArray<
+      Readonly<{
+        patch: Partial<StoredCredentialEnvelope>;
+        identity?: CredentialIdentity;
+        expectedCode: string;
+      }>
+    > = [
+      {
+        patch: { ownerId: OTHER_OWNER_ID },
+        identity: { ...IDENTITY, ownerId: OTHER_OWNER_ID },
+        expectedCode: "decryption_failed",
+      },
+      {
+        patch: { credentialId: OTHER_CREDENTIAL_ID },
+        identity: { ...IDENTITY, credentialId: OTHER_CREDENTIAL_ID },
+        expectedCode: "decryption_failed",
+      },
+      {
+        patch: { credentialFormatVersion: 2 },
+        identity: { ...IDENTITY, credentialFormatVersion: 2 },
+        expectedCode: "decryption_failed",
+      },
+      {
+        patch: { keyVersion: PREVIOUS_KEY.keyVersion },
+        expectedCode: "key_unavailable",
+      },
+      {
+        patch: { operationId: OTHER_OPERATION_ID },
+        expectedCode: "decryption_failed",
+      },
+      {
+        patch: {
+          recordRevision: "revision_v1_00000000-0000-4000-8000-000000000099",
+        },
+        expectedCode: "decryption_failed",
+      },
+    ];
+
+    for (const testCase of tamperCases) {
+      const { persistence, store } = createFixture();
+      await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+      persistence.record = Object.freeze({
+        ...(persistence.record as StoredCredentialEnvelope),
+        ...testCase.patch,
+      });
+      await expect(
+        store.use(testCase.identity ?? IDENTITY, () => undefined)
+      ).rejects.toMatchObject({ code: testCase.expectedCode });
+    }
+  });
+
+  it("rejects tampered ciphertext, tag, and nonce with one stable error", async () => {
+    for (const field of ["ciphertext", "authTag", "nonce"] as const) {
+      const { persistence, store } = createFixture();
+      await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+      const record = persistence.record as StoredCredentialEnvelope;
+      const value = record[field];
+      persistence.record = Object.freeze({
+        ...record,
+        [field]: `${value.slice(0, -1)}${value.endsWith("A") ? "B" : "A"}`,
+      });
+      await expect(store.use(IDENTITY, () => undefined)).rejects.toMatchObject({
+        code: "decryption_failed",
+        message: "Credential record could not be decrypted",
+      });
+    }
+  });
+
+  it("accepts only a current and optional distinct previous 256-bit key", () => {
+    const persistence = new MemoryPersistence();
+    expect(
+      () =>
+        new EncryptedConnectionStore(persistence, {
+          current: CURRENT_KEY,
+          previous: CURRENT_KEY,
+        })
+    ).toThrowError(
+      expect.objectContaining({ code: "internal_configuration_invalid" })
+    );
+
+    const shortBytes = Buffer.alloc(16, 7);
+    const shortKey = createSecretKey(shortBytes);
+    shortBytes.fill(0);
+    expect(
+      () =>
+        new EncryptedConnectionStore(persistence, {
+          current: { keyVersion: "encryption-v1-00000003", key: shortKey },
+        })
+    ).toThrowError(
+      expect.objectContaining({ code: "internal_configuration_invalid" })
+    );
+  });
+
+  it("reads current and previous keys but rejects versions outside the overlap", async () => {
+    const persistence = new MemoryPersistence();
+    const oldStore = createFixture({
+      persistence,
+      current: PREVIOUS_KEY,
+      seed: 10,
+    }).store;
+    await oldStore.store(MUTATION, Buffer.from(SECRET_CANARY));
+
+    const overlapping = createFixture({
+      persistence,
+      current: CURRENT_KEY,
+      previous: PREVIOUS_KEY,
+      seed: 20,
+    }).store;
+    expect(Buffer.from(await readBytes(overlapping)).toString()).toBe(
+      SECRET_CANARY
+    );
+
+    const withoutPrevious = createFixture({ persistence }).store;
+    await expect(
+      withoutPrevious.use(IDENTITY, () => undefined)
+    ).rejects.toMatchObject({ code: "key_unavailable" });
+  });
+
+  it("re-encrypts previous-key records and makes current-key retries no-ops", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({
+      persistence,
+      current: PREVIOUS_KEY,
+      seed: 30,
+    }).store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    const originalCiphertext = persistence.record?.ciphertext;
+    const rotating = createFixture({
+      persistence,
+      current: CURRENT_KEY,
+      previous: PREVIOUS_KEY,
+      seed: 40,
+    }).store;
+
+    const rotated = await rotating.rotate({
+      ...MUTATION,
+      operationId: OTHER_OPERATION_ID,
+    });
+    expect(rotated.status).toBe("rotated");
+    expect(persistence.record?.keyVersion).toBe(CURRENT_KEY.keyVersion);
+    expect(persistence.record?.ciphertext).not.toBe(originalCiphertext);
+    expect(Buffer.from(await readBytes(rotating)).toString()).toBe(
+      SECRET_CANARY
+    );
+    await expect(rotating.rotate(MUTATION)).resolves.toMatchObject({
+      status: "already_current",
+      keyVersion: CURRENT_KEY.keyVersion,
+    });
+  });
+
+  it("makes same-operation creates idempotent and rejects a different operation", async () => {
+    const { persistence, store } = createFixture();
+    const first = await store.store(MUTATION, Buffer.from("first"));
+    const firstRecord = persistence.record;
+    const retry = await store.store(
+      MUTATION,
+      Buffer.from("ignored retry bytes")
+    );
+
+    expect(first.status).toBe("created");
+    expect(retry).toMatchObject({
+      status: "already_created",
+      recordRevision: first.recordRevision,
+    });
+    expect(persistence.record).toBe(firstRecord);
+    await expect(
+      store.store(
+        { ...MUTATION, operationId: OTHER_OPERATION_ID },
+        Buffer.from("replacement")
+      )
+    ).rejects.toMatchObject({ code: "credential_already_exists" });
+  });
+
+  it("atomically resolves concurrent same-operation creates to one record", async () => {
+    const persistence = new MemoryPersistence();
+    const first = createFixture({ persistence, seed: 50 }).store;
+    const second = createFixture({ persistence, seed: 60 }).store;
+
+    const results = await Promise.all([
+      first.store(MUTATION, Buffer.from("one")),
+      second.store(MUTATION, Buffer.from("two")),
+    ]);
+    expect(results.map((result) => result.status).sort()).toEqual([
+      "already_created",
+      "created",
+    ]);
+    expect(results[0].recordRevision).toBe(results[1].recordRevision);
+  });
+
+  it("treats a concurrent successful rotation as an idempotent outcome", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({
+      persistence,
+      current: PREVIOUS_KEY,
+      seed: 70,
+    }).store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    const winner = createFixture({
+      persistence: new MemoryPersistence(),
+      current: CURRENT_KEY,
+      seed: 80,
+    });
+    await winner.store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    const winnerRecord = winner.persistence.record as StoredCredentialEnvelope;
+    persistence.beforeReplace = () =>
+      persistence.replaceOutOfBand(winnerRecord);
+    const rotating = createFixture({
+      persistence,
+      current: CURRENT_KEY,
+      previous: PREVIOUS_KEY,
+      seed: 90,
+    }).store;
+
+    await expect(rotating.rotate(MUTATION)).resolves.toMatchObject({
+      status: "already_current",
+      recordRevision: winnerRecord.recordRevision,
+    });
+  });
+
+  it("rejects a concurrent non-rotation replacement", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({
+      persistence,
+      current: PREVIOUS_KEY,
+      seed: 100,
+    }).store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    const competingRecord = Object.freeze({
+      ...(persistence.record as StoredCredentialEnvelope),
+      recordRevision: "revision_v1_00000000-0000-4000-8000-000000000088",
+    });
+    persistence.beforeReplace = () =>
+      persistence.replaceOutOfBand(competingRecord);
+    const rotating = createFixture({
+      persistence,
+      current: CURRENT_KEY,
+      previous: PREVIOUS_KEY,
+      seed: 110,
+    }).store;
+
+    await expect(rotating.rotate(MUTATION)).rejects.toMatchObject({
+      code: "concurrent_modification",
+    });
+  });
+
+  it("deletes idempotently and never deletes a concurrently replaced record", async () => {
+    const { persistence, store } = createFixture();
+    await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    await expect(store.delete(IDENTITY)).resolves.toEqual({
+      status: "deleted",
+    });
+    await expect(store.delete(IDENTITY)).resolves.toEqual({
+      status: "already_deleted",
+    });
+
+    await store.store(
+      { ...MUTATION, operationId: OTHER_OPERATION_ID },
+      Buffer.from(SECRET_CANARY)
+    );
+    const replacement = Object.freeze({
+      ...(persistence.record as StoredCredentialEnvelope),
+      recordRevision: "revision_v1_00000000-0000-4000-8000-000000000077",
+    });
+    persistence.beforeDelete = () => persistence.replaceOutOfBand(replacement);
+    await expect(store.delete(IDENTITY)).rejects.toMatchObject({
+      code: "concurrent_modification",
+    });
+    expect(persistence.record).toBe(replacement);
+  });
+
+  it("strictly rejects oversized, empty, extended, and malformed inputs", async () => {
+    const { store } = createFixture();
+    await expect(store.store(MUTATION, new Uint8Array())).rejects.toMatchObject(
+      {
+        code: "invalid_input",
+      }
+    );
+    await expect(
+      store.store(MUTATION, new Uint8Array(MAX_CREDENTIAL_BYTES + 1))
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    await expect(
+      store.store(
+        { ...MUTATION, token: SECRET_CANARY } as CredentialMutation,
+        Buffer.from("x")
+      )
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    await expect(
+      store.store({ ...MUTATION, ownerId: "user_short" }, Buffer.from("x"))
+    ).rejects.toMatchObject({ code: "invalid_input" });
+  });
+
+  it("rejects malformed and extended persistence records before decryption", async () => {
+    for (const patch of [
+      { ciphertext: "not+padded=" },
+      { nonce: "A" },
+      { authTag: "A" },
+      { envelopeVersion: 2 },
+      { extra: SECRET_CANARY },
+    ]) {
+      const { persistence, store } = createFixture();
+      await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+      persistence.record = {
+        ...persistence.record,
+        ...patch,
+      } as unknown as StoredCredentialEnvelope;
+      await expect(store.use(IDENTITY, () => undefined)).rejects.toMatchObject({
+        code: "invalid_record",
+        message: "Credential record is invalid",
+      });
+    }
+  });
+
+  it("normalizes persistence failures without reflecting secret data", async () => {
+    const persistence: EncryptedCredentialPersistence = {
+      read: async () => {
+        throw new Error(SECRET_CANARY);
+      },
+      create: async () => {
+        throw new Error(SECRET_CANARY);
+      },
+      replace: async () => {
+        throw new Error(SECRET_CANARY);
+      },
+      delete: async () => {
+        throw new Error(SECRET_CANARY);
+      },
+    };
+    const store = new EncryptedConnectionStore(
+      persistence,
+      { current: CURRENT_KEY },
+      createRandomSource()
+    );
+
+    for (const operation of [
+      () => store.store(MUTATION, Buffer.from(SECRET_CANARY)),
+      () => store.use(IDENTITY, () => undefined),
+      () => store.rotate(MUTATION),
+      () => store.delete(IDENTITY),
+    ]) {
+      const error = await operation().catch((reason: unknown) => reason);
+      expect(error).toBeInstanceOf(CredentialStoreError);
+      expect(error).toMatchObject({
+        code: "persistence_unavailable",
+        message: "Credential persistence is unavailable",
+      });
+      expect(String(error)).not.toContain(SECRET_CANARY);
+    }
+  });
+
+  it("normalizes invalid or failing randomness without reflecting details", async () => {
+    for (const randomSource of [
+      {
+        nonce: () => {
+          throw new Error(SECRET_CANARY);
+        },
+        recordRevision: () =>
+          "revision_v1_00000000-0000-4000-8000-000000000001",
+      },
+      {
+        nonce: () => new Uint8Array(11),
+        recordRevision: () => SECRET_CANARY,
+      },
+    ]) {
+      const store = new EncryptedConnectionStore(
+        new MemoryPersistence(),
+        { current: CURRENT_KEY },
+        randomSource
+      );
+      const error = await store
+        .store(MUTATION, Buffer.from(SECRET_CANARY))
+        .catch((reason: unknown) => reason);
+      expect(error).toMatchObject({
+        code: "internal_configuration_invalid",
+        message: "Credential store configuration is invalid",
+      });
+      expect(String(error)).not.toContain(SECRET_CANARY);
+    }
+  });
+
+  it("fails closed on malformed adapter results", async () => {
+    const { persistence, store } = createFixture();
+    persistence.create = async () =>
+      ({
+        status: "created",
+        extension: true,
+      }) as unknown as CreateCredentialResult;
+    await expect(
+      store.store(MUTATION, Buffer.from(SECRET_CANARY))
+    ).rejects.toMatchObject({ code: "persistence_unavailable" });
+  });
+});

--- a/services/agent-gateway/encrypted-connection-store.test.ts
+++ b/services/agent-gateway/encrypted-connection-store.test.ts
@@ -1,13 +1,14 @@
 import { createSecretKey } from "node:crypto";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   type CreateCredentialResult,
-  type CredentialEncryptionKey,
+  type CredentialCreateMutation,
   type CredentialIdentity,
-  type CredentialMutation,
+  type CredentialKeyEncryptionKey,
   type CredentialRandomSource,
+  type CredentialRotationMutation,
   CredentialStoreError,
   type DeleteCredentialResult,
   EncryptedConnectionStore,
@@ -21,8 +22,11 @@ const OWNER_ID = "user_0123456789ABCDEF";
 const OTHER_OWNER_ID = "user_FEDCBA9876543210";
 const CREDENTIAL_ID = "gwcred_v1_00000000-0000-4000-8000-000000000001";
 const OTHER_CREDENTIAL_ID = "gwcred_v1_00000000-0000-4000-8000-000000000002";
-const OPERATION_ID = "mutation_v1_00000000-0000-4000-8000-000000000001";
-const OTHER_OPERATION_ID = "mutation_v1_00000000-0000-4000-8000-000000000002";
+const CREATE_OPERATION_ID = "mutation_v1_00000000-0000-4000-8000-000000000001";
+const OTHER_CREATE_OPERATION_ID =
+  "mutation_v1_00000000-0000-4000-8000-000000000002";
+const ROTATION_OPERATION_ID =
+  "mutation_v1_00000000-0000-4000-8000-000000000003";
 const SECRET_CANARY = "sk-secret-never-reflect";
 
 const IDENTITY: CredentialIdentity = Object.freeze({
@@ -31,16 +35,20 @@ const IDENTITY: CredentialIdentity = Object.freeze({
   credentialId: CREDENTIAL_ID,
   credentialFormatVersion: 1,
 });
-const MUTATION: CredentialMutation = Object.freeze({
+const CREATE_MUTATION: CredentialCreateMutation = Object.freeze({
   ...IDENTITY,
-  operationId: OPERATION_ID,
+  creationOperationId: CREATE_OPERATION_ID,
+});
+const ROTATION_MUTATION: CredentialRotationMutation = Object.freeze({
+  ...IDENTITY,
+  rotationOperationId: ROTATION_OPERATION_ID,
 });
 
 /** Creates a 256-bit secret KeyObject, then clears its construction buffer. */
-function createEncryptionKey(
+function createKek(
   keyVersion: string,
   fill: number
-): CredentialEncryptionKey {
+): CredentialKeyEncryptionKey {
   const bytes = Buffer.alloc(32, fill);
   try {
     return Object.freeze({ keyVersion, key: createSecretKey(bytes) });
@@ -49,29 +57,112 @@ function createEncryptionKey(
   }
 }
 
-/** Produces unique valid nonces and revisions without ambient randomness. */
-function createRandomSource(seed = 1): CredentialRandomSource {
-  let sequence = seed;
+const CURRENT_KEK = createKek("encryption-v1-00000002", 2);
+const PREVIOUS_KEK = createKek("encryption-v1-00000001", 1);
+
+/** Controllable CSPRNG-shaped source whose transferred buffers remain observable. */
+class TestRandomSource implements CredentialRandomSource {
+  readonly transferred: Buffer[] = [];
+  duplicateDataKey = false;
+  duplicateWrapNonce = false;
+  duplicateLayerNonces = false;
+  zeroDataKey = false;
+  zeroPayloadNonce = false;
+  zeroWrapNonce = false;
+  private sequence: number;
+  private firstDataKey?: Buffer;
+  private firstWrapNonce?: Buffer;
+
+  constructor(seed = 1) {
+    this.sequence = seed;
+  }
+
+  dataKey(): Buffer {
+    let value: Buffer;
+    if (this.zeroDataKey) {
+      value = Buffer.alloc(32);
+    } else if (this.duplicateDataKey && this.firstDataKey !== undefined) {
+      value = Buffer.from(this.firstDataKey);
+    } else {
+      value = Buffer.alloc(32, this.nextByte());
+      this.firstDataKey = Buffer.from(value);
+    }
+    this.transferred.push(value);
+    return value;
+  }
+
+  payloadNonce(): Buffer {
+    const value = this.zeroPayloadNonce
+      ? Buffer.alloc(12)
+      : Buffer.alloc(12, this.nextByte());
+    this.transferred.push(value);
+    return value;
+  }
+
+  wrapNonce(): Buffer {
+    let value: Buffer;
+    if (this.zeroWrapNonce) {
+      value = Buffer.alloc(12);
+    } else if (this.duplicateLayerNonces) {
+      const payloadNonce = this.transferred.at(-1);
+      value = Buffer.from(payloadNonce ?? Buffer.alloc(12));
+    } else if (this.duplicateWrapNonce && this.firstWrapNonce !== undefined) {
+      value = Buffer.from(this.firstWrapNonce);
+    } else {
+      value = Buffer.alloc(12, this.nextByte());
+      this.firstWrapNonce = Buffer.from(value);
+    }
+    this.transferred.push(value);
+    return value;
+  }
+
+  recordRevision(): string {
+    const suffix = this.sequence.toString(16).padStart(12, "0");
+    this.sequence += 1;
+    return `revision_v1_00000000-0000-4000-8000-${suffix}`;
+  }
+
+  /** Returns a nonzero deterministic byte for test-only cryptographic input. */
+  private nextByte(): number {
+    const value = (this.sequence % 254) + 1;
+    this.sequence += 1;
+    return value;
+  }
+}
+
+/** Exposes a class-backed test source through the production plain-data shape. */
+function randomSourceContract(
+  randomSource: TestRandomSource
+): CredentialRandomSource {
   return Object.freeze({
-    nonce: () => {
-      const nonce = Buffer.alloc(12);
-      nonce.writeUInt32BE(sequence, 8);
-      sequence += 1;
-      return nonce;
-    },
-    recordRevision: () => {
-      const suffix = sequence.toString(16).padStart(12, "0");
-      sequence += 1;
-      return `revision_v1_00000000-0000-4000-8000-${suffix}`;
-    },
+    dataKey: randomSource.dataKey.bind(randomSource),
+    payloadNonce: randomSource.payloadNonce.bind(randomSource),
+    wrapNonce: randomSource.wrapNonce.bind(randomSource),
+    recordRevision: randomSource.recordRevision.bind(randomSource),
   });
 }
 
-/** Atomic in-memory adapter used only to prove the injected persistence contract. */
+/** One-shot promise controller used to hold an adapter await open. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+/** Atomic in-memory adapter used only to exercise the injected contract. */
 class MemoryPersistence implements EncryptedCredentialPersistence {
   record: StoredCredentialEnvelope | null = null;
   beforeReplace?: () => void;
   beforeDelete?: () => void;
+  createImplementation?: (
+    record: StoredCredentialEnvelope
+  ) => Promise<CreateCredentialResult>;
+  replaceImplementation?: (
+    record: StoredCredentialEnvelope,
+    expectedRecordRevision: string
+  ) => Promise<ReplaceCredentialResult>;
 
   async read(identity: CredentialIdentity) {
     return this.matches(identity) ? this.record : null;
@@ -80,6 +171,7 @@ class MemoryPersistence implements EncryptedCredentialPersistence {
   async create(
     record: StoredCredentialEnvelope
   ): Promise<CreateCredentialResult> {
+    if (this.createImplementation) return this.createImplementation(record);
     if (this.record !== null) return { status: "exists", record: this.record };
     this.record = record;
     return { status: "created" };
@@ -89,6 +181,9 @@ class MemoryPersistence implements EncryptedCredentialPersistence {
     record: StoredCredentialEnvelope,
     expectedRecordRevision: string
   ): Promise<ReplaceCredentialResult> {
+    if (this.replaceImplementation) {
+      return this.replaceImplementation(record, expectedRecordRevision);
+    }
     this.beforeReplace?.();
     this.beforeReplace = undefined;
     if (this.record === null) return { status: "missing" };
@@ -132,31 +227,33 @@ class MemoryPersistence implements EncryptedCredentialPersistence {
   }
 }
 
-const CURRENT_KEY = createEncryptionKey("encryption-v1-00000002", 2);
-const PREVIOUS_KEY = createEncryptionKey("encryption-v1-00000001", 1);
-
-/** Creates an isolated store fixture with deterministic randomness. */
+/** Creates an isolated envelope-store fixture. */
 function createFixture(
   options: Readonly<{
     persistence?: MemoryPersistence;
-    current?: CredentialEncryptionKey;
-    previous?: CredentialEncryptionKey;
+    current?: CredentialKeyEncryptionKey;
+    previous?: CredentialKeyEncryptionKey;
+    randomSource?: TestRandomSource;
     seed?: number;
+    maxKekEncryptions?: number;
   }> = {}
 ) {
   const persistence = options.persistence ?? new MemoryPersistence();
+  const randomSource =
+    options.randomSource ?? new TestRandomSource(options.seed ?? 1);
   const store = new EncryptedConnectionStore(
     persistence,
     {
-      current: options.current ?? CURRENT_KEY,
+      current: options.current ?? CURRENT_KEK,
       ...(options.previous ? { previous: options.previous } : {}),
     },
-    createRandomSource(options.seed)
+    randomSourceContract(randomSource),
+    options.maxKekEncryptions
   );
-  return { persistence, store };
+  return { persistence, randomSource, store };
 }
 
-/** Reads plaintext inside the store's bounded callback lifetime. */
+/** Reads a copy during the bounded callback lifetime. */
 async function readBytes(
   store: EncryptedConnectionStore,
   identity: CredentialIdentity = IDENTITY
@@ -164,35 +261,108 @@ async function readBytes(
   return store.use(identity, (payload) => Uint8Array.from(payload));
 }
 
-describe("EncryptedConnectionStore", () => {
-  it("encrypts an opaque Codex bundle and never persists plaintext", async () => {
-    const { persistence, store } = createFixture();
-    const payload = Buffer.from(`{"access_token":"${SECRET_CANARY}"}`);
+/** Stores one fresh Buffer and returns its pre-transfer bytes separately. */
+async function storeText(
+  store: EncryptedConnectionStore,
+  text = SECRET_CANARY,
+  mutation: CredentialCreateMutation = CREATE_MUTATION
+) {
+  return store.store(mutation, Buffer.from(text));
+}
 
-    const result = await store.store(MUTATION, payload);
+/** Returns a structurally valid replacement with controlled scalar changes. */
+function patchRecord(
+  record: StoredCredentialEnvelope,
+  patch: Partial<StoredCredentialEnvelope>
+): StoredCredentialEnvelope {
+  return Object.freeze({ ...record, ...patch });
+}
 
-    expect(result.status).toBe("created");
-    expect(persistence.record?.algorithm).toBe("aes-256-gcm");
-    expect(persistence.record?.envelopeVersion).toBe(1);
-    expect(JSON.stringify(persistence.record)).not.toContain(SECRET_CANARY);
-    expect(Buffer.from(await readBytes(store)).toString("utf8")).toBe(
-      payload.toString("utf8")
+describe("EncryptedConnectionStore envelope encryption", () => {
+  it("encrypts every credential with a fresh DEK and wraps only that DEK", async () => {
+    const first = createFixture({ seed: 10 });
+    const second = createFixture({ seed: 20 });
+    await storeText(first.store);
+    await storeText(second.store);
+    const firstRecord = first.persistence.record as StoredCredentialEnvelope;
+    const secondRecord = second.persistence.record as StoredCredentialEnvelope;
+
+    expect(firstRecord.payloadAlgorithm).toBe("aes-256-gcm");
+    expect(firstRecord.keyWrapAlgorithm).toBe("aes-256-gcm");
+    expect(Buffer.from(firstRecord.wrappedDataKey, "base64url")).toHaveLength(
+      32
     );
-    // The store copies caller-owned bytes and therefore never mutates its input.
-    expect(payload.toString("utf8")).toContain(SECRET_CANARY);
-    payload.fill(0);
+    expect(firstRecord.wrappedDataKey).not.toBe(secondRecord.wrappedDataKey);
+    expect(firstRecord.ciphertext).not.toBe(secondRecord.ciphertext);
+    expect(JSON.stringify(firstRecord)).not.toContain(SECRET_CANARY);
+    expect(Buffer.from(await readBytes(first.store)).toString()).toBe(
+      SECRET_CANARY
+    );
   });
 
-  it("supports arbitrary non-text provider-owned bytes", async () => {
-    const { store } = createFixture();
-    const payload = Uint8Array.from([0, 255, 1, 128, 2]);
-    await store.store(MUTATION, payload);
-    expect(await readBytes(store)).toEqual(payload);
+  it("clears transferred plaintext, DEK, and nonces before create awaits", async () => {
+    const gate = deferred<CreateCredentialResult>();
+    const persistence = new MemoryPersistence();
+    let persisted: StoredCredentialEnvelope | undefined;
+    persistence.createImplementation = async (record) => {
+      persisted = record;
+      return gate.promise;
+    };
+    const { randomSource, store } = createFixture({ persistence, seed: 30 });
+    const transferredPlaintext = Buffer.from(SECRET_CANARY);
+
+    const pending = store.store(CREATE_MUTATION, transferredPlaintext);
+    await vi.waitFor(() => expect(persisted).toBeDefined());
+
+    expect(Array.from(transferredPlaintext)).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+    expect(randomSource.transferred).toHaveLength(3);
+    for (const transferred of randomSource.transferred) {
+      expect(Array.from(transferred)).toEqual(
+        Array(transferred.length).fill(0)
+      );
+    }
+    expect(JSON.stringify(persisted)).not.toContain(SECRET_CANARY);
+    gate.resolve({ status: "created" });
+    await expect(pending).resolves.toMatchObject({ status: "created" });
+  });
+
+  it("clears rotation material before CAS persistence awaits", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({
+      persistence,
+      current: PREVIOUS_KEK,
+      seed: 40,
+    }).store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    const gate = deferred<ReplaceCredentialResult>();
+    let replacement: StoredCredentialEnvelope | undefined;
+    persistence.replaceImplementation = async (record) => {
+      replacement = record;
+      return gate.promise;
+    };
+    const { randomSource, store } = createFixture({
+      persistence,
+      current: CURRENT_KEK,
+      previous: PREVIOUS_KEK,
+      seed: 50,
+    });
+
+    const pending = store.rotate(ROTATION_MUTATION);
+    await vi.waitFor(() => expect(replacement).toBeDefined());
+    for (const transferred of randomSource.transferred) {
+      expect(Array.from(transferred)).toEqual(
+        Array(transferred.length).fill(0)
+      );
+    }
+    expect(JSON.stringify(replacement)).not.toContain(SECRET_CANARY);
+    gate.resolve({ status: "replaced" });
+    await expect(pending).resolves.toMatchObject({ status: "rotated" });
   });
 
   it("clears callback-scoped plaintext after success and rejection", async () => {
     const { store } = createFixture();
-    await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    await storeText(store);
     let successfulAlias: Uint8Array | undefined;
     await store.use(IDENTITY, (payload) => {
       successfulAlias = payload;
@@ -213,66 +383,68 @@ describe("EncryptedConnectionStore", () => {
     );
   });
 
-  it("binds identity, format, key version, operation, and revision as AAD", async () => {
-    const tamperCases: ReadonlyArray<
+  it("binds identity, lineage, versions, and revisions to authenticated layers", async () => {
+    const cases: ReadonlyArray<
       Readonly<{
         patch: Partial<StoredCredentialEnvelope>;
         identity?: CredentialIdentity;
-        expectedCode: string;
+        previous?: CredentialKeyEncryptionKey;
       }>
     > = [
       {
         patch: { ownerId: OTHER_OWNER_ID },
         identity: { ...IDENTITY, ownerId: OTHER_OWNER_ID },
-        expectedCode: "decryption_failed",
       },
       {
         patch: { credentialId: OTHER_CREDENTIAL_ID },
         identity: { ...IDENTITY, credentialId: OTHER_CREDENTIAL_ID },
-        expectedCode: "decryption_failed",
       },
       {
         patch: { credentialFormatVersion: 2 },
         identity: { ...IDENTITY, credentialFormatVersion: 2 },
-        expectedCode: "decryption_failed",
       },
       {
-        patch: { keyVersion: PREVIOUS_KEY.keyVersion },
-        expectedCode: "key_unavailable",
+        patch: { keyVersion: PREVIOUS_KEK.keyVersion },
+        previous: PREVIOUS_KEK,
       },
-      {
-        patch: { operationId: OTHER_OPERATION_ID },
-        expectedCode: "decryption_failed",
-      },
+      { patch: { creationOperationId: OTHER_CREATE_OPERATION_ID } },
       {
         patch: {
           recordRevision: "revision_v1_00000000-0000-4000-8000-000000000099",
         },
-        expectedCode: "decryption_failed",
       },
     ];
 
-    for (const testCase of tamperCases) {
-      const { persistence, store } = createFixture();
-      await store.store(MUTATION, Buffer.from(SECRET_CANARY));
-      persistence.record = Object.freeze({
-        ...(persistence.record as StoredCredentialEnvelope),
-        ...testCase.patch,
+    for (const testCase of cases) {
+      const fixture = createFixture({
+        previous: testCase.previous,
+        seed: 60,
       });
+      await storeText(fixture.store);
+      fixture.persistence.record = patchRecord(
+        fixture.persistence.record as StoredCredentialEnvelope,
+        testCase.patch
+      );
       await expect(
-        store.use(testCase.identity ?? IDENTITY, () => undefined)
-      ).rejects.toMatchObject({ code: testCase.expectedCode });
+        fixture.store.use(testCase.identity ?? IDENTITY, () => undefined)
+      ).rejects.toMatchObject({ code: "decryption_failed" });
     }
   });
 
-  it("rejects tampered ciphertext, tag, and nonce with one stable error", async () => {
-    for (const field of ["ciphertext", "authTag", "nonce"] as const) {
-      const { persistence, store } = createFixture();
-      await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+  it("fails closed when payload or wrapped-DEK fields are tampered", async () => {
+    for (const field of [
+      "payloadNonce",
+      "ciphertext",
+      "payloadAuthTag",
+      "wrappedDataKey",
+      "wrapNonce",
+      "wrapAuthTag",
+    ] as const) {
+      const { persistence, store } = createFixture({ seed: 70 });
+      await storeText(store);
       const record = persistence.record as StoredCredentialEnvelope;
       const value = record[field];
-      persistence.record = Object.freeze({
-        ...record,
+      persistence.record = patchRecord(record, {
         [field]: `${value.slice(0, -1)}${value.endsWith("A") ? "B" : "A"}`,
       });
       await expect(store.use(IDENTITY, () => undefined)).rejects.toMatchObject({
@@ -281,184 +453,292 @@ describe("EncryptedConnectionStore", () => {
       });
     }
   });
+});
 
-  it("accepts only a current and optional distinct previous 256-bit key", () => {
-    const persistence = new MemoryPersistence();
+describe("EncryptedConnectionStore key and nonce safety", () => {
+  it("rejects current and previous KEK labels backed by identical material", () => {
+    const sameMaterial = createKek("encryption-v1-00000003", 2);
     expect(
       () =>
-        new EncryptedConnectionStore(persistence, {
-          current: CURRENT_KEY,
-          previous: CURRENT_KEY,
+        new EncryptedConnectionStore(new MemoryPersistence(), {
+          current: CURRENT_KEK,
+          previous: sameMaterial,
         })
     ).toThrowError(
       expect.objectContaining({ code: "internal_configuration_invalid" })
     );
+  });
 
+  it("accepts only distinct 256-bit KEKs with distinct versions", () => {
     const shortBytes = Buffer.alloc(16, 7);
     const shortKey = createSecretKey(shortBytes);
     shortBytes.fill(0);
     expect(
       () =>
-        new EncryptedConnectionStore(persistence, {
-          current: { keyVersion: "encryption-v1-00000003", key: shortKey },
+        new EncryptedConnectionStore(new MemoryPersistence(), {
+          current: {
+            keyVersion: "encryption-v1-00000003",
+            key: shortKey,
+          },
         })
     ).toThrowError(
       expect.objectContaining({ code: "internal_configuration_invalid" })
     );
   });
 
-  it("reads current and previous keys but rejects versions outside the overlap", async () => {
+  it("fails closed when a record's KEK version is outside the overlap", async () => {
     const persistence = new MemoryPersistence();
-    const oldStore = createFixture({
+    await createFixture({
       persistence,
-      current: PREVIOUS_KEY,
-      seed: 10,
-    }).store;
-    await oldStore.store(MUTATION, Buffer.from(SECRET_CANARY));
-
-    const overlapping = createFixture({
-      persistence,
-      current: CURRENT_KEY,
-      previous: PREVIOUS_KEY,
-      seed: 20,
-    }).store;
-    expect(Buffer.from(await readBytes(overlapping)).toString()).toBe(
-      SECRET_CANARY
-    );
-
-    const withoutPrevious = createFixture({ persistence }).store;
+      current: PREVIOUS_KEK,
+      seed: 75,
+    }).store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    const withoutPrevious = createFixture({ persistence, seed: 76 }).store;
     await expect(
       withoutPrevious.use(IDENTITY, () => undefined)
     ).rejects.toMatchObject({ code: "key_unavailable" });
   });
 
-  it("re-encrypts previous-key records and makes current-key retries no-ops", async () => {
-    const persistence = new MemoryPersistence();
-    await createFixture({
-      persistence,
-      current: PREVIOUS_KEY,
-      seed: 30,
-    }).store.store(MUTATION, Buffer.from(SECRET_CANARY));
-    const originalCiphertext = persistence.record?.ciphertext;
-    const rotating = createFixture({
-      persistence,
-      current: CURRENT_KEY,
-      previous: PREVIOUS_KEY,
-      seed: 40,
-    }).store;
-
-    const rotated = await rotating.rotate({
-      ...MUTATION,
-      operationId: OTHER_OPERATION_ID,
-    });
-    expect(rotated.status).toBe("rotated");
-    expect(persistence.record?.keyVersion).toBe(CURRENT_KEY.keyVersion);
-    expect(persistence.record?.ciphertext).not.toBe(originalCiphertext);
-    expect(Buffer.from(await readBytes(rotating)).toString()).toBe(
-      SECRET_CANARY
-    );
-    await expect(rotating.rotate(MUTATION)).resolves.toMatchObject({
-      status: "already_current",
-      keyVersion: CURRENT_KEY.keyVersion,
-    });
+  it("rejects all-zero DEKs and nonces plus duplicate layer nonces", async () => {
+    for (const configure of [
+      (source: TestRandomSource) => (source.zeroDataKey = true),
+      (source: TestRandomSource) => (source.zeroPayloadNonce = true),
+      (source: TestRandomSource) => (source.zeroWrapNonce = true),
+      (source: TestRandomSource) => (source.duplicateLayerNonces = true),
+    ]) {
+      const randomSource = new TestRandomSource(80);
+      configure(randomSource);
+      const { store } = createFixture({ randomSource });
+      await expect(storeText(store)).rejects.toMatchObject({
+        code: "internal_configuration_invalid",
+      });
+      for (const transferred of randomSource.transferred) {
+        expect(Array.from(transferred)).toEqual(
+          Array(transferred.length).fill(0)
+        );
+      }
+    }
   });
 
-  it("makes same-operation creates idempotent and rejects a different operation", async () => {
-    const { persistence, store } = createFixture();
-    const first = await store.store(MUTATION, Buffer.from("first"));
-    const firstRecord = persistence.record;
-    const retry = await store.store(
-      MUTATION,
-      Buffer.from("ignored retry bytes")
-    );
+  it("rejects repeated DEKs and wrap nonces within one bounded instance", async () => {
+    for (const duplicateField of [
+      "duplicateDataKey",
+      "duplicateWrapNonce",
+    ] as const) {
+      const persistence = new MemoryPersistence();
+      const randomSource = new TestRandomSource(90);
+      const { store } = createFixture({ persistence, randomSource });
+      await storeText(store);
+      persistence.record = null;
+      randomSource[duplicateField] = true;
+      await expect(
+        store.store(
+          {
+            ...CREATE_MUTATION,
+            creationOperationId: OTHER_CREATE_OPERATION_ID,
+          },
+          Buffer.from(SECRET_CANARY)
+        )
+      ).rejects.toMatchObject({ code: "internal_configuration_invalid" });
+    }
+  });
 
-    expect(first.status).toBe("created");
+  it("caps KEK encryption invocations per store instance", async () => {
+    const { persistence, store } = createFixture({ maxKekEncryptions: 1 });
+    await storeText(store);
+    persistence.record = null;
+    const secondPayload = Buffer.from(SECRET_CANARY);
+    await expect(
+      store.store(
+        {
+          ...CREATE_MUTATION,
+          creationOperationId: OTHER_CREATE_OPERATION_ID,
+        },
+        secondPayload
+      )
+    ).rejects.toMatchObject({ code: "internal_configuration_invalid" });
+    expect(Array.from(secondPayload)).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+  });
+});
+
+describe("EncryptedConnectionStore idempotency, lineage, and concurrency", () => {
+  it("requires same-operation create retries to contain identical bytes", async () => {
+    const { persistence, store } = createFixture({ seed: 100 });
+    const first = await storeText(store, "first");
+    const firstRecord = persistence.record;
+    const retry = await storeText(store, "first");
     expect(retry).toMatchObject({
       status: "already_created",
       recordRevision: first.recordRevision,
     });
     expect(persistence.record).toBe(firstRecord);
-    await expect(
-      store.store(
-        { ...MUTATION, operationId: OTHER_OPERATION_ID },
-        Buffer.from("replacement")
-      )
-    ).rejects.toMatchObject({ code: "credential_already_exists" });
+
+    await expect(storeText(store, "different")).rejects.toMatchObject({
+      code: "credential_already_exists",
+      message: "Credential record already exists",
+    });
   });
 
-  it("atomically resolves concurrent same-operation creates to one record", async () => {
+  it("resolves concurrent same-operation creates only when payloads match", async () => {
     const persistence = new MemoryPersistence();
-    const first = createFixture({ persistence, seed: 50 }).store;
-    const second = createFixture({ persistence, seed: 60 }).store;
-
-    const results = await Promise.all([
-      first.store(MUTATION, Buffer.from("one")),
-      second.store(MUTATION, Buffer.from("two")),
+    const first = createFixture({ persistence, seed: 110 }).store;
+    const second = createFixture({ persistence, seed: 120 }).store;
+    const sameResults = await Promise.all([
+      storeText(first, "same"),
+      storeText(second, "same"),
     ]);
-    expect(results.map((result) => result.status).sort()).toEqual([
+    expect(sameResults.map((result) => result.status).sort()).toEqual([
       "already_created",
       "created",
     ]);
-    expect(results[0].recordRevision).toBe(results[1].recordRevision);
-  });
 
-  it("treats a concurrent successful rotation as an idempotent outcome", async () => {
-    const persistence = new MemoryPersistence();
-    await createFixture({
-      persistence,
-      current: PREVIOUS_KEY,
-      seed: 70,
-    }).store.store(MUTATION, Buffer.from(SECRET_CANARY));
+    const collisionPersistence = new MemoryPersistence();
     const winner = createFixture({
-      persistence: new MemoryPersistence(),
-      current: CURRENT_KEY,
-      seed: 80,
-    });
-    await winner.store.store(MUTATION, Buffer.from(SECRET_CANARY));
-    const winnerRecord = winner.persistence.record as StoredCredentialEnvelope;
-    persistence.beforeReplace = () =>
-      persistence.replaceOutOfBand(winnerRecord);
-    const rotating = createFixture({
-      persistence,
-      current: CURRENT_KEY,
-      previous: PREVIOUS_KEY,
-      seed: 90,
+      persistence: collisionPersistence,
+      seed: 130,
     }).store;
-
-    await expect(rotating.rotate(MUTATION)).resolves.toMatchObject({
-      status: "already_current",
-      recordRevision: winnerRecord.recordRevision,
-    });
+    const loser = createFixture({
+      persistence: collisionPersistence,
+      seed: 140,
+    }).store;
+    const collisions = await Promise.allSettled([
+      storeText(winner, "one"),
+      storeText(loser, "two"),
+    ]);
+    expect(
+      collisions.filter((result) => result.status === "fulfilled")
+    ).toHaveLength(1);
+    expect(
+      collisions.filter((result) => result.status === "rejected")
+    ).toHaveLength(1);
+    expect(
+      (
+        collisions.find(
+          (result) => result.status === "rejected"
+        ) as PromiseRejectedResult
+      ).reason
+    ).toMatchObject({ code: "credential_already_exists" });
   });
 
-  it("rejects a concurrent non-rotation replacement", async () => {
+  it("preserves immutable create lineage through rotation and restarts", async () => {
     const persistence = new MemoryPersistence();
     await createFixture({
       persistence,
-      current: PREVIOUS_KEY,
-      seed: 100,
-    }).store.store(MUTATION, Buffer.from(SECRET_CANARY));
-    const competingRecord = Object.freeze({
-      ...(persistence.record as StoredCredentialEnvelope),
-      recordRevision: "revision_v1_00000000-0000-4000-8000-000000000088",
-    });
-    persistence.beforeReplace = () =>
-      persistence.replaceOutOfBand(competingRecord);
+      current: PREVIOUS_KEK,
+      seed: 150,
+    }).store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
     const rotating = createFixture({
       persistence,
-      current: CURRENT_KEY,
-      previous: PREVIOUS_KEY,
-      seed: 110,
+      current: CURRENT_KEK,
+      previous: PREVIOUS_KEK,
+      seed: 160,
+    }).store;
+    await expect(rotating.rotate(ROTATION_MUTATION)).resolves.toMatchObject({
+      status: "rotated",
+    });
+    expect(persistence.record).toMatchObject({
+      creationOperationId: CREATE_OPERATION_ID,
+      lastRotationOperationId: ROTATION_OPERATION_ID,
+      rotationSequence: 1,
+      keyVersion: CURRENT_KEK.keyVersion,
+    });
+
+    const restarted = createFixture({
+      persistence,
+      current: CURRENT_KEK,
+      previous: PREVIOUS_KEK,
+      seed: 170,
+    }).store;
+    await expect(
+      restarted.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY))
+    ).resolves.toMatchObject({ status: "already_created" });
+    await expect(
+      restarted.store(CREATE_MUTATION, Buffer.from("different"))
+    ).rejects.toMatchObject({ code: "credential_already_exists" });
+  });
+
+  it("rejects reuse of the creation identity as a rotation identity", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({
+      persistence,
+      current: PREVIOUS_KEK,
+      seed: 175,
+    }).store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    const rotating = createFixture({
+      persistence,
+      current: CURRENT_KEK,
+      previous: PREVIOUS_KEK,
+      seed: 176,
     }).store;
 
-    await expect(rotating.rotate(MUTATION)).rejects.toMatchObject({
+    await expect(
+      rotating.rotate({
+        ...IDENTITY,
+        rotationOperationId: CREATE_OPERATION_ID,
+      })
+    ).rejects.toMatchObject({ code: "invalid_input" });
+  });
+
+  it("treats a concurrent equivalent rotation as idempotent", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({
+      persistence,
+      current: PREVIOUS_KEK,
+      seed: 180,
+    }).store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    const winnerPersistence = new MemoryPersistence();
+    await createFixture({
+      persistence: winnerPersistence,
+      seed: 190,
+    }).store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    const winner = winnerPersistence.record as StoredCredentialEnvelope;
+    persistence.beforeReplace = () => persistence.replaceOutOfBand(winner);
+    const rotating = createFixture({
+      persistence,
+      current: CURRENT_KEK,
+      previous: PREVIOUS_KEK,
+      seed: 200,
+    }).store;
+
+    await expect(rotating.rotate(ROTATION_MUTATION)).resolves.toMatchObject({
+      status: "already_current",
+      recordRevision: winner.recordRevision,
+    });
+  });
+
+  it("rejects a concurrent current-key record with different payload", async () => {
+    const persistence = new MemoryPersistence();
+    await createFixture({
+      persistence,
+      current: PREVIOUS_KEK,
+      seed: 210,
+    }).store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY));
+    const competingPersistence = new MemoryPersistence();
+    await createFixture({
+      persistence: competingPersistence,
+      seed: 220,
+    }).store.store(CREATE_MUTATION, Buffer.from("different"));
+    persistence.beforeReplace = () =>
+      persistence.replaceOutOfBand(
+        competingPersistence.record as StoredCredentialEnvelope
+      );
+    const rotating = createFixture({
+      persistence,
+      current: CURRENT_KEK,
+      previous: PREVIOUS_KEK,
+      seed: 230,
+    }).store;
+
+    await expect(rotating.rotate(ROTATION_MUTATION)).rejects.toMatchObject({
       code: "concurrent_modification",
     });
   });
 
-  it("deletes idempotently and never deletes a concurrently replaced record", async () => {
-    const { persistence, store } = createFixture();
-    await store.store(MUTATION, Buffer.from(SECRET_CANARY));
+  it("deletes idempotently and never deletes a concurrent replacement", async () => {
+    const { persistence, store } = createFixture({ seed: 240 });
+    await storeText(store);
     await expect(store.delete(IDENTITY)).resolves.toEqual({
       status: "deleted",
     });
@@ -467,63 +747,172 @@ describe("EncryptedConnectionStore", () => {
     });
 
     await store.store(
-      { ...MUTATION, operationId: OTHER_OPERATION_ID },
+      {
+        ...CREATE_MUTATION,
+        creationOperationId: OTHER_CREATE_OPERATION_ID,
+      },
       Buffer.from(SECRET_CANARY)
     );
-    const replacement = Object.freeze({
-      ...(persistence.record as StoredCredentialEnvelope),
-      recordRevision: "revision_v1_00000000-0000-4000-8000-000000000077",
-    });
+    const replacement = patchRecord(
+      persistence.record as StoredCredentialEnvelope,
+      {
+        recordRevision: "revision_v1_00000000-0000-4000-8000-000000000077",
+      }
+    );
     persistence.beforeDelete = () => persistence.replaceOutOfBand(replacement);
     await expect(store.delete(IDENTITY)).rejects.toMatchObject({
       code: "concurrent_modification",
     });
     expect(persistence.record).toBe(replacement);
   });
+});
 
-  it("strictly rejects oversized, empty, extended, and malformed inputs", async () => {
+describe("EncryptedConnectionStore closed snapshots and errors", () => {
+  it("rejects accessors, proxies, symbols, hidden fields, and extensions", async () => {
+    let getterCalls = 0;
+    const accessor = { ...CREATE_MUTATION } as Record<string, unknown>;
+    Object.defineProperty(accessor, "creationOperationId", {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1;
+        return getterCalls === 1 ? CREATE_OPERATION_ID : SECRET_CANARY;
+      },
+    });
+    const symbol = Object.assign(
+      { ...CREATE_MUTATION },
+      { [Symbol("secret")]: SECRET_CANARY }
+    );
+    const hidden = { ...CREATE_MUTATION };
+    Object.defineProperty(hidden, "hidden", {
+      enumerable: false,
+      value: SECRET_CANARY,
+    });
+    const inputs = [
+      accessor,
+      new Proxy({ ...CREATE_MUTATION }, {}),
+      symbol,
+      hidden,
+      { ...CREATE_MUTATION, token: SECRET_CANARY },
+      {
+        ...CREATE_MUTATION,
+        creationOperationId: `mutation_v1_${"a".repeat(4_096)}`,
+      },
+    ];
+
+    for (const input of inputs) {
+      const { store } = createFixture();
+      await expect(
+        store.store(input as CredentialCreateMutation, Buffer.from("x"))
+      ).rejects.toMatchObject({ code: "invalid_input" });
+    }
+    expect(getterCalls).toBe(0);
+  });
+
+  it("rejects non-Buffer, empty, and oversized transferred payloads", async () => {
     const { store } = createFixture();
-    await expect(store.store(MUTATION, new Uint8Array())).rejects.toMatchObject(
+    await expect(
+      store.store(CREATE_MUTATION, new Uint8Array([1]) as unknown as Buffer)
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    await expect(
+      store.store(CREATE_MUTATION, Buffer.alloc(0))
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+    });
+    const oversized = Buffer.alloc(MAX_CREDENTIAL_BYTES + 1, 1);
+    await expect(store.store(CREATE_MUTATION, oversized)).rejects.toMatchObject(
       {
         code: "invalid_input",
       }
     );
-    await expect(
-      store.store(MUTATION, new Uint8Array(MAX_CREDENTIAL_BYTES + 1))
-    ).rejects.toMatchObject({ code: "invalid_input" });
-    await expect(
-      store.store(
-        { ...MUTATION, token: SECRET_CANARY } as CredentialMutation,
-        Buffer.from("x")
-      )
-    ).rejects.toMatchObject({ code: "invalid_input" });
-    await expect(
-      store.store({ ...MUTATION, ownerId: "user_short" }, Buffer.from("x"))
-    ).rejects.toMatchObject({ code: "invalid_input" });
   });
 
-  it("rejects malformed and extended persistence records before decryption", async () => {
-    for (const patch of [
-      { ciphertext: "not+padded=" },
-      { nonce: "A" },
-      { authTag: "A" },
-      { envelopeVersion: 2 },
-      { extra: SECRET_CANARY },
+  it("snapshots adapter records and rejects accessors, proxies, and extras", async () => {
+    let getterCalls = 0;
+    for (const mutate of [
+      (record: StoredCredentialEnvelope) => {
+        const accessor = { ...record } as Record<string, unknown>;
+        Object.defineProperty(accessor, "creationOperationId", {
+          enumerable: true,
+          get: () => {
+            getterCalls += 1;
+            return getterCalls === 1 ? CREATE_OPERATION_ID : SECRET_CANARY;
+          },
+        });
+        return accessor;
+      },
+      (record: StoredCredentialEnvelope) => new Proxy({ ...record }, {}),
+      (record: StoredCredentialEnvelope) => ({
+        ...record,
+        token: SECRET_CANARY,
+      }),
+      (record: StoredCredentialEnvelope) => {
+        const hidden = { ...record };
+        Object.defineProperty(hidden, "hidden", {
+          enumerable: false,
+          value: SECRET_CANARY,
+        });
+        return hidden;
+      },
     ]) {
-      const { persistence, store } = createFixture();
-      await store.store(MUTATION, Buffer.from(SECRET_CANARY));
-      persistence.record = {
-        ...persistence.record,
-        ...patch,
-      } as unknown as StoredCredentialEnvelope;
+      const { persistence, store } = createFixture({ seed: 250 });
+      await storeText(store);
+      persistence.record = mutate(
+        persistence.record as StoredCredentialEnvelope
+      ) as StoredCredentialEnvelope;
       await expect(store.use(IDENTITY, () => undefined)).rejects.toMatchObject({
         code: "invalid_record",
         message: "Credential record is invalid",
       });
     }
+    expect(getterCalls).toBe(0);
   });
 
-  it("normalizes persistence failures without reflecting secret data", async () => {
+  it("rejects malformed and over-bounds persisted fields", async () => {
+    for (const patch of [
+      { ciphertext: "not+padded=" },
+      { payloadNonce: "A" },
+      { wrappedDataKey: "A" },
+      { ciphertext: "A".repeat(1_398_103) },
+      { rotationSequence: 65_536 },
+      { envelopeVersion: 2 },
+    ]) {
+      const { persistence, store } = createFixture({ seed: 260 });
+      await storeText(store);
+      persistence.record = patchRecord(
+        persistence.record as StoredCredentialEnvelope,
+        patch as Partial<StoredCredentialEnvelope>
+      );
+      await expect(store.use(IDENTITY, () => undefined)).rejects.toMatchObject({
+        code: "invalid_record",
+      });
+    }
+  });
+
+  it("rejects proxy and accessor persistence outcomes without invoking getters", async () => {
+    let getterCalls = 0;
+    for (const result of [
+      new Proxy({ status: "created" }, {}),
+      Object.defineProperty({}, "status", {
+        enumerable: true,
+        get: () => {
+          getterCalls += 1;
+          return "created";
+        },
+      }),
+      { status: "created", extension: SECRET_CANARY },
+    ]) {
+      const persistence = new MemoryPersistence();
+      persistence.createImplementation = async () =>
+        result as unknown as CreateCredentialResult;
+      const { store } = createFixture({ persistence });
+      await expect(storeText(store)).rejects.toMatchObject({
+        code: "persistence_unavailable",
+      });
+    }
+    expect(getterCalls).toBe(0);
+  });
+
+  it("normalizes adapter and random-source failures without reflecting secrets", async () => {
     const persistence: EncryptedCredentialPersistence = {
       read: async () => {
         throw new Error(SECRET_CANARY);
@@ -540,14 +929,13 @@ describe("EncryptedConnectionStore", () => {
     };
     const store = new EncryptedConnectionStore(
       persistence,
-      { current: CURRENT_KEY },
-      createRandomSource()
+      { current: CURRENT_KEK },
+      randomSourceContract(new TestRandomSource())
     );
-
     for (const operation of [
-      () => store.store(MUTATION, Buffer.from(SECRET_CANARY)),
+      () => store.store(CREATE_MUTATION, Buffer.from(SECRET_CANARY)),
       () => store.use(IDENTITY, () => undefined),
-      () => store.rotate(MUTATION),
+      () => store.rotate(ROTATION_MUTATION),
       () => store.delete(IDENTITY),
     ]) {
       const error = await operation().catch((reason: unknown) => reason);
@@ -558,47 +946,27 @@ describe("EncryptedConnectionStore", () => {
       });
       expect(String(error)).not.toContain(SECRET_CANARY);
     }
-  });
 
-  it("normalizes invalid or failing randomness without reflecting details", async () => {
-    for (const randomSource of [
-      {
-        nonce: () => {
-          throw new Error(SECRET_CANARY);
-        },
-        recordRevision: () =>
-          "revision_v1_00000000-0000-4000-8000-000000000001",
+    const failingRandomSource: CredentialRandomSource = Object.freeze({
+      dataKey: () => {
+        throw new Error(SECRET_CANARY);
       },
-      {
-        nonce: () => new Uint8Array(11),
-        recordRevision: () => SECRET_CANARY,
-      },
-    ]) {
-      const store = new EncryptedConnectionStore(
-        new MemoryPersistence(),
-        { current: CURRENT_KEY },
-        randomSource
-      );
-      const error = await store
-        .store(MUTATION, Buffer.from(SECRET_CANARY))
-        .catch((reason: unknown) => reason);
-      expect(error).toMatchObject({
-        code: "internal_configuration_invalid",
-        message: "Credential store configuration is invalid",
-      });
-      expect(String(error)).not.toContain(SECRET_CANARY);
-    }
-  });
-
-  it("fails closed on malformed adapter results", async () => {
-    const { persistence, store } = createFixture();
-    persistence.create = async () =>
-      ({
-        status: "created",
-        extension: true,
-      }) as unknown as CreateCredentialResult;
-    await expect(
-      store.store(MUTATION, Buffer.from(SECRET_CANARY))
-    ).rejects.toMatchObject({ code: "persistence_unavailable" });
+      payloadNonce: () => Buffer.alloc(12, 1),
+      wrapNonce: () => Buffer.alloc(12, 2),
+      recordRevision: () => "revision_v1_00000000-0000-4000-8000-000000000001",
+    });
+    const randomStore = new EncryptedConnectionStore(
+      new MemoryPersistence(),
+      { current: CURRENT_KEK },
+      failingRandomSource
+    );
+    const error = await randomStore
+      .store(CREATE_MUTATION, Buffer.from(SECRET_CANARY))
+      .catch((reason: unknown) => reason);
+    expect(error).toMatchObject({
+      code: "internal_configuration_invalid",
+      message: "Credential store configuration is invalid",
+    });
+    expect(String(error)).not.toContain(SECRET_CANARY);
   });
 });

--- a/services/agent-gateway/encrypted-connection-store.test.ts
+++ b/services/agent-gateway/encrypted-connection-store.test.ts
@@ -280,6 +280,36 @@ function patchRecord(
   return Object.freeze({ ...record, ...patch });
 }
 
+/** Adds hostile own overrides while retaining a native view for zero checks. */
+function overrideBufferSurface(buffer: Buffer) {
+  const nativeView = new Uint8Array(
+    buffer.buffer,
+    buffer.byteOffset,
+    buffer.byteLength
+  );
+  let overrideCalls = 0;
+  for (const property of ["byteLength", "length"] as const) {
+    Object.defineProperty(buffer, property, {
+      configurable: true,
+      get: () => {
+        overrideCalls += 1;
+        throw new Error(`${property} override must not run`);
+      },
+    });
+  }
+  Object.defineProperty(buffer, "fill", {
+    configurable: true,
+    value: () => {
+      overrideCalls += 1;
+      throw new Error("fill override must not run");
+    },
+  });
+  return {
+    nativeView,
+    overrideCalls: () => overrideCalls,
+  };
+}
+
 describe("EncryptedConnectionStore envelope encryption", () => {
   it("encrypts every credential with a fresh DEK and wraps only that DEK", async () => {
     const first = createFixture({ seed: 10 });
@@ -875,6 +905,62 @@ describe("EncryptedConnectionStore idempotency, lineage, and concurrency", () =>
 });
 
 describe("EncryptedConnectionStore closed snapshots and errors", () => {
+  it("uses native Buffer length and clearing despite hostile own overrides", async () => {
+    const invalidMetadataPayload = Buffer.from(SECRET_CANARY);
+    const invalidMetadataObservation = overrideBufferSurface(
+      invalidMetadataPayload
+    );
+    const invalidStore = createFixture({ seed: 241 }).store;
+    await expect(
+      invalidStore.store(
+        {
+          ...CREATE_MUTATION,
+          token: SECRET_CANARY,
+        } as CredentialCreateMutation,
+        invalidMetadataPayload
+      )
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    expect(Array.from(invalidMetadataObservation.nativeView)).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+    expect(invalidMetadataObservation.overrideCalls()).toBe(0);
+
+    const validPayload = Buffer.from(SECRET_CANARY);
+    const validObservation = overrideBufferSurface(validPayload);
+    const validStore = createFixture({ seed: 242 }).store;
+    await expect(
+      validStore.store(CREATE_MUTATION, validPayload)
+    ).resolves.toMatchObject({ status: "created" });
+    expect(Array.from(validObservation.nativeView)).toEqual(
+      Array(SECRET_CANARY.length).fill(0)
+    );
+    expect(validObservation.overrideCalls()).toBe(0);
+  });
+
+  it("clears rejected random Buffers without invoking hostile own overrides", async () => {
+    const hostileDataKey = Buffer.alloc(31, 7);
+    const observation = overrideBufferSurface(hostileDataKey);
+    const source: CredentialRandomSource = Object.freeze({
+      dataKey: () => hostileDataKey,
+      payloadNonce: () => Buffer.alloc(12, 2),
+      wrapNonce: () => Buffer.alloc(12, 3),
+      recordRevision: () => "revision_v1_00000000-0000-4000-8000-000000000001",
+    });
+    const store = new EncryptedConnectionStore(
+      new MemoryPersistence(),
+      { current: CURRENT_KEK },
+      source
+    );
+    const payload = Buffer.from(SECRET_CANARY);
+
+    await expect(store.store(CREATE_MUTATION, payload)).rejects.toMatchObject({
+      code: "internal_configuration_invalid",
+    });
+    expect(Array.from(observation.nativeView)).toEqual(Array(31).fill(0));
+    expect(observation.overrideCalls()).toBe(0);
+    expect(Array.from(payload)).toEqual(Array(SECRET_CANARY.length).fill(0));
+  });
+
   it("clears canaries before rejecting hostile or invalid metadata", async () => {
     let getterCalls = 0;
     const accessor = { ...CREATE_MUTATION } as Record<string, unknown>;

--- a/services/agent-gateway/encrypted-connection-store.ts
+++ b/services/agent-gateway/encrypted-connection-store.ts
@@ -1,20 +1,27 @@
 import {
   createCipheriv,
   createDecipheriv,
+  createHash,
   KeyObject,
   randomBytes,
   randomUUID,
+  timingSafeEqual,
 } from "node:crypto";
+import { types as utilTypes } from "node:util";
 
 import type { ControlPlaneOperationContext } from "./control-plane.ts";
 
 const ENVELOPE_VERSION = 1;
-const ENCRYPTION_ALGORITHM = "aes-256-gcm";
+const PAYLOAD_ALGORITHM = "aes-256-gcm";
+const KEY_WRAP_ALGORITHM = "aes-256-gcm";
 const AUTH_TAG_BYTES = 16;
 const NONCE_BYTES = 12;
+const DATA_KEY_BYTES = 32;
 const MAX_CREDENTIAL_BYTES = 1_048_576;
 const MAX_CIPHERTEXT_LENGTH = 1_398_102;
 const MAX_CREDENTIAL_FORMAT_VERSION = 65_535;
+const MAX_ROTATION_SEQUENCE = 65_535;
+const MAX_KEK_ENCRYPTIONS_PER_STORE_INSTANCE = 65_536;
 
 const UUID_V4_PATTERN =
   "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
@@ -34,34 +41,45 @@ type CredentialIdentity = Readonly<{
   credentialFormatVersion: number;
 }>;
 
-type CredentialMutation = CredentialIdentity &
+type CredentialCreateMutation = CredentialIdentity &
   Readonly<{
-    operationId: string;
+    creationOperationId: string;
   }>;
 
-type CredentialEncryptionKey = Readonly<{
+type CredentialRotationMutation = CredentialIdentity &
+  Readonly<{
+    rotationOperationId: string;
+  }>;
+
+type CredentialKeyEncryptionKey = Readonly<{
   keyVersion: string;
   key: KeyObject;
 }>;
 
-type CredentialEncryptionKeys = Readonly<{
-  current: CredentialEncryptionKey;
-  previous?: CredentialEncryptionKey;
+type CredentialKeyEncryptionKeys = Readonly<{
+  current: CredentialKeyEncryptionKey;
+  previous?: CredentialKeyEncryptionKey;
 }>;
 
 type StoredCredentialEnvelope = Readonly<{
   envelopeVersion: typeof ENVELOPE_VERSION;
-  algorithm: typeof ENCRYPTION_ALGORITHM;
+  payloadAlgorithm: typeof PAYLOAD_ALGORITHM;
+  keyWrapAlgorithm: typeof KEY_WRAP_ALGORITHM;
   ownerId: string;
   provider: CredentialProvider;
   credentialId: string;
   credentialFormatVersion: number;
   keyVersion: string;
-  operationId: string;
+  creationOperationId: string;
+  rotationSequence: number;
+  lastRotationOperationId: string | null;
   recordRevision: string;
-  nonce: string;
+  payloadNonce: string;
   ciphertext: string;
-  authTag: string;
+  payloadAuthTag: string;
+  wrappedDataKey: string;
+  wrapNonce: string;
+  wrapAuthTag: string;
 }>;
 
 type CreateCredentialResult =
@@ -81,9 +99,9 @@ type DeleteCredentialResult =
 /**
  * Atomic persistence boundary for encrypted credential envelopes.
  *
- * Implementations must key all methods by the complete credential identity.
+ * Implementations must key every method by the complete credential identity.
  * `create`, `replace`, and `delete` must each be one atomic storage operation;
- * `replace` and `delete` compare exactly against `expectedRecordRevision`.
+ * replace and delete compare exactly against `expectedRecordRevision`.
  */
 interface EncryptedCredentialPersistence {
   read(
@@ -137,8 +155,23 @@ type DeleteStoredCredentialResult = Readonly<{
 }>;
 
 type CredentialRandomSource = Readonly<{
-  nonce: () => Uint8Array;
+  dataKey: () => Buffer;
+  payloadNonce: () => Buffer;
+  wrapNonce: () => Buffer;
   recordRevision: () => string;
+}>;
+
+type EnvelopeLineage = Readonly<{
+  creationOperationId: string;
+  rotationSequence: number;
+  lastRotationOperationId: string | null;
+}>;
+
+type EncryptionMaterial = Readonly<{
+  dataKey: Buffer;
+  payloadNonce: Buffer;
+  wrapNonce: Buffer;
+  recordRevision: string;
 }>;
 
 /** Stable, secret-free failure exposed by the encrypted-store boundary. */
@@ -165,76 +198,98 @@ const CREDENTIAL_STORE_ERROR_MESSAGES = {
 } as const satisfies Record<CredentialStoreErrorCode, string>;
 
 const DEFAULT_RANDOM_SOURCE: CredentialRandomSource = Object.freeze({
-  nonce: () => randomBytes(NONCE_BYTES),
+  dataKey: () => randomBytes(DATA_KEY_BYTES),
+  payloadNonce: () => randomBytes(NONCE_BYTES),
+  wrapNonce: () => randomBytes(NONCE_BYTES),
   recordRevision: () => `revision_v1_${randomUUID()}`,
 });
 
 /**
- * Encrypts and atomically persists opaque provider-owned credential bundles.
+ * Stores opaque provider bundles using per-record envelope encryption.
  *
- * The store never serializes plaintext and only exposes decrypted bytes to a
- * callback. Its temporary plaintext copy is cleared after encryption, and the
- * decrypted buffer is cleared after the callback settles. The callback must not
- * retain aliases and must independently clear any copy it creates.
+ * A fresh data-encryption key encrypts each credential and the versioned KEK
+ * only wraps that DEK. Passing a Buffer transfers ownership to this method; the
+ * caller must not retain or reuse it. Every transferred plaintext, random value,
+ * and DEK buffer is cleared before persistence is awaited.
+ * Decrypted bytes exist only for `use`'s callback lifetime and are then cleared.
  */
 class EncryptedConnectionStore {
-  private readonly keys: CredentialEncryptionKeys;
+  private readonly keys: CredentialKeyEncryptionKeys;
+  private readonly randomSource: CredentialRandomSource;
+  private readonly maxKekEncryptions: number;
+  private readonly dataKeyFingerprints = new Set<string>();
+  private readonly wrapNoncesByKeyVersion = new Map<string, Set<string>>();
+  private kekEncryptionCount = 0;
 
   constructor(
     private readonly persistence: EncryptedCredentialPersistence,
-    keys: CredentialEncryptionKeys,
-    private readonly randomSource: CredentialRandomSource = DEFAULT_RANDOM_SOURCE
+    keys: CredentialKeyEncryptionKeys,
+    randomSource: CredentialRandomSource = DEFAULT_RANDOM_SOURCE,
+    maxKekEncryptions = MAX_KEK_ENCRYPTIONS_PER_STORE_INSTANCE
   ) {
     this.keys = validateKeyRing(keys);
-    validateRandomSource(randomSource);
+    this.randomSource = validateRandomSource(randomSource);
+    if (
+      !Number.isSafeInteger(maxKekEncryptions) ||
+      maxKekEncryptions < 1 ||
+      maxKekEncryptions > MAX_KEK_ENCRYPTIONS_PER_STORE_INSTANCE
+    ) {
+      throw new CredentialStoreError("internal_configuration_invalid");
+    }
+    this.maxKekEncryptions = maxKekEncryptions;
   }
 
-  /** Creates one credential, treating only the same operation id as a retry. */
+  /** Creates one credential; a retry must match operation and payload exactly. */
   async store(
-    mutation: CredentialMutation,
-    credentialPayload: Uint8Array,
+    mutation: CredentialCreateMutation,
+    credentialPayload: Buffer,
     context?: ControlPlaneOperationContext
   ): Promise<StoreCredentialResult> {
-    const validatedMutation = validateMutation(mutation);
-    const plaintext = copyCredentialPayload(credentialPayload);
-
+    const validatedMutation = validateCreateMutation(mutation);
+    const plaintext = takeCredentialPayload(credentialPayload);
+    let candidate: StoredCredentialEnvelope;
     try {
-      const record = encryptCredential(
+      candidate = this.encryptEnvelope(
         validatedMutation,
-        plaintext,
-        this.keys.current,
-        this.randomSource
+        {
+          creationOperationId: validatedMutation.creationOperationId,
+          rotationSequence: 0,
+          lastRotationOperationId: null,
+        },
+        plaintext
       );
-      const result = await callPersistence(() =>
-        this.persistence.create(record, context)
-      );
-      validateCreateResult(result, validatedMutation);
-
-      if (result.status === "created") {
-        return {
-          status: "created",
-          recordRevision: record.recordRevision,
-          keyVersion: record.keyVersion,
-        };
-      }
-
-      const existing = validateStoredRecord(result.record, validatedMutation);
-      if (existing.operationId !== validatedMutation.operationId) {
-        throw new CredentialStoreError("credential_already_exists");
-      }
-      authenticateRecord(existing, this.keys);
-
-      return {
-        status: "already_created",
-        recordRevision: existing.recordRevision,
-        keyVersion: existing.keyVersion,
-      };
     } finally {
+      // This executes before the first persistence/dependency await.
       plaintext.fill(0);
     }
+
+    const result = validateCreateResult(
+      await callPersistence(() => this.persistence.create(candidate, context)),
+      validatedMutation
+    );
+    if (result.status === "created") {
+      return {
+        status: "created",
+        recordRevision: candidate.recordRevision,
+        keyVersion: candidate.keyVersion,
+      };
+    }
+
+    const existing = result.record;
+    if (
+      existing.creationOperationId !== validatedMutation.creationOperationId ||
+      !this.recordsContainSamePayload(candidate, existing)
+    ) {
+      throw new CredentialStoreError("credential_already_exists");
+    }
+    return {
+      status: "already_created",
+      recordRevision: existing.recordRevision,
+      keyVersion: existing.keyVersion,
+    };
   }
 
-  /** Decrypts one bundle for a callback and clears plaintext after it settles. */
+  /** Decrypts one bundle for a callback and clears plaintext after settlement. */
   async use<T>(
     identity: CredentialIdentity,
     consume: (credentialPayload: Uint8Array) => T | PromiseLike<T>,
@@ -252,10 +307,7 @@ class EncryptedConnectionStore {
     }
 
     const record = validateStoredRecord(stored, validatedIdentity);
-    const plaintext = decryptCredential(
-      record,
-      findDecryptionKey(record, this.keys)
-    );
+    const plaintext = this.decryptEnvelope(record);
     try {
       return await consume(plaintext);
     } finally {
@@ -263,17 +315,12 @@ class EncryptedConnectionStore {
     }
   }
 
-  /**
-   * Re-encrypts a previous-key record under the current key with atomic CAS.
-   *
-   * Current-key records are an idempotent no-op. Unknown key versions fail
-   * closed; callers must never widen the overlap ring to bypass rotation.
-   */
+  /** Re-wraps a previous-KEK record with fresh DEK and immutable create lineage. */
   async rotate(
-    mutation: CredentialMutation,
+    mutation: CredentialRotationMutation,
     context?: ControlPlaneOperationContext
   ): Promise<RotateCredentialResult> {
-    const validatedMutation = validateMutation(mutation);
+    const validatedMutation = validateRotationMutation(mutation);
     const stored = await callPersistence(() =>
       this.persistence.read(validatedMutation, context)
     );
@@ -282,59 +329,70 @@ class EncryptedConnectionStore {
     }
 
     const existing = validateStoredRecord(stored, validatedMutation);
+    if (
+      validatedMutation.rotationOperationId === existing.creationOperationId
+    ) {
+      throw new CredentialStoreError("invalid_input");
+    }
     if (existing.keyVersion === this.keys.current.keyVersion) {
-      authenticateRecord(existing, this.keys);
+      this.authenticateRecord(existing);
       return {
         status: "already_current",
         recordRevision: existing.recordRevision,
         keyVersion: existing.keyVersion,
       };
     }
+    if (existing.rotationSequence >= MAX_ROTATION_SEQUENCE) {
+      throw new CredentialStoreError("invalid_record");
+    }
 
-    const plaintext = decryptCredential(
-      existing,
-      findDecryptionKey(existing, this.keys)
-    );
+    const plaintext = this.decryptEnvelope(existing);
+    let replacement: StoredCredentialEnvelope;
     try {
-      const replacement = encryptCredential(
+      replacement = this.encryptEnvelope(
         validatedMutation,
-        plaintext,
-        this.keys.current,
-        this.randomSource
+        {
+          creationOperationId: existing.creationOperationId,
+          rotationSequence: existing.rotationSequence + 1,
+          lastRotationOperationId: validatedMutation.rotationOperationId,
+        },
+        plaintext
       );
-      const result = await callPersistence(() =>
-        this.persistence.replace(replacement, existing.recordRevision, context)
-      );
-      validateReplaceResult(result, validatedMutation);
-
-      if (result.status === "replaced") {
-        return {
-          status: "rotated",
-          recordRevision: replacement.recordRevision,
-          keyVersion: replacement.keyVersion,
-        };
-      }
-      if (result.status === "missing") {
-        throw new CredentialStoreError("credential_not_found");
-      }
-
-      const conflicting = validateStoredRecord(
-        result.record,
-        validatedMutation
-      );
-      // A concurrent successful rotation makes retries safely idempotent.
-      if (conflicting.keyVersion === this.keys.current.keyVersion) {
-        authenticateRecord(conflicting, this.keys);
-        return {
-          status: "already_current",
-          recordRevision: conflicting.recordRevision,
-          keyVersion: conflicting.keyVersion,
-        };
-      }
-      throw new CredentialStoreError("concurrent_modification");
     } finally {
+      // Re-encryption owns no mutable plaintext when the CAS begins.
       plaintext.fill(0);
     }
+
+    const result = validateReplaceResult(
+      await callPersistence(() =>
+        this.persistence.replace(replacement, existing.recordRevision, context)
+      ),
+      validatedMutation
+    );
+    if (result.status === "replaced") {
+      return {
+        status: "rotated",
+        recordRevision: replacement.recordRevision,
+        keyVersion: replacement.keyVersion,
+      };
+    }
+    if (result.status === "missing") {
+      throw new CredentialStoreError("credential_not_found");
+    }
+
+    const conflicting = result.record;
+    if (
+      conflicting.keyVersion === this.keys.current.keyVersion &&
+      conflicting.creationOperationId === existing.creationOperationId &&
+      this.recordsContainSamePayload(replacement, conflicting)
+    ) {
+      return {
+        status: "already_current",
+        recordRevision: conflicting.recordRevision,
+        keyVersion: conflicting.keyVersion,
+      };
+    }
+    throw new CredentialStoreError("concurrent_modification");
   }
 
   /** Deletes exactly the record revision observed by this operation. */
@@ -349,322 +407,605 @@ class EncryptedConnectionStore {
     if (stored === null) return { status: "already_deleted" };
 
     const existing = validateStoredRecord(stored, validatedIdentity);
-    const result = await callPersistence(() =>
-      this.persistence.delete(
-        validatedIdentity,
-        existing.recordRevision,
-        context
-      )
+    const result = validateDeleteResult(
+      await callPersistence(() =>
+        this.persistence.delete(
+          validatedIdentity,
+          existing.recordRevision,
+          context
+        )
+      ),
+      validatedIdentity
     );
-    validateDeleteResult(result, validatedIdentity);
-
     if (result.status === "deleted") return { status: "deleted" };
     if (result.status === "missing") return { status: "already_deleted" };
 
-    validateStoredRecord(result.record, validatedIdentity);
     throw new CredentialStoreError("concurrent_modification");
   }
-}
 
-/** Encrypts one bounded plaintext copy with all record metadata as AAD. */
-function encryptCredential(
-  mutation: CredentialMutation,
-  plaintext: Buffer,
-  encryptionKey: CredentialEncryptionKey,
-  randomSource: CredentialRandomSource
-): StoredCredentialEnvelope {
-  let nonce: Buffer | undefined;
-  let recordRevision: string;
-  try {
-    const randomNonce = randomSource.nonce();
-    if (
-      !(randomNonce instanceof Uint8Array) ||
-      randomNonce.byteLength !== NONCE_BYTES
-    ) {
-      throw new Error("invalid nonce source");
+  /** Builds one envelope synchronously and clears fresh cryptographic material. */
+  private encryptEnvelope(
+    identity: CredentialIdentity,
+    lineage: EnvelopeLineage,
+    plaintext: Buffer
+  ): StoredCredentialEnvelope {
+    const material = this.createEncryptionMaterial();
+    try {
+      return encryptCredential(
+        identity,
+        lineage,
+        plaintext,
+        this.keys.current,
+        material
+      );
+    } finally {
+      material.dataKey.fill(0);
+      material.payloadNonce.fill(0);
+      material.wrapNonce.fill(0);
     }
-    nonce = Buffer.from(randomNonce);
-    recordRevision = randomSource.recordRevision();
-    if (
-      typeof recordRevision !== "string" ||
-      !RECORD_REVISION_PATTERN.test(recordRevision)
-    ) {
-      throw new Error("invalid revision source");
-    }
-  } catch {
-    nonce?.fill(0);
-    throw new CredentialStoreError("internal_configuration_invalid");
   }
 
-  const metadata = {
-    envelopeVersion: ENVELOPE_VERSION,
-    algorithm: ENCRYPTION_ALGORITHM,
-    ownerId: mutation.ownerId,
-    provider: mutation.provider,
-    credentialId: mutation.credentialId,
-    credentialFormatVersion: mutation.credentialFormatVersion,
-    keyVersion: encryptionKey.keyVersion,
-    operationId: mutation.operationId,
-    recordRevision,
-  } as const;
-  const aad = Buffer.from(JSON.stringify(metadata), "utf8");
+  /** Decrypts through the KEK-wrapped per-record DEK. */
+  private decryptEnvelope(record: StoredCredentialEnvelope): Buffer {
+    return decryptCredential(record, findDecryptionKey(record, this.keys));
+  }
+
+  /** Authenticates an envelope without retaining its plaintext. */
+  private authenticateRecord(record: StoredCredentialEnvelope): void {
+    const plaintext = this.decryptEnvelope(record);
+    plaintext.fill(0);
+  }
+
+  /** Constant-time compares credential contents while clearing both plaintexts. */
+  private recordsContainSamePayload(
+    first: StoredCredentialEnvelope,
+    second: StoredCredentialEnvelope
+  ): boolean {
+    const firstPlaintext = this.decryptEnvelope(first);
+    let secondPlaintext: Buffer | undefined;
+    let firstDigest: Buffer | undefined;
+    let secondDigest: Buffer | undefined;
+    try {
+      secondPlaintext = this.decryptEnvelope(second);
+      firstDigest = createHash("sha256").update(firstPlaintext).digest();
+      secondDigest = createHash("sha256").update(secondPlaintext).digest();
+      return timingSafeEqual(firstDigest, secondDigest);
+    } finally {
+      firstPlaintext.fill(0);
+      secondPlaintext?.fill(0);
+      firstDigest?.fill(0);
+      secondDigest?.fill(0);
+    }
+  }
+
+  /** Generates and reserves one bounded set of fresh cryptographic material. */
+  private createEncryptionMaterial(): EncryptionMaterial {
+    if (this.kekEncryptionCount >= this.maxKekEncryptions) {
+      throw new CredentialStoreError("internal_configuration_invalid");
+    }
+
+    let dataKey: Buffer | undefined;
+    let payloadNonce: Buffer | undefined;
+    let wrapNonce: Buffer | undefined;
+    try {
+      dataKey = takeRandomBytes(this.randomSource.dataKey(), DATA_KEY_BYTES);
+      payloadNonce = takeRandomBytes(
+        this.randomSource.payloadNonce(),
+        NONCE_BYTES
+      );
+      wrapNonce = takeRandomBytes(this.randomSource.wrapNonce(), NONCE_BYTES);
+      const recordRevision = this.randomSource.recordRevision();
+      if (
+        typeof recordRevision !== "string" ||
+        !RECORD_REVISION_PATTERN.test(recordRevision) ||
+        isAllZero(dataKey) ||
+        isAllZero(payloadNonce) ||
+        isAllZero(wrapNonce) ||
+        timingSafeEqual(payloadNonce, wrapNonce)
+      ) {
+        throw new Error("invalid encryption material");
+      }
+
+      const fingerprintBytes = createHash("sha256").update(dataKey).digest();
+      const dataKeyFingerprint = fingerprintBytes.toString("base64url");
+      fingerprintBytes.fill(0);
+      const wrapNonceText = wrapNonce.toString("base64url");
+      const keyNonces =
+        this.wrapNoncesByKeyVersion.get(this.keys.current.keyVersion) ??
+        new Set<string>();
+      if (
+        this.dataKeyFingerprints.has(dataKeyFingerprint) ||
+        keyNonces.has(wrapNonceText)
+      ) {
+        throw new Error("duplicate encryption material");
+      }
+
+      this.dataKeyFingerprints.add(dataKeyFingerprint);
+      keyNonces.add(wrapNonceText);
+      this.wrapNoncesByKeyVersion.set(this.keys.current.keyVersion, keyNonces);
+      this.kekEncryptionCount += 1;
+      return { dataKey, payloadNonce, wrapNonce, recordRevision };
+    } catch {
+      dataKey?.fill(0);
+      payloadNonce?.fill(0);
+      wrapNonce?.fill(0);
+      throw new CredentialStoreError("internal_configuration_invalid");
+    }
+  }
+}
+
+/** Encrypts payload under a fresh DEK and wraps only that DEK under the KEK. */
+function encryptCredential(
+  identity: CredentialIdentity,
+  lineage: EnvelopeLineage,
+  plaintext: Buffer,
+  keyEncryptionKey: CredentialKeyEncryptionKey,
+  material: EncryptionMaterial
+): StoredCredentialEnvelope {
+  const common = commonMetadata(
+    identity,
+    lineage,
+    keyEncryptionKey.keyVersion,
+    material.recordRevision
+  );
+  const payloadAad = encodeCanonicalAad({
+    ...common,
+    layer: "credential-payload-v1",
+  });
+  let ciphertext: Buffer | undefined;
+  let payloadAuthTag: Buffer | undefined;
+  let wrappedDataKey: Buffer | undefined;
+  let wrapAuthTag: Buffer | undefined;
+  let wrapAad: Buffer | undefined;
 
   try {
-    const cipher = createCipheriv(
-      ENCRYPTION_ALGORITHM,
-      encryptionKey.key,
-      nonce,
+    const payloadCipher = createCipheriv(
+      PAYLOAD_ALGORITHM,
+      material.dataKey,
+      material.payloadNonce,
       { authTagLength: AUTH_TAG_BYTES }
     );
-    cipher.setAAD(aad);
-    const ciphertext = Buffer.concat([
-      cipher.update(plaintext),
-      cipher.final(),
+    payloadCipher.setAAD(payloadAad);
+    ciphertext = Buffer.concat([
+      payloadCipher.update(plaintext),
+      payloadCipher.final(),
     ]);
-    const authTag = cipher.getAuthTag();
+    payloadAuthTag = payloadCipher.getAuthTag();
+
+    const payloadDigest = createHash("sha256").update(ciphertext).digest();
     try {
-      return Object.freeze({
-        ...metadata,
-        nonce: nonce.toString("base64url"),
-        ciphertext: ciphertext.toString("base64url"),
-        authTag: authTag.toString("base64url"),
+      wrapAad = encodeCanonicalAad({
+        ...common,
+        layer: "data-key-wrap-v1",
+        payloadNonce: material.payloadNonce.toString("base64url"),
+        payloadAuthTag: payloadAuthTag.toString("base64url"),
+        ciphertextDigest: payloadDigest.toString("base64url"),
       });
     } finally {
-      ciphertext.fill(0);
-      authTag.fill(0);
+      payloadDigest.fill(0);
     }
+
+    const wrapCipher = createCipheriv(
+      KEY_WRAP_ALGORITHM,
+      keyEncryptionKey.key,
+      material.wrapNonce,
+      { authTagLength: AUTH_TAG_BYTES }
+    );
+    wrapCipher.setAAD(wrapAad);
+    wrappedDataKey = Buffer.concat([
+      wrapCipher.update(material.dataKey),
+      wrapCipher.final(),
+    ]);
+    wrapAuthTag = wrapCipher.getAuthTag();
+
+    return Object.freeze({
+      ...common,
+      payloadNonce: material.payloadNonce.toString("base64url"),
+      ciphertext: ciphertext.toString("base64url"),
+      payloadAuthTag: payloadAuthTag.toString("base64url"),
+      wrappedDataKey: wrappedDataKey.toString("base64url"),
+      wrapNonce: material.wrapNonce.toString("base64url"),
+      wrapAuthTag: wrapAuthTag.toString("base64url"),
+    });
   } catch (error) {
     if (error instanceof CredentialStoreError) throw error;
     throw new CredentialStoreError("internal_configuration_invalid");
   } finally {
-    nonce.fill(0);
-    aad.fill(0);
+    payloadAad.fill(0);
+    wrapAad?.fill(0);
+    ciphertext?.fill(0);
+    payloadAuthTag?.fill(0);
+    wrappedDataKey?.fill(0);
+    wrapAuthTag?.fill(0);
   }
 }
 
-/** Authenticates and decrypts one strict envelope without reflecting details. */
+/** Unwraps the per-record DEK, authenticates payload AAD, and decrypts bytes. */
 function decryptCredential(
   record: StoredCredentialEnvelope,
-  encryptionKey: CredentialEncryptionKey
+  keyEncryptionKey: CredentialKeyEncryptionKey
 ): Buffer {
-  const nonce = decodeBase64Url(record.nonce, NONCE_BYTES, "invalid_record");
-  const ciphertext = decodeBase64Url(
-    record.ciphertext,
-    undefined,
-    "invalid_record"
-  );
-  const authTag = decodeBase64Url(
-    record.authTag,
-    AUTH_TAG_BYTES,
-    "invalid_record"
-  );
-  const aad = Buffer.from(JSON.stringify(recordMetadata(record)), "utf8");
-  let firstChunk: Buffer | undefined;
+  const payloadNonce = decodeBase64Url(record.payloadNonce, NONCE_BYTES);
+  const ciphertext = decodeBase64Url(record.ciphertext);
+  const payloadAuthTag = decodeBase64Url(record.payloadAuthTag, AUTH_TAG_BYTES);
+  const wrappedDataKey = decodeBase64Url(record.wrappedDataKey, DATA_KEY_BYTES);
+  const wrapNonce = decodeBase64Url(record.wrapNonce, NONCE_BYTES);
+  const wrapAuthTag = decodeBase64Url(record.wrapAuthTag, AUTH_TAG_BYTES);
+  const common = commonMetadataFromRecord(record);
+  const payloadDigest = createHash("sha256").update(ciphertext).digest();
+  const wrapAad = encodeCanonicalAad({
+    ...common,
+    layer: "data-key-wrap-v1",
+    payloadNonce: record.payloadNonce,
+    payloadAuthTag: record.payloadAuthTag,
+    ciphertextDigest: payloadDigest.toString("base64url"),
+  });
+  payloadDigest.fill(0);
+  let dataKey: Buffer | undefined;
+  let plaintextFirst: Buffer | undefined;
 
   try {
-    const decipher = createDecipheriv(
-      ENCRYPTION_ALGORITHM,
-      encryptionKey.key,
-      nonce,
+    const unwrap = createDecipheriv(
+      KEY_WRAP_ALGORITHM,
+      keyEncryptionKey.key,
+      wrapNonce,
       { authTagLength: AUTH_TAG_BYTES }
     );
-    decipher.setAAD(aad);
-    decipher.setAuthTag(authTag);
-    firstChunk = decipher.update(ciphertext);
-    const finalChunk = decipher.final();
-    try {
-      const plaintext = Buffer.concat([firstChunk, finalChunk]);
-      if (
-        plaintext.byteLength === 0 ||
-        plaintext.byteLength > MAX_CREDENTIAL_BYTES
-      ) {
-        plaintext.fill(0);
-        throw new CredentialStoreError("decryption_failed");
-      }
-      return plaintext;
-    } finally {
-      finalChunk.fill(0);
+    unwrap.setAAD(wrapAad);
+    unwrap.setAuthTag(wrapAuthTag);
+    dataKey = Buffer.concat([unwrap.update(wrappedDataKey), unwrap.final()]);
+    if (dataKey.byteLength !== DATA_KEY_BYTES) {
+      throw new Error("invalid data key");
     }
-  } catch (error) {
-    if (error instanceof CredentialStoreError) throw error;
+
+    const payloadAad = encodeCanonicalAad({
+      ...common,
+      layer: "credential-payload-v1",
+    });
+    try {
+      const decipher = createDecipheriv(
+        PAYLOAD_ALGORITHM,
+        dataKey,
+        payloadNonce,
+        { authTagLength: AUTH_TAG_BYTES }
+      );
+      decipher.setAAD(payloadAad);
+      decipher.setAuthTag(payloadAuthTag);
+      plaintextFirst = decipher.update(ciphertext);
+      const plaintextFinal = decipher.final();
+      try {
+        const plaintext = Buffer.concat([plaintextFirst, plaintextFinal]);
+        if (
+          plaintext.byteLength === 0 ||
+          plaintext.byteLength > MAX_CREDENTIAL_BYTES
+        ) {
+          plaintext.fill(0);
+          throw new Error("invalid plaintext length");
+        }
+        return plaintext;
+      } finally {
+        plaintextFinal.fill(0);
+      }
+    } finally {
+      payloadAad.fill(0);
+    }
+  } catch {
     throw new CredentialStoreError("decryption_failed");
   } finally {
-    firstChunk?.fill(0);
-    nonce.fill(0);
+    dataKey?.fill(0);
+    plaintextFirst?.fill(0);
+    payloadNonce.fill(0);
     ciphertext.fill(0);
-    authTag.fill(0);
-    aad.fill(0);
+    payloadAuthTag.fill(0);
+    wrappedDataKey.fill(0);
+    wrapNonce.fill(0);
+    wrapAuthTag.fill(0);
+    wrapAad.fill(0);
   }
 }
 
-/** Selects only the explicitly configured current or previous key. */
+/** Returns common metadata in the sole canonical AAD property order. */
+function commonMetadata(
+  identity: CredentialIdentity,
+  lineage: EnvelopeLineage,
+  keyVersion: string,
+  recordRevision: string
+) {
+  return {
+    envelopeVersion: ENVELOPE_VERSION,
+    payloadAlgorithm: PAYLOAD_ALGORITHM,
+    keyWrapAlgorithm: KEY_WRAP_ALGORITHM,
+    ownerId: identity.ownerId,
+    provider: identity.provider,
+    credentialId: identity.credentialId,
+    credentialFormatVersion: identity.credentialFormatVersion,
+    keyVersion,
+    creationOperationId: lineage.creationOperationId,
+    rotationSequence: lineage.rotationSequence,
+    lastRotationOperationId: lineage.lastRotationOperationId,
+    recordRevision,
+  } as const;
+}
+
+/** Reconstructs canonical common metadata from one validated record. */
+function commonMetadataFromRecord(record: StoredCredentialEnvelope) {
+  return commonMetadata(
+    record,
+    record,
+    record.keyVersion,
+    record.recordRevision
+  );
+}
+
+/** Encodes fixed-order metadata into a temporary AAD buffer. */
+function encodeCanonicalAad(value: object): Buffer {
+  return Buffer.from(JSON.stringify(value), "utf8");
+}
+
+/** Selects only the explicitly configured current or previous KEK. */
 function findDecryptionKey(
   record: StoredCredentialEnvelope,
-  keys: CredentialEncryptionKeys
-): CredentialEncryptionKey {
+  keys: CredentialKeyEncryptionKeys
+): CredentialKeyEncryptionKey {
   if (record.keyVersion === keys.current.keyVersion) return keys.current;
   if (record.keyVersion === keys.previous?.keyVersion) return keys.previous;
   throw new CredentialStoreError("key_unavailable");
 }
 
-/** Authenticates an envelope for an idempotent path without retaining plaintext. */
-function authenticateRecord(
-  record: StoredCredentialEnvelope,
-  keys: CredentialEncryptionKeys
-): void {
-  const plaintext = decryptCredential(record, findDecryptionKey(record, keys));
-  plaintext.fill(0);
-}
-
-/** Returns metadata in the one canonical AAD property order. */
-function recordMetadata(record: StoredCredentialEnvelope) {
-  return {
-    envelopeVersion: record.envelopeVersion,
-    algorithm: record.algorithm,
-    ownerId: record.ownerId,
-    provider: record.provider,
-    credentialId: record.credentialId,
-    credentialFormatVersion: record.credentialFormatVersion,
-    keyVersion: record.keyVersion,
-    operationId: record.operationId,
-    recordRevision: record.recordRevision,
-  } as const;
-}
-
-/** Copies and bounds caller-owned plaintext before any asynchronous operation. */
-function copyCredentialPayload(payload: Uint8Array): Buffer {
-  if (!(payload instanceof Uint8Array)) {
+/** Accepts ownership of one bounded mutable Buffer for synchronous encryption. */
+function takeCredentialPayload(payload: Buffer): Buffer {
+  if (!Buffer.isBuffer(payload)) {
     throw new CredentialStoreError("invalid_input");
   }
   if (payload.byteLength === 0 || payload.byteLength > MAX_CREDENTIAL_BYTES) {
     throw new CredentialStoreError("invalid_input");
   }
-  return Buffer.from(payload);
+  return payload;
 }
 
-/** Validates and freezes the closed credential identity contract. */
-function validateIdentity(value: CredentialIdentity): CredentialIdentity {
-  assertPlainExactObject(value, [
-    "ownerId",
-    "provider",
-    "credentialId",
-    "credentialFormatVersion",
-  ]);
+/** Accepts ownership of one exact-sized random Buffer for immediate clearing. */
+function takeRandomBytes(value: unknown, expectedBytes: number): Buffer {
+  if (!Buffer.isBuffer(value) || value.byteLength !== expectedBytes) {
+    throw new Error("invalid random bytes");
+  }
+  return value;
+}
+
+/** Checks an owned random buffer without allocating secret-derived text. */
+function isAllZero(value: Buffer): boolean {
+  let combined = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    combined |= value[index];
+  }
+  return combined === 0;
+}
+
+/** Validates and snapshots the closed credential identity. */
+function validateIdentity(value: unknown): CredentialIdentity {
+  const snapshot = snapshotExactDataObject(
+    value,
+    [["ownerId", "provider", "credentialId", "credentialFormatVersion"]],
+    "invalid_input"
+  );
   if (
-    !OWNER_ID_PATTERN.test(value.ownerId) ||
-    value.provider !== "codex" ||
-    !CREDENTIAL_ID_PATTERN.test(value.credentialId) ||
-    !Number.isSafeInteger(value.credentialFormatVersion) ||
-    value.credentialFormatVersion < 1 ||
-    value.credentialFormatVersion > MAX_CREDENTIAL_FORMAT_VERSION
+    typeof snapshot.ownerId !== "string" ||
+    !OWNER_ID_PATTERN.test(snapshot.ownerId) ||
+    snapshot.provider !== "codex" ||
+    typeof snapshot.credentialId !== "string" ||
+    !CREDENTIAL_ID_PATTERN.test(snapshot.credentialId) ||
+    !Number.isSafeInteger(snapshot.credentialFormatVersion) ||
+    (snapshot.credentialFormatVersion as number) < 1 ||
+    (snapshot.credentialFormatVersion as number) > MAX_CREDENTIAL_FORMAT_VERSION
   ) {
     throw new CredentialStoreError("invalid_input");
   }
-  return Object.freeze({ ...value });
+  return Object.freeze({
+    ownerId: snapshot.ownerId,
+    provider: "codex",
+    credentialId: snapshot.credentialId,
+    credentialFormatVersion: snapshot.credentialFormatVersion as number,
+  });
 }
 
-/** Validates the identity plus one bounded idempotency key. */
-function validateMutation(value: CredentialMutation): CredentialMutation {
-  assertPlainExactObject(value, [
-    "ownerId",
-    "provider",
-    "credentialId",
-    "credentialFormatVersion",
-    "operationId",
-  ]);
+/** Validates and snapshots immutable creation idempotency. */
+function validateCreateMutation(value: unknown): CredentialCreateMutation {
+  const snapshot = snapshotExactDataObject(
+    value,
+    [
+      [
+        "ownerId",
+        "provider",
+        "credentialId",
+        "credentialFormatVersion",
+        "creationOperationId",
+      ],
+    ],
+    "invalid_input"
+  );
   const identity = validateIdentity({
-    ownerId: value.ownerId,
-    provider: value.provider,
-    credentialId: value.credentialId,
-    credentialFormatVersion: value.credentialFormatVersion,
+    ownerId: snapshot.ownerId,
+    provider: snapshot.provider,
+    credentialId: snapshot.credentialId,
+    credentialFormatVersion: snapshot.credentialFormatVersion,
   });
-  if (!OPERATION_ID_PATTERN.test(value.operationId)) {
+  if (
+    typeof snapshot.creationOperationId !== "string" ||
+    !OPERATION_ID_PATTERN.test(snapshot.creationOperationId)
+  ) {
     throw new CredentialStoreError("invalid_input");
   }
-  return Object.freeze({ ...identity, operationId: value.operationId });
+  return Object.freeze({
+    ...identity,
+    creationOperationId: snapshot.creationOperationId,
+  });
 }
 
-/** Validates a persisted envelope before its metadata or ciphertext is trusted. */
+/** Validates and snapshots a rotation operation independently of create lineage. */
+function validateRotationMutation(value: unknown): CredentialRotationMutation {
+  const snapshot = snapshotExactDataObject(
+    value,
+    [
+      [
+        "ownerId",
+        "provider",
+        "credentialId",
+        "credentialFormatVersion",
+        "rotationOperationId",
+      ],
+    ],
+    "invalid_input"
+  );
+  const identity = validateIdentity({
+    ownerId: snapshot.ownerId,
+    provider: snapshot.provider,
+    credentialId: snapshot.credentialId,
+    credentialFormatVersion: snapshot.credentialFormatVersion,
+  });
+  if (
+    typeof snapshot.rotationOperationId !== "string" ||
+    !OPERATION_ID_PATTERN.test(snapshot.rotationOperationId)
+  ) {
+    throw new CredentialStoreError("invalid_input");
+  }
+  return Object.freeze({
+    ...identity,
+    rotationOperationId: snapshot.rotationOperationId,
+  });
+}
+
+/** Validates and snapshots a persistence record before any later use. */
 function validateStoredRecord(
-  value: StoredCredentialEnvelope,
+  value: unknown,
   expected: CredentialIdentity
 ): StoredCredentialEnvelope {
-  try {
-    assertPlainExactObject(value, [
-      "envelopeVersion",
-      "algorithm",
-      "ownerId",
-      "provider",
-      "credentialId",
-      "credentialFormatVersion",
-      "keyVersion",
-      "operationId",
-      "recordRevision",
-      "nonce",
-      "ciphertext",
-      "authTag",
-    ]);
-    if (
-      value.envelopeVersion !== ENVELOPE_VERSION ||
-      value.algorithm !== ENCRYPTION_ALGORITHM ||
-      value.ownerId !== expected.ownerId ||
-      value.provider !== expected.provider ||
-      value.credentialId !== expected.credentialId ||
-      value.credentialFormatVersion !== expected.credentialFormatVersion ||
-      !KEY_VERSION_PATTERN.test(value.keyVersion) ||
-      !OPERATION_ID_PATTERN.test(value.operationId) ||
-      !RECORD_REVISION_PATTERN.test(value.recordRevision) ||
-      value.nonce.length !== 16 ||
-      value.authTag.length !== 22 ||
-      value.ciphertext.length === 0 ||
-      value.ciphertext.length > MAX_CIPHERTEXT_LENGTH ||
-      !BASE64URL_PATTERN.test(value.nonce) ||
-      !BASE64URL_PATTERN.test(value.authTag) ||
-      !BASE64URL_PATTERN.test(value.ciphertext)
-    ) {
-      throw new CredentialStoreError("invalid_record");
-    }
-    decodeBase64Url(value.nonce, NONCE_BYTES, "invalid_record").fill(0);
-    decodeBase64Url(value.authTag, AUTH_TAG_BYTES, "invalid_record").fill(0);
-    const ciphertext = decodeBase64Url(
-      value.ciphertext,
-      undefined,
-      "invalid_record"
-    );
-    if (
-      ciphertext.byteLength === 0 ||
-      ciphertext.byteLength > MAX_CREDENTIAL_BYTES
-    ) {
-      ciphertext.fill(0);
-      throw new CredentialStoreError("invalid_record");
-    }
-    ciphertext.fill(0);
-    return Object.freeze({ ...value });
-  } catch (error) {
-    if (
-      error instanceof CredentialStoreError &&
-      error.code === "invalid_record"
-    ) {
-      throw error;
-    }
+  const snapshot = snapshotExactDataObject(
+    value,
+    [
+      [
+        "envelopeVersion",
+        "payloadAlgorithm",
+        "keyWrapAlgorithm",
+        "ownerId",
+        "provider",
+        "credentialId",
+        "credentialFormatVersion",
+        "keyVersion",
+        "creationOperationId",
+        "rotationSequence",
+        "lastRotationOperationId",
+        "recordRevision",
+        "payloadNonce",
+        "ciphertext",
+        "payloadAuthTag",
+        "wrappedDataKey",
+        "wrapNonce",
+        "wrapAuthTag",
+      ],
+    ],
+    "invalid_record"
+  );
+  if (
+    snapshot.envelopeVersion !== ENVELOPE_VERSION ||
+    snapshot.payloadAlgorithm !== PAYLOAD_ALGORITHM ||
+    snapshot.keyWrapAlgorithm !== KEY_WRAP_ALGORITHM ||
+    snapshot.ownerId !== expected.ownerId ||
+    snapshot.provider !== expected.provider ||
+    snapshot.credentialId !== expected.credentialId ||
+    snapshot.credentialFormatVersion !== expected.credentialFormatVersion ||
+    typeof snapshot.keyVersion !== "string" ||
+    !KEY_VERSION_PATTERN.test(snapshot.keyVersion) ||
+    typeof snapshot.creationOperationId !== "string" ||
+    !OPERATION_ID_PATTERN.test(snapshot.creationOperationId) ||
+    !Number.isSafeInteger(snapshot.rotationSequence) ||
+    (snapshot.rotationSequence as number) < 0 ||
+    (snapshot.rotationSequence as number) > MAX_ROTATION_SEQUENCE ||
+    !isOptionalOperationId(snapshot.lastRotationOperationId) ||
+    snapshot.lastRotationOperationId === snapshot.creationOperationId ||
+    ((snapshot.rotationSequence as number) === 0) !==
+      (snapshot.lastRotationOperationId === null) ||
+    typeof snapshot.recordRevision !== "string" ||
+    !RECORD_REVISION_PATTERN.test(snapshot.recordRevision) ||
+    !isBoundedBase64Url(snapshot.payloadNonce, 16) ||
+    !isBoundedBase64Url(snapshot.payloadAuthTag, 22) ||
+    !isBoundedBase64Url(snapshot.wrapNonce, 16) ||
+    !isBoundedBase64Url(snapshot.wrapAuthTag, 22) ||
+    !isBoundedBase64Url(snapshot.wrappedDataKey, 43) ||
+    !isBoundedBase64Url(snapshot.ciphertext, MAX_CIPHERTEXT_LENGTH)
+  ) {
     throw new CredentialStoreError("invalid_record");
   }
+
+  const payloadNonce = decodeBase64Url(snapshot.payloadNonce, NONCE_BYTES);
+  const payloadAuthTag = decodeBase64Url(
+    snapshot.payloadAuthTag,
+    AUTH_TAG_BYTES
+  );
+  const wrapNonce = decodeBase64Url(snapshot.wrapNonce, NONCE_BYTES);
+  const wrapAuthTag = decodeBase64Url(snapshot.wrapAuthTag, AUTH_TAG_BYTES);
+  const wrappedDataKey = decodeBase64Url(
+    snapshot.wrappedDataKey,
+    DATA_KEY_BYTES
+  );
+  const ciphertext = decodeBase64Url(snapshot.ciphertext);
+  try {
+    if (
+      ciphertext.byteLength === 0 ||
+      ciphertext.byteLength > MAX_CREDENTIAL_BYTES ||
+      isAllZero(payloadNonce) ||
+      isAllZero(wrapNonce) ||
+      timingSafeEqual(payloadNonce, wrapNonce)
+    ) {
+      throw new CredentialStoreError("invalid_record");
+    }
+  } finally {
+    payloadNonce.fill(0);
+    payloadAuthTag.fill(0);
+    wrapNonce.fill(0);
+    wrapAuthTag.fill(0);
+    wrappedDataKey.fill(0);
+    ciphertext.fill(0);
+  }
+
+  return Object.freeze({
+    envelopeVersion: ENVELOPE_VERSION,
+    payloadAlgorithm: PAYLOAD_ALGORITHM,
+    keyWrapAlgorithm: KEY_WRAP_ALGORITHM,
+    ownerId: snapshot.ownerId as string,
+    provider: "codex",
+    credentialId: snapshot.credentialId as string,
+    credentialFormatVersion: snapshot.credentialFormatVersion as number,
+    keyVersion: snapshot.keyVersion,
+    creationOperationId: snapshot.creationOperationId,
+    rotationSequence: snapshot.rotationSequence as number,
+    lastRotationOperationId: snapshot.lastRotationOperationId,
+    recordRevision: snapshot.recordRevision,
+    payloadNonce: snapshot.payloadNonce,
+    ciphertext: snapshot.ciphertext,
+    payloadAuthTag: snapshot.payloadAuthTag,
+    wrappedDataKey: snapshot.wrappedDataKey,
+    wrapNonce: snapshot.wrapNonce,
+    wrapAuthTag: snapshot.wrapAuthTag,
+  });
 }
 
-/** Validates the two-key overlap ring without exporting key bytes. */
-function validateKeyRing(
-  value: CredentialEncryptionKeys
-): CredentialEncryptionKeys {
+/** Validates the two-KEK overlap without exposing material or accepting aliases. */
+function validateKeyRing(value: unknown): CredentialKeyEncryptionKeys {
   try {
-    assertPlainExactObject(
+    const snapshot = snapshotExactDataObject(
       value,
-      value.previous === undefined ? ["current"] : ["current", "previous"]
+      [["current"], ["current", "previous"]],
+      "internal_configuration_invalid"
     );
-    const current = validateEncryptionKey(value.current);
-    const previous = value.previous
-      ? validateEncryptionKey(value.previous)
-      : undefined;
-    if (previous?.keyVersion === current.keyVersion) {
+    const current = validateEncryptionKey(snapshot.current);
+    const previous =
+      snapshot.previous === undefined
+        ? undefined
+        : validateEncryptionKey(snapshot.previous);
+    if (
+      previous !== undefined &&
+      (previous.keyVersion === current.keyVersion ||
+        previous.key.equals(current.key))
+    ) {
       throw new CredentialStoreError("internal_configuration_invalid");
     }
     return Object.freeze({ current, ...(previous ? { previous } : {}) });
@@ -673,32 +1014,47 @@ function validateKeyRing(
   }
 }
 
-/** Accepts one non-exported-by-this-module 256-bit Node secret KeyObject. */
-function validateEncryptionKey(
-  value: CredentialEncryptionKey
-): CredentialEncryptionKey {
-  assertPlainExactObject(value, ["keyVersion", "key"]);
+/** Accepts one exact 256-bit Node secret KEK without exporting it. */
+function validateEncryptionKey(value: unknown): CredentialKeyEncryptionKey {
+  const snapshot = snapshotExactDataObject(
+    value,
+    [["keyVersion", "key"]],
+    "internal_configuration_invalid"
+  );
   if (
-    !KEY_VERSION_PATTERN.test(value.keyVersion) ||
-    !(value.key instanceof KeyObject) ||
-    value.key.type !== "secret" ||
-    value.key.symmetricKeySize !== 32
+    typeof snapshot.keyVersion !== "string" ||
+    !KEY_VERSION_PATTERN.test(snapshot.keyVersion) ||
+    !(snapshot.key instanceof KeyObject) ||
+    snapshot.key.type !== "secret" ||
+    snapshot.key.symmetricKeySize !== 32
   ) {
     throw new CredentialStoreError("internal_configuration_invalid");
   }
-  return Object.freeze({ ...value });
+  return Object.freeze({ keyVersion: snapshot.keyVersion, key: snapshot.key });
 }
 
-/** Validates injected randomness synchronously without consuming it. */
-function validateRandomSource(value: CredentialRandomSource): void {
+/** Snapshots the injected randomness interface without invoking accessors. */
+function validateRandomSource(value: unknown): CredentialRandomSource {
   try {
-    assertPlainExactObject(value, ["nonce", "recordRevision"]);
+    const snapshot = snapshotExactDataObject(
+      value,
+      [["dataKey", "payloadNonce", "wrapNonce", "recordRevision"]],
+      "internal_configuration_invalid"
+    );
     if (
-      typeof value.nonce !== "function" ||
-      typeof value.recordRevision !== "function"
+      typeof snapshot.dataKey !== "function" ||
+      typeof snapshot.payloadNonce !== "function" ||
+      typeof snapshot.wrapNonce !== "function" ||
+      typeof snapshot.recordRevision !== "function"
     ) {
       throw new Error("invalid random source");
     }
+    return Object.freeze({
+      dataKey: snapshot.dataKey as () => Buffer,
+      payloadNonce: snapshot.payloadNonce as () => Buffer,
+      wrapNonce: snapshot.wrapNonce as () => Buffer,
+      recordRevision: snapshot.recordRevision as () => string,
+    });
   } catch {
     throw new CredentialStoreError("internal_configuration_invalid");
   }
@@ -713,75 +1069,94 @@ async function callPersistence<T>(operation: () => Promise<T>): Promise<T> {
   }
 }
 
-/** Validates the closed create-result union before branching on it. */
+/** Snapshots and validates the closed create-result union. */
 function validateCreateResult(
-  value: CreateCredentialResult,
+  value: unknown,
   expected: CredentialIdentity
-): void {
+): CreateCredentialResult {
   try {
-    assertPlainExactObject(
+    const snapshot = snapshotExactDataObject(
       value,
-      value.status === "created" ? ["status"] : ["status", "record"]
+      [["status"], ["status", "record"]],
+      "persistence_unavailable"
     );
-    if (value.status === "created") return;
-    if (value.status === "exists") {
-      validateStoredRecord(value.record, expected);
-      return;
+    if (snapshot.status === "created" && !("record" in snapshot)) {
+      return { status: "created" };
+    }
+    if (snapshot.status === "exists" && "record" in snapshot) {
+      return {
+        status: "exists",
+        record: validateStoredRecord(snapshot.record, expected),
+      };
     }
   } catch {
-    // Fall through to one stable persistence error.
+    // Fall through to one stable adapter-contract failure.
   }
   throw new CredentialStoreError("persistence_unavailable");
 }
 
-/** Validates the closed CAS-replace result union. */
+/** Snapshots and validates the closed CAS-replace result union. */
 function validateReplaceResult(
-  value: ReplaceCredentialResult,
+  value: unknown,
   expected: CredentialIdentity
-): void {
+): ReplaceCredentialResult {
   try {
-    const expectedKeys =
-      value.status === "conflict" ? ["status", "record"] : ["status"];
-    assertPlainExactObject(value, expectedKeys);
-    if (value.status === "replaced" || value.status === "missing") return;
-    if (value.status === "conflict") {
-      validateStoredRecord(value.record, expected);
-      return;
+    const snapshot = snapshotExactDataObject(
+      value,
+      [["status"], ["status", "record"]],
+      "persistence_unavailable"
+    );
+    if (
+      (snapshot.status === "replaced" || snapshot.status === "missing") &&
+      !("record" in snapshot)
+    ) {
+      return { status: snapshot.status };
+    }
+    if (snapshot.status === "conflict" && "record" in snapshot) {
+      return {
+        status: "conflict",
+        record: validateStoredRecord(snapshot.record, expected),
+      };
     }
   } catch {
-    // Fall through to one stable persistence error.
+    // Fall through to one stable adapter-contract failure.
   }
   throw new CredentialStoreError("persistence_unavailable");
 }
 
-/** Validates the closed CAS-delete result union. */
+/** Snapshots and validates the closed CAS-delete result union. */
 function validateDeleteResult(
-  value: DeleteCredentialResult,
+  value: unknown,
   expected: CredentialIdentity
-): void {
+): DeleteCredentialResult {
   try {
-    const expectedKeys =
-      value.status === "conflict" ? ["status", "record"] : ["status"];
-    assertPlainExactObject(value, expectedKeys);
-    if (value.status === "deleted" || value.status === "missing") return;
-    if (value.status === "conflict") {
-      validateStoredRecord(value.record, expected);
-      return;
+    const snapshot = snapshotExactDataObject(
+      value,
+      [["status"], ["status", "record"]],
+      "persistence_unavailable"
+    );
+    if (
+      (snapshot.status === "deleted" || snapshot.status === "missing") &&
+      !("record" in snapshot)
+    ) {
+      return { status: snapshot.status };
+    }
+    if (snapshot.status === "conflict" && "record" in snapshot) {
+      return {
+        status: "conflict",
+        record: validateStoredRecord(snapshot.record, expected),
+      };
     }
   } catch {
-    // Fall through to one stable persistence error.
+    // Fall through to one stable adapter-contract failure.
   }
   throw new CredentialStoreError("persistence_unavailable");
 }
 
 /** Strictly decodes canonical unpadded base64url with an optional byte length. */
-function decodeBase64Url(
-  value: string,
-  expectedBytes: number | undefined,
-  errorCode: "invalid_record"
-): Buffer {
+function decodeBase64Url(value: string, expectedBytes?: number): Buffer {
   if (!BASE64URL_PATTERN.test(value)) {
-    throw new CredentialStoreError(errorCode);
+    throw new CredentialStoreError("invalid_record");
   }
   const decoded = Buffer.from(value, "base64url");
   if (
@@ -789,55 +1164,120 @@ function decodeBase64Url(
     (expectedBytes !== undefined && decoded.byteLength !== expectedBytes)
   ) {
     decoded.fill(0);
-    throw new CredentialStoreError(errorCode);
+    throw new CredentialStoreError("invalid_record");
   }
   return decoded;
 }
 
-/** Rejects arrays, custom prototypes, symbols, omissions, and extensions. */
-function assertPlainExactObject(
+/** Checks a scalar for bounded canonical base64url before decoding. */
+function isBoundedBase64Url(
   value: unknown,
-  expectedKeys: readonly string[]
-): asserts value is Record<string, unknown> {
-  if (
-    typeof value !== "object" ||
+  maxLength: number
+): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maxLength &&
+    BASE64URL_PATTERN.test(value)
+  );
+}
+
+/** Accepts null or one valid bounded mutation id. */
+function isOptionalOperationId(value: unknown): value is string | null {
+  return (
     value === null ||
-    Array.isArray(value) ||
-    (Object.getPrototypeOf(value) !== Object.prototype &&
-      Object.getPrototypeOf(value) !== null) ||
-    Object.getOwnPropertySymbols(value).length !== 0
-  ) {
-    throw new CredentialStoreError("invalid_input");
-  }
-  const actual = Object.keys(value).sort();
-  const expected = [...expectedKeys].sort();
-  if (
-    actual.length !== expected.length ||
-    actual.some((key, index) => key !== expected[index])
-  ) {
-    throw new CredentialStoreError("invalid_input");
+    (typeof value === "string" && OPERATION_ID_PATTERN.test(value))
+  );
+}
+
+/**
+ * Takes one data-descriptor snapshot and rejects proxy/accessor/hidden state.
+ *
+ * No caller or adapter property is read again after this function returns.
+ * The snapshot itself is a fresh frozen plain object with only the closed keys.
+ */
+function snapshotExactDataObject(
+  value: unknown,
+  expectedShapes: readonly (readonly string[])[],
+  errorCode:
+    | "internal_configuration_invalid"
+    | "invalid_input"
+    | "invalid_record"
+    | "persistence_unavailable"
+): Readonly<Record<string, unknown>> {
+  try {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      utilTypes.isProxy(value)
+    ) {
+      throw new Error("invalid object");
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("invalid prototype");
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const ownKeys = Reflect.ownKeys(descriptors);
+    if (ownKeys.some((key) => typeof key === "symbol")) {
+      throw new Error("symbol field");
+    }
+    const actualKeys = (ownKeys as string[]).sort();
+    const matchingShape = expectedShapes.find((shape) => {
+      const expectedKeys = [...shape].sort();
+      return (
+        expectedKeys.length === actualKeys.length &&
+        expectedKeys.every((key, index) => key === actualKeys[index])
+      );
+    });
+    if (matchingShape === undefined) {
+      throw new Error("unexpected fields");
+    }
+
+    const snapshot: Record<string, unknown> = {};
+    for (const key of matchingShape) {
+      const descriptor = descriptors[key];
+      if (
+        descriptor === undefined ||
+        !("value" in descriptor) ||
+        descriptor.get !== undefined ||
+        descriptor.set !== undefined ||
+        descriptor.enumerable !== true
+      ) {
+        throw new Error("non-data field");
+      }
+      snapshot[key] = descriptor.value;
+    }
+    return Object.freeze(snapshot);
+  } catch {
+    throw new CredentialStoreError(errorCode);
   }
 }
 
 export {
   AUTH_TAG_BYTES,
   type CreateCredentialResult,
-  type CredentialEncryptionKey,
-  type CredentialEncryptionKeys,
+  type CredentialCreateMutation,
   type CredentialIdentity,
-  type CredentialMutation,
+  type CredentialKeyEncryptionKey,
+  type CredentialKeyEncryptionKeys,
   type CredentialProvider,
   type CredentialRandomSource,
+  type CredentialRotationMutation,
   CredentialStoreError,
   type CredentialStoreErrorCode,
+  DATA_KEY_BYTES,
   type DeleteCredentialResult,
   type DeleteStoredCredentialResult,
   EncryptedConnectionStore,
   type EncryptedCredentialPersistence,
-  ENCRYPTION_ALGORITHM,
   ENVELOPE_VERSION,
+  KEY_WRAP_ALGORITHM,
   MAX_CREDENTIAL_BYTES,
+  MAX_KEK_ENCRYPTIONS_PER_STORE_INSTANCE,
   NONCE_BYTES,
+  PAYLOAD_ALGORITHM,
   type ReplaceCredentialResult,
   type RotateCredentialResult,
   type StoreCredentialResult,

--- a/services/agent-gateway/encrypted-connection-store.ts
+++ b/services/agent-gateway/encrypted-connection-store.ts
@@ -1,0 +1,845 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  KeyObject,
+  randomBytes,
+  randomUUID,
+} from "node:crypto";
+
+import type { ControlPlaneOperationContext } from "./control-plane.ts";
+
+const ENVELOPE_VERSION = 1;
+const ENCRYPTION_ALGORITHM = "aes-256-gcm";
+const AUTH_TAG_BYTES = 16;
+const NONCE_BYTES = 12;
+const MAX_CREDENTIAL_BYTES = 1_048_576;
+const MAX_CIPHERTEXT_LENGTH = 1_398_102;
+const MAX_CREDENTIAL_FORMAT_VERSION = 65_535;
+
+const UUID_V4_PATTERN =
+  "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+const OWNER_ID_PATTERN = /^user_[A-Za-z0-9]{16,64}$/;
+const CREDENTIAL_ID_PATTERN = new RegExp(`^gwcred_v1_${UUID_V4_PATTERN}$`);
+const OPERATION_ID_PATTERN = new RegExp(`^mutation_v1_${UUID_V4_PATTERN}$`);
+const RECORD_REVISION_PATTERN = new RegExp(`^revision_v1_${UUID_V4_PATTERN}$`);
+const KEY_VERSION_PATTERN = /^encryption-v1-[0-9a-f]{8}$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+type CredentialProvider = "codex";
+
+type CredentialIdentity = Readonly<{
+  ownerId: string;
+  provider: CredentialProvider;
+  credentialId: string;
+  credentialFormatVersion: number;
+}>;
+
+type CredentialMutation = CredentialIdentity &
+  Readonly<{
+    operationId: string;
+  }>;
+
+type CredentialEncryptionKey = Readonly<{
+  keyVersion: string;
+  key: KeyObject;
+}>;
+
+type CredentialEncryptionKeys = Readonly<{
+  current: CredentialEncryptionKey;
+  previous?: CredentialEncryptionKey;
+}>;
+
+type StoredCredentialEnvelope = Readonly<{
+  envelopeVersion: typeof ENVELOPE_VERSION;
+  algorithm: typeof ENCRYPTION_ALGORITHM;
+  ownerId: string;
+  provider: CredentialProvider;
+  credentialId: string;
+  credentialFormatVersion: number;
+  keyVersion: string;
+  operationId: string;
+  recordRevision: string;
+  nonce: string;
+  ciphertext: string;
+  authTag: string;
+}>;
+
+type CreateCredentialResult =
+  | Readonly<{ status: "created" }>
+  | Readonly<{ status: "exists"; record: StoredCredentialEnvelope }>;
+
+type ReplaceCredentialResult =
+  | Readonly<{ status: "replaced" }>
+  | Readonly<{ status: "conflict"; record: StoredCredentialEnvelope }>
+  | Readonly<{ status: "missing" }>;
+
+type DeleteCredentialResult =
+  | Readonly<{ status: "deleted" }>
+  | Readonly<{ status: "conflict"; record: StoredCredentialEnvelope }>
+  | Readonly<{ status: "missing" }>;
+
+/**
+ * Atomic persistence boundary for encrypted credential envelopes.
+ *
+ * Implementations must key all methods by the complete credential identity.
+ * `create`, `replace`, and `delete` must each be one atomic storage operation;
+ * `replace` and `delete` compare exactly against `expectedRecordRevision`.
+ */
+interface EncryptedCredentialPersistence {
+  read(
+    identity: CredentialIdentity,
+    context?: ControlPlaneOperationContext
+  ): Promise<StoredCredentialEnvelope | null>;
+
+  create(
+    record: StoredCredentialEnvelope,
+    context?: ControlPlaneOperationContext
+  ): Promise<CreateCredentialResult>;
+
+  replace(
+    record: StoredCredentialEnvelope,
+    expectedRecordRevision: string,
+    context?: ControlPlaneOperationContext
+  ): Promise<ReplaceCredentialResult>;
+
+  delete(
+    identity: CredentialIdentity,
+    expectedRecordRevision: string,
+    context?: ControlPlaneOperationContext
+  ): Promise<DeleteCredentialResult>;
+}
+
+type CredentialStoreErrorCode =
+  | "concurrent_modification"
+  | "credential_already_exists"
+  | "credential_not_found"
+  | "decryption_failed"
+  | "internal_configuration_invalid"
+  | "invalid_input"
+  | "invalid_record"
+  | "key_unavailable"
+  | "persistence_unavailable";
+
+type StoreCredentialResult = Readonly<{
+  status: "created" | "already_created";
+  recordRevision: string;
+  keyVersion: string;
+}>;
+
+type RotateCredentialResult = Readonly<{
+  status: "already_current" | "rotated";
+  recordRevision: string;
+  keyVersion: string;
+}>;
+
+type DeleteStoredCredentialResult = Readonly<{
+  status: "deleted" | "already_deleted";
+}>;
+
+type CredentialRandomSource = Readonly<{
+  nonce: () => Uint8Array;
+  recordRevision: () => string;
+}>;
+
+/** Stable, secret-free failure exposed by the encrypted-store boundary. */
+class CredentialStoreError extends Error {
+  readonly code: CredentialStoreErrorCode;
+
+  constructor(code: CredentialStoreErrorCode) {
+    super(CREDENTIAL_STORE_ERROR_MESSAGES[code]);
+    this.name = "CredentialStoreError";
+    this.code = code;
+  }
+}
+
+const CREDENTIAL_STORE_ERROR_MESSAGES = {
+  concurrent_modification: "Credential record changed concurrently",
+  credential_already_exists: "Credential record already exists",
+  credential_not_found: "Credential record was not found",
+  decryption_failed: "Credential record could not be decrypted",
+  internal_configuration_invalid: "Credential store configuration is invalid",
+  invalid_input: "Credential store input is invalid",
+  invalid_record: "Credential record is invalid",
+  key_unavailable: "Credential encryption key is unavailable",
+  persistence_unavailable: "Credential persistence is unavailable",
+} as const satisfies Record<CredentialStoreErrorCode, string>;
+
+const DEFAULT_RANDOM_SOURCE: CredentialRandomSource = Object.freeze({
+  nonce: () => randomBytes(NONCE_BYTES),
+  recordRevision: () => `revision_v1_${randomUUID()}`,
+});
+
+/**
+ * Encrypts and atomically persists opaque provider-owned credential bundles.
+ *
+ * The store never serializes plaintext and only exposes decrypted bytes to a
+ * callback. Its temporary plaintext copy is cleared after encryption, and the
+ * decrypted buffer is cleared after the callback settles. The callback must not
+ * retain aliases and must independently clear any copy it creates.
+ */
+class EncryptedConnectionStore {
+  private readonly keys: CredentialEncryptionKeys;
+
+  constructor(
+    private readonly persistence: EncryptedCredentialPersistence,
+    keys: CredentialEncryptionKeys,
+    private readonly randomSource: CredentialRandomSource = DEFAULT_RANDOM_SOURCE
+  ) {
+    this.keys = validateKeyRing(keys);
+    validateRandomSource(randomSource);
+  }
+
+  /** Creates one credential, treating only the same operation id as a retry. */
+  async store(
+    mutation: CredentialMutation,
+    credentialPayload: Uint8Array,
+    context?: ControlPlaneOperationContext
+  ): Promise<StoreCredentialResult> {
+    const validatedMutation = validateMutation(mutation);
+    const plaintext = copyCredentialPayload(credentialPayload);
+
+    try {
+      const record = encryptCredential(
+        validatedMutation,
+        plaintext,
+        this.keys.current,
+        this.randomSource
+      );
+      const result = await callPersistence(() =>
+        this.persistence.create(record, context)
+      );
+      validateCreateResult(result, validatedMutation);
+
+      if (result.status === "created") {
+        return {
+          status: "created",
+          recordRevision: record.recordRevision,
+          keyVersion: record.keyVersion,
+        };
+      }
+
+      const existing = validateStoredRecord(result.record, validatedMutation);
+      if (existing.operationId !== validatedMutation.operationId) {
+        throw new CredentialStoreError("credential_already_exists");
+      }
+      authenticateRecord(existing, this.keys);
+
+      return {
+        status: "already_created",
+        recordRevision: existing.recordRevision,
+        keyVersion: existing.keyVersion,
+      };
+    } finally {
+      plaintext.fill(0);
+    }
+  }
+
+  /** Decrypts one bundle for a callback and clears plaintext after it settles. */
+  async use<T>(
+    identity: CredentialIdentity,
+    consume: (credentialPayload: Uint8Array) => T | PromiseLike<T>,
+    context?: ControlPlaneOperationContext
+  ): Promise<T> {
+    const validatedIdentity = validateIdentity(identity);
+    if (typeof consume !== "function") {
+      throw new CredentialStoreError("invalid_input");
+    }
+    const stored = await callPersistence(() =>
+      this.persistence.read(validatedIdentity, context)
+    );
+    if (stored === null) {
+      throw new CredentialStoreError("credential_not_found");
+    }
+
+    const record = validateStoredRecord(stored, validatedIdentity);
+    const plaintext = decryptCredential(
+      record,
+      findDecryptionKey(record, this.keys)
+    );
+    try {
+      return await consume(plaintext);
+    } finally {
+      plaintext.fill(0);
+    }
+  }
+
+  /**
+   * Re-encrypts a previous-key record under the current key with atomic CAS.
+   *
+   * Current-key records are an idempotent no-op. Unknown key versions fail
+   * closed; callers must never widen the overlap ring to bypass rotation.
+   */
+  async rotate(
+    mutation: CredentialMutation,
+    context?: ControlPlaneOperationContext
+  ): Promise<RotateCredentialResult> {
+    const validatedMutation = validateMutation(mutation);
+    const stored = await callPersistence(() =>
+      this.persistence.read(validatedMutation, context)
+    );
+    if (stored === null) {
+      throw new CredentialStoreError("credential_not_found");
+    }
+
+    const existing = validateStoredRecord(stored, validatedMutation);
+    if (existing.keyVersion === this.keys.current.keyVersion) {
+      authenticateRecord(existing, this.keys);
+      return {
+        status: "already_current",
+        recordRevision: existing.recordRevision,
+        keyVersion: existing.keyVersion,
+      };
+    }
+
+    const plaintext = decryptCredential(
+      existing,
+      findDecryptionKey(existing, this.keys)
+    );
+    try {
+      const replacement = encryptCredential(
+        validatedMutation,
+        plaintext,
+        this.keys.current,
+        this.randomSource
+      );
+      const result = await callPersistence(() =>
+        this.persistence.replace(replacement, existing.recordRevision, context)
+      );
+      validateReplaceResult(result, validatedMutation);
+
+      if (result.status === "replaced") {
+        return {
+          status: "rotated",
+          recordRevision: replacement.recordRevision,
+          keyVersion: replacement.keyVersion,
+        };
+      }
+      if (result.status === "missing") {
+        throw new CredentialStoreError("credential_not_found");
+      }
+
+      const conflicting = validateStoredRecord(
+        result.record,
+        validatedMutation
+      );
+      // A concurrent successful rotation makes retries safely idempotent.
+      if (conflicting.keyVersion === this.keys.current.keyVersion) {
+        authenticateRecord(conflicting, this.keys);
+        return {
+          status: "already_current",
+          recordRevision: conflicting.recordRevision,
+          keyVersion: conflicting.keyVersion,
+        };
+      }
+      throw new CredentialStoreError("concurrent_modification");
+    } finally {
+      plaintext.fill(0);
+    }
+  }
+
+  /** Deletes exactly the record revision observed by this operation. */
+  async delete(
+    identity: CredentialIdentity,
+    context?: ControlPlaneOperationContext
+  ): Promise<DeleteStoredCredentialResult> {
+    const validatedIdentity = validateIdentity(identity);
+    const stored = await callPersistence(() =>
+      this.persistence.read(validatedIdentity, context)
+    );
+    if (stored === null) return { status: "already_deleted" };
+
+    const existing = validateStoredRecord(stored, validatedIdentity);
+    const result = await callPersistence(() =>
+      this.persistence.delete(
+        validatedIdentity,
+        existing.recordRevision,
+        context
+      )
+    );
+    validateDeleteResult(result, validatedIdentity);
+
+    if (result.status === "deleted") return { status: "deleted" };
+    if (result.status === "missing") return { status: "already_deleted" };
+
+    validateStoredRecord(result.record, validatedIdentity);
+    throw new CredentialStoreError("concurrent_modification");
+  }
+}
+
+/** Encrypts one bounded plaintext copy with all record metadata as AAD. */
+function encryptCredential(
+  mutation: CredentialMutation,
+  plaintext: Buffer,
+  encryptionKey: CredentialEncryptionKey,
+  randomSource: CredentialRandomSource
+): StoredCredentialEnvelope {
+  let nonce: Buffer | undefined;
+  let recordRevision: string;
+  try {
+    const randomNonce = randomSource.nonce();
+    if (
+      !(randomNonce instanceof Uint8Array) ||
+      randomNonce.byteLength !== NONCE_BYTES
+    ) {
+      throw new Error("invalid nonce source");
+    }
+    nonce = Buffer.from(randomNonce);
+    recordRevision = randomSource.recordRevision();
+    if (
+      typeof recordRevision !== "string" ||
+      !RECORD_REVISION_PATTERN.test(recordRevision)
+    ) {
+      throw new Error("invalid revision source");
+    }
+  } catch {
+    nonce?.fill(0);
+    throw new CredentialStoreError("internal_configuration_invalid");
+  }
+
+  const metadata = {
+    envelopeVersion: ENVELOPE_VERSION,
+    algorithm: ENCRYPTION_ALGORITHM,
+    ownerId: mutation.ownerId,
+    provider: mutation.provider,
+    credentialId: mutation.credentialId,
+    credentialFormatVersion: mutation.credentialFormatVersion,
+    keyVersion: encryptionKey.keyVersion,
+    operationId: mutation.operationId,
+    recordRevision,
+  } as const;
+  const aad = Buffer.from(JSON.stringify(metadata), "utf8");
+
+  try {
+    const cipher = createCipheriv(
+      ENCRYPTION_ALGORITHM,
+      encryptionKey.key,
+      nonce,
+      { authTagLength: AUTH_TAG_BYTES }
+    );
+    cipher.setAAD(aad);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+    try {
+      return Object.freeze({
+        ...metadata,
+        nonce: nonce.toString("base64url"),
+        ciphertext: ciphertext.toString("base64url"),
+        authTag: authTag.toString("base64url"),
+      });
+    } finally {
+      ciphertext.fill(0);
+      authTag.fill(0);
+    }
+  } catch (error) {
+    if (error instanceof CredentialStoreError) throw error;
+    throw new CredentialStoreError("internal_configuration_invalid");
+  } finally {
+    nonce.fill(0);
+    aad.fill(0);
+  }
+}
+
+/** Authenticates and decrypts one strict envelope without reflecting details. */
+function decryptCredential(
+  record: StoredCredentialEnvelope,
+  encryptionKey: CredentialEncryptionKey
+): Buffer {
+  const nonce = decodeBase64Url(record.nonce, NONCE_BYTES, "invalid_record");
+  const ciphertext = decodeBase64Url(
+    record.ciphertext,
+    undefined,
+    "invalid_record"
+  );
+  const authTag = decodeBase64Url(
+    record.authTag,
+    AUTH_TAG_BYTES,
+    "invalid_record"
+  );
+  const aad = Buffer.from(JSON.stringify(recordMetadata(record)), "utf8");
+  let firstChunk: Buffer | undefined;
+
+  try {
+    const decipher = createDecipheriv(
+      ENCRYPTION_ALGORITHM,
+      encryptionKey.key,
+      nonce,
+      { authTagLength: AUTH_TAG_BYTES }
+    );
+    decipher.setAAD(aad);
+    decipher.setAuthTag(authTag);
+    firstChunk = decipher.update(ciphertext);
+    const finalChunk = decipher.final();
+    try {
+      const plaintext = Buffer.concat([firstChunk, finalChunk]);
+      if (
+        plaintext.byteLength === 0 ||
+        plaintext.byteLength > MAX_CREDENTIAL_BYTES
+      ) {
+        plaintext.fill(0);
+        throw new CredentialStoreError("decryption_failed");
+      }
+      return plaintext;
+    } finally {
+      finalChunk.fill(0);
+    }
+  } catch (error) {
+    if (error instanceof CredentialStoreError) throw error;
+    throw new CredentialStoreError("decryption_failed");
+  } finally {
+    firstChunk?.fill(0);
+    nonce.fill(0);
+    ciphertext.fill(0);
+    authTag.fill(0);
+    aad.fill(0);
+  }
+}
+
+/** Selects only the explicitly configured current or previous key. */
+function findDecryptionKey(
+  record: StoredCredentialEnvelope,
+  keys: CredentialEncryptionKeys
+): CredentialEncryptionKey {
+  if (record.keyVersion === keys.current.keyVersion) return keys.current;
+  if (record.keyVersion === keys.previous?.keyVersion) return keys.previous;
+  throw new CredentialStoreError("key_unavailable");
+}
+
+/** Authenticates an envelope for an idempotent path without retaining plaintext. */
+function authenticateRecord(
+  record: StoredCredentialEnvelope,
+  keys: CredentialEncryptionKeys
+): void {
+  const plaintext = decryptCredential(record, findDecryptionKey(record, keys));
+  plaintext.fill(0);
+}
+
+/** Returns metadata in the one canonical AAD property order. */
+function recordMetadata(record: StoredCredentialEnvelope) {
+  return {
+    envelopeVersion: record.envelopeVersion,
+    algorithm: record.algorithm,
+    ownerId: record.ownerId,
+    provider: record.provider,
+    credentialId: record.credentialId,
+    credentialFormatVersion: record.credentialFormatVersion,
+    keyVersion: record.keyVersion,
+    operationId: record.operationId,
+    recordRevision: record.recordRevision,
+  } as const;
+}
+
+/** Copies and bounds caller-owned plaintext before any asynchronous operation. */
+function copyCredentialPayload(payload: Uint8Array): Buffer {
+  if (!(payload instanceof Uint8Array)) {
+    throw new CredentialStoreError("invalid_input");
+  }
+  if (payload.byteLength === 0 || payload.byteLength > MAX_CREDENTIAL_BYTES) {
+    throw new CredentialStoreError("invalid_input");
+  }
+  return Buffer.from(payload);
+}
+
+/** Validates and freezes the closed credential identity contract. */
+function validateIdentity(value: CredentialIdentity): CredentialIdentity {
+  assertPlainExactObject(value, [
+    "ownerId",
+    "provider",
+    "credentialId",
+    "credentialFormatVersion",
+  ]);
+  if (
+    !OWNER_ID_PATTERN.test(value.ownerId) ||
+    value.provider !== "codex" ||
+    !CREDENTIAL_ID_PATTERN.test(value.credentialId) ||
+    !Number.isSafeInteger(value.credentialFormatVersion) ||
+    value.credentialFormatVersion < 1 ||
+    value.credentialFormatVersion > MAX_CREDENTIAL_FORMAT_VERSION
+  ) {
+    throw new CredentialStoreError("invalid_input");
+  }
+  return Object.freeze({ ...value });
+}
+
+/** Validates the identity plus one bounded idempotency key. */
+function validateMutation(value: CredentialMutation): CredentialMutation {
+  assertPlainExactObject(value, [
+    "ownerId",
+    "provider",
+    "credentialId",
+    "credentialFormatVersion",
+    "operationId",
+  ]);
+  const identity = validateIdentity({
+    ownerId: value.ownerId,
+    provider: value.provider,
+    credentialId: value.credentialId,
+    credentialFormatVersion: value.credentialFormatVersion,
+  });
+  if (!OPERATION_ID_PATTERN.test(value.operationId)) {
+    throw new CredentialStoreError("invalid_input");
+  }
+  return Object.freeze({ ...identity, operationId: value.operationId });
+}
+
+/** Validates a persisted envelope before its metadata or ciphertext is trusted. */
+function validateStoredRecord(
+  value: StoredCredentialEnvelope,
+  expected: CredentialIdentity
+): StoredCredentialEnvelope {
+  try {
+    assertPlainExactObject(value, [
+      "envelopeVersion",
+      "algorithm",
+      "ownerId",
+      "provider",
+      "credentialId",
+      "credentialFormatVersion",
+      "keyVersion",
+      "operationId",
+      "recordRevision",
+      "nonce",
+      "ciphertext",
+      "authTag",
+    ]);
+    if (
+      value.envelopeVersion !== ENVELOPE_VERSION ||
+      value.algorithm !== ENCRYPTION_ALGORITHM ||
+      value.ownerId !== expected.ownerId ||
+      value.provider !== expected.provider ||
+      value.credentialId !== expected.credentialId ||
+      value.credentialFormatVersion !== expected.credentialFormatVersion ||
+      !KEY_VERSION_PATTERN.test(value.keyVersion) ||
+      !OPERATION_ID_PATTERN.test(value.operationId) ||
+      !RECORD_REVISION_PATTERN.test(value.recordRevision) ||
+      value.nonce.length !== 16 ||
+      value.authTag.length !== 22 ||
+      value.ciphertext.length === 0 ||
+      value.ciphertext.length > MAX_CIPHERTEXT_LENGTH ||
+      !BASE64URL_PATTERN.test(value.nonce) ||
+      !BASE64URL_PATTERN.test(value.authTag) ||
+      !BASE64URL_PATTERN.test(value.ciphertext)
+    ) {
+      throw new CredentialStoreError("invalid_record");
+    }
+    decodeBase64Url(value.nonce, NONCE_BYTES, "invalid_record").fill(0);
+    decodeBase64Url(value.authTag, AUTH_TAG_BYTES, "invalid_record").fill(0);
+    const ciphertext = decodeBase64Url(
+      value.ciphertext,
+      undefined,
+      "invalid_record"
+    );
+    if (
+      ciphertext.byteLength === 0 ||
+      ciphertext.byteLength > MAX_CREDENTIAL_BYTES
+    ) {
+      ciphertext.fill(0);
+      throw new CredentialStoreError("invalid_record");
+    }
+    ciphertext.fill(0);
+    return Object.freeze({ ...value });
+  } catch (error) {
+    if (
+      error instanceof CredentialStoreError &&
+      error.code === "invalid_record"
+    ) {
+      throw error;
+    }
+    throw new CredentialStoreError("invalid_record");
+  }
+}
+
+/** Validates the two-key overlap ring without exporting key bytes. */
+function validateKeyRing(
+  value: CredentialEncryptionKeys
+): CredentialEncryptionKeys {
+  try {
+    assertPlainExactObject(
+      value,
+      value.previous === undefined ? ["current"] : ["current", "previous"]
+    );
+    const current = validateEncryptionKey(value.current);
+    const previous = value.previous
+      ? validateEncryptionKey(value.previous)
+      : undefined;
+    if (previous?.keyVersion === current.keyVersion) {
+      throw new CredentialStoreError("internal_configuration_invalid");
+    }
+    return Object.freeze({ current, ...(previous ? { previous } : {}) });
+  } catch {
+    throw new CredentialStoreError("internal_configuration_invalid");
+  }
+}
+
+/** Accepts one non-exported-by-this-module 256-bit Node secret KeyObject. */
+function validateEncryptionKey(
+  value: CredentialEncryptionKey
+): CredentialEncryptionKey {
+  assertPlainExactObject(value, ["keyVersion", "key"]);
+  if (
+    !KEY_VERSION_PATTERN.test(value.keyVersion) ||
+    !(value.key instanceof KeyObject) ||
+    value.key.type !== "secret" ||
+    value.key.symmetricKeySize !== 32
+  ) {
+    throw new CredentialStoreError("internal_configuration_invalid");
+  }
+  return Object.freeze({ ...value });
+}
+
+/** Validates injected randomness synchronously without consuming it. */
+function validateRandomSource(value: CredentialRandomSource): void {
+  try {
+    assertPlainExactObject(value, ["nonce", "recordRevision"]);
+    if (
+      typeof value.nonce !== "function" ||
+      typeof value.recordRevision !== "function"
+    ) {
+      throw new Error("invalid random source");
+    }
+  } catch {
+    throw new CredentialStoreError("internal_configuration_invalid");
+  }
+}
+
+/** Normalizes all adapter throws so backend details never cross the boundary. */
+async function callPersistence<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch {
+    throw new CredentialStoreError("persistence_unavailable");
+  }
+}
+
+/** Validates the closed create-result union before branching on it. */
+function validateCreateResult(
+  value: CreateCredentialResult,
+  expected: CredentialIdentity
+): void {
+  try {
+    assertPlainExactObject(
+      value,
+      value.status === "created" ? ["status"] : ["status", "record"]
+    );
+    if (value.status === "created") return;
+    if (value.status === "exists") {
+      validateStoredRecord(value.record, expected);
+      return;
+    }
+  } catch {
+    // Fall through to one stable persistence error.
+  }
+  throw new CredentialStoreError("persistence_unavailable");
+}
+
+/** Validates the closed CAS-replace result union. */
+function validateReplaceResult(
+  value: ReplaceCredentialResult,
+  expected: CredentialIdentity
+): void {
+  try {
+    const expectedKeys =
+      value.status === "conflict" ? ["status", "record"] : ["status"];
+    assertPlainExactObject(value, expectedKeys);
+    if (value.status === "replaced" || value.status === "missing") return;
+    if (value.status === "conflict") {
+      validateStoredRecord(value.record, expected);
+      return;
+    }
+  } catch {
+    // Fall through to one stable persistence error.
+  }
+  throw new CredentialStoreError("persistence_unavailable");
+}
+
+/** Validates the closed CAS-delete result union. */
+function validateDeleteResult(
+  value: DeleteCredentialResult,
+  expected: CredentialIdentity
+): void {
+  try {
+    const expectedKeys =
+      value.status === "conflict" ? ["status", "record"] : ["status"];
+    assertPlainExactObject(value, expectedKeys);
+    if (value.status === "deleted" || value.status === "missing") return;
+    if (value.status === "conflict") {
+      validateStoredRecord(value.record, expected);
+      return;
+    }
+  } catch {
+    // Fall through to one stable persistence error.
+  }
+  throw new CredentialStoreError("persistence_unavailable");
+}
+
+/** Strictly decodes canonical unpadded base64url with an optional byte length. */
+function decodeBase64Url(
+  value: string,
+  expectedBytes: number | undefined,
+  errorCode: "invalid_record"
+): Buffer {
+  if (!BASE64URL_PATTERN.test(value)) {
+    throw new CredentialStoreError(errorCode);
+  }
+  const decoded = Buffer.from(value, "base64url");
+  if (
+    decoded.toString("base64url") !== value ||
+    (expectedBytes !== undefined && decoded.byteLength !== expectedBytes)
+  ) {
+    decoded.fill(0);
+    throw new CredentialStoreError(errorCode);
+  }
+  return decoded;
+}
+
+/** Rejects arrays, custom prototypes, symbols, omissions, and extensions. */
+function assertPlainExactObject(
+  value: unknown,
+  expectedKeys: readonly string[]
+): asserts value is Record<string, unknown> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    (Object.getPrototypeOf(value) !== Object.prototype &&
+      Object.getPrototypeOf(value) !== null) ||
+    Object.getOwnPropertySymbols(value).length !== 0
+  ) {
+    throw new CredentialStoreError("invalid_input");
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...expectedKeys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    throw new CredentialStoreError("invalid_input");
+  }
+}
+
+export {
+  AUTH_TAG_BYTES,
+  type CreateCredentialResult,
+  type CredentialEncryptionKey,
+  type CredentialEncryptionKeys,
+  type CredentialIdentity,
+  type CredentialMutation,
+  type CredentialProvider,
+  type CredentialRandomSource,
+  CredentialStoreError,
+  type CredentialStoreErrorCode,
+  type DeleteCredentialResult,
+  type DeleteStoredCredentialResult,
+  EncryptedConnectionStore,
+  type EncryptedCredentialPersistence,
+  ENCRYPTION_ALGORITHM,
+  ENVELOPE_VERSION,
+  MAX_CREDENTIAL_BYTES,
+  NONCE_BYTES,
+  type ReplaceCredentialResult,
+  type RotateCredentialResult,
+  type StoreCredentialResult,
+  type StoredCredentialEnvelope,
+};

--- a/services/agent-gateway/encrypted-connection-store.ts
+++ b/services/agent-gateway/encrypted-connection-store.ts
@@ -101,7 +101,9 @@ type DeleteCredentialResult =
  *
  * Implementations must key every method by the complete credential identity.
  * `create`, `replace`, and `delete` must each be one atomic storage operation;
- * replace and delete compare exactly against `expectedRecordRevision`.
+ * replace and delete compare exactly against `expectedRecordRevision`. A read
+ * after an ambiguous create outcome must be strongly consistent with any create
+ * that committed before that outcome; otherwise reconciliation fails closed.
  */
 interface EncryptedCredentialPersistence {
   read(
@@ -245,10 +247,27 @@ class EncryptedConnectionStore {
     credentialPayload: Buffer,
     context?: ControlPlaneOperationContext
   ): Promise<StoreCredentialResult> {
-    const validatedMutation = validateCreateMutation(mutation);
-    const plaintext = takeCredentialPayload(credentialPayload);
+    if (!Buffer.isBuffer(credentialPayload)) {
+      throw new CredentialStoreError("invalid_input");
+    }
+    return this.storeOwnedCredentialBuffer(
+      credentialPayload,
+      mutation,
+      context
+    );
+  }
+
+  /** Owns and clears the Buffer before inspecting any hostile metadata or size. */
+  private async storeOwnedCredentialBuffer(
+    plaintext: Buffer,
+    mutation: CredentialCreateMutation,
+    context?: ControlPlaneOperationContext
+  ): Promise<StoreCredentialResult> {
     let candidate: StoredCredentialEnvelope;
+    let validatedMutation: CredentialCreateMutation;
     try {
+      assertCredentialPayloadBounds(plaintext);
+      validatedMutation = validateCreateMutation(mutation);
       candidate = this.encryptEnvelope(
         validatedMutation,
         {
@@ -260,13 +279,20 @@ class EncryptedConnectionStore {
       );
     } finally {
       // This executes before the first persistence/dependency await.
-      plaintext.fill(0);
+      clearBuffer(plaintext);
     }
 
-    const result = validateCreateResult(
-      await callPersistence(() => this.persistence.create(candidate, context)),
-      validatedMutation
-    );
+    let result: CreateCredentialResult;
+    try {
+      const rawResult = await this.persistence.create(candidate, context);
+      result = validateCreateResult(rawResult, validatedMutation);
+    } catch {
+      return this.reconcileAmbiguousCreate(
+        candidate,
+        validatedMutation,
+        context
+      );
+    }
     if (result.status === "created") {
       return {
         status: "created",
@@ -275,9 +301,46 @@ class EncryptedConnectionStore {
       };
     }
 
-    const existing = result.record;
+    return this.resolveExistingCreate(
+      candidate,
+      result.record,
+      validatedMutation
+    );
+  }
+
+  /** Resolves a lost or malformed create response from encrypted state only. */
+  private async reconcileAmbiguousCreate(
+    candidate: StoredCredentialEnvelope,
+    mutation: CredentialCreateMutation,
+    context?: ControlPlaneOperationContext
+  ): Promise<StoreCredentialResult> {
+    let stored: StoredCredentialEnvelope | null;
+    try {
+      stored = await this.persistence.read(mutation, context);
+    } catch {
+      throw new CredentialStoreError("persistence_unavailable");
+    }
+    if (stored === null) {
+      throw new CredentialStoreError("persistence_unavailable");
+    }
+
+    let existing: StoredCredentialEnvelope;
+    try {
+      existing = validateStoredRecord(stored, mutation);
+    } catch {
+      throw new CredentialStoreError("persistence_unavailable");
+    }
+    return this.resolveExistingCreate(candidate, existing, mutation);
+  }
+
+  /** Accepts an existing create only when lineage and payload both match. */
+  private resolveExistingCreate(
+    candidate: StoredCredentialEnvelope,
+    existing: StoredCredentialEnvelope,
+    mutation: CredentialCreateMutation
+  ): StoreCredentialResult {
     if (
-      existing.creationOperationId !== validatedMutation.creationOperationId ||
+      existing.creationOperationId !== mutation.creationOperationId ||
       !this.recordsContainSamePayload(candidate, existing)
     ) {
       throw new CredentialStoreError("credential_already_exists");
@@ -311,7 +374,7 @@ class EncryptedConnectionStore {
     try {
       return await consume(plaintext);
     } finally {
-      plaintext.fill(0);
+      clearBuffer(plaintext);
     }
   }
 
@@ -360,7 +423,7 @@ class EncryptedConnectionStore {
       );
     } finally {
       // Re-encryption owns no mutable plaintext when the CAS begins.
-      plaintext.fill(0);
+      clearBuffer(plaintext);
     }
 
     const result = validateReplaceResult(
@@ -439,9 +502,9 @@ class EncryptedConnectionStore {
         material
       );
     } finally {
-      material.dataKey.fill(0);
-      material.payloadNonce.fill(0);
-      material.wrapNonce.fill(0);
+      clearBuffer(material.dataKey);
+      clearBuffer(material.payloadNonce);
+      clearBuffer(material.wrapNonce);
     }
   }
 
@@ -453,7 +516,7 @@ class EncryptedConnectionStore {
   /** Authenticates an envelope without retaining its plaintext. */
   private authenticateRecord(record: StoredCredentialEnvelope): void {
     const plaintext = this.decryptEnvelope(record);
-    plaintext.fill(0);
+    clearBuffer(plaintext);
   }
 
   /** Constant-time compares credential contents while clearing both plaintexts. */
@@ -471,10 +534,10 @@ class EncryptedConnectionStore {
       secondDigest = createHash("sha256").update(secondPlaintext).digest();
       return timingSafeEqual(firstDigest, secondDigest);
     } finally {
-      firstPlaintext.fill(0);
-      secondPlaintext?.fill(0);
-      firstDigest?.fill(0);
-      secondDigest?.fill(0);
+      clearBuffer(firstPlaintext);
+      clearBuffer(secondPlaintext);
+      clearBuffer(firstDigest);
+      clearBuffer(secondDigest);
     }
   }
 
@@ -508,7 +571,7 @@ class EncryptedConnectionStore {
 
       const fingerprintBytes = createHash("sha256").update(dataKey).digest();
       const dataKeyFingerprint = fingerprintBytes.toString("base64url");
-      fingerprintBytes.fill(0);
+      clearBuffer(fingerprintBytes);
       const wrapNonceText = wrapNonce.toString("base64url");
       const keyNonces =
         this.wrapNoncesByKeyVersion.get(this.keys.current.keyVersion) ??
@@ -526,9 +589,9 @@ class EncryptedConnectionStore {
       this.kekEncryptionCount += 1;
       return { dataKey, payloadNonce, wrapNonce, recordRevision };
     } catch {
-      dataKey?.fill(0);
-      payloadNonce?.fill(0);
-      wrapNonce?.fill(0);
+      clearBuffer(dataKey);
+      clearBuffer(payloadNonce);
+      clearBuffer(wrapNonce);
       throw new CredentialStoreError("internal_configuration_invalid");
     }
   }
@@ -582,7 +645,7 @@ function encryptCredential(
         ciphertextDigest: payloadDigest.toString("base64url"),
       });
     } finally {
-      payloadDigest.fill(0);
+      clearBuffer(payloadDigest);
     }
 
     const wrapCipher = createCipheriv(
@@ -611,12 +674,12 @@ function encryptCredential(
     if (error instanceof CredentialStoreError) throw error;
     throw new CredentialStoreError("internal_configuration_invalid");
   } finally {
-    payloadAad.fill(0);
-    wrapAad?.fill(0);
-    ciphertext?.fill(0);
-    payloadAuthTag?.fill(0);
-    wrappedDataKey?.fill(0);
-    wrapAuthTag?.fill(0);
+    clearBuffer(payloadAad);
+    clearBuffer(wrapAad);
+    clearBuffer(ciphertext);
+    clearBuffer(payloadAuthTag);
+    clearBuffer(wrappedDataKey);
+    clearBuffer(wrapAuthTag);
   }
 }
 
@@ -640,7 +703,7 @@ function decryptCredential(
     payloadAuthTag: record.payloadAuthTag,
     ciphertextDigest: payloadDigest.toString("base64url"),
   });
-  payloadDigest.fill(0);
+  clearBuffer(payloadDigest);
   let dataKey: Buffer | undefined;
   let plaintextFirst: Buffer | undefined;
 
@@ -679,28 +742,28 @@ function decryptCredential(
           plaintext.byteLength === 0 ||
           plaintext.byteLength > MAX_CREDENTIAL_BYTES
         ) {
-          plaintext.fill(0);
+          clearBuffer(plaintext);
           throw new Error("invalid plaintext length");
         }
         return plaintext;
       } finally {
-        plaintextFinal.fill(0);
+        clearBuffer(plaintextFinal);
       }
     } finally {
-      payloadAad.fill(0);
+      clearBuffer(payloadAad);
     }
   } catch {
     throw new CredentialStoreError("decryption_failed");
   } finally {
-    dataKey?.fill(0);
-    plaintextFirst?.fill(0);
-    payloadNonce.fill(0);
-    ciphertext.fill(0);
-    payloadAuthTag.fill(0);
-    wrappedDataKey.fill(0);
-    wrapNonce.fill(0);
-    wrapAuthTag.fill(0);
-    wrapAad.fill(0);
+    clearBuffer(dataKey);
+    clearBuffer(plaintextFirst);
+    clearBuffer(payloadNonce);
+    clearBuffer(ciphertext);
+    clearBuffer(payloadAuthTag);
+    clearBuffer(wrappedDataKey);
+    clearBuffer(wrapNonce);
+    clearBuffer(wrapAuthTag);
+    clearBuffer(wrapAad);
   }
 }
 
@@ -752,23 +815,28 @@ function findDecryptionKey(
   throw new CredentialStoreError("key_unavailable");
 }
 
-/** Accepts ownership of one bounded mutable Buffer for synchronous encryption. */
-function takeCredentialPayload(payload: Buffer): Buffer {
-  if (!Buffer.isBuffer(payload)) {
-    throw new CredentialStoreError("invalid_input");
-  }
+/** Bounds a Buffer after ownership has entered an unconditional clearing scope. */
+function assertCredentialPayloadBounds(payload: Buffer): void {
   if (payload.byteLength === 0 || payload.byteLength > MAX_CREDENTIAL_BYTES) {
     throw new CredentialStoreError("invalid_input");
   }
-  return payload;
 }
 
 /** Accepts ownership of one exact-sized random Buffer for immediate clearing. */
 function takeRandomBytes(value: unknown, expectedBytes: number): Buffer {
-  if (!Buffer.isBuffer(value) || value.byteLength !== expectedBytes) {
+  if (!Buffer.isBuffer(value)) {
+    throw new Error("invalid random bytes");
+  }
+  if (value.byteLength !== expectedBytes) {
+    clearBuffer(value);
     throw new Error("invalid random bytes");
   }
   return value;
+}
+
+/** Clears a Buffer through the native method even if an instance shadows it. */
+function clearBuffer(value: Buffer | undefined): void {
+  if (value !== undefined) Buffer.prototype.fill.call(value, 0);
 }
 
 /** Checks an owned random buffer without allocating secret-derived text. */
@@ -958,12 +1026,12 @@ function validateStoredRecord(
       throw new CredentialStoreError("invalid_record");
     }
   } finally {
-    payloadNonce.fill(0);
-    payloadAuthTag.fill(0);
-    wrapNonce.fill(0);
-    wrapAuthTag.fill(0);
-    wrappedDataKey.fill(0);
-    ciphertext.fill(0);
+    clearBuffer(payloadNonce);
+    clearBuffer(payloadAuthTag);
+    clearBuffer(wrapNonce);
+    clearBuffer(wrapAuthTag);
+    clearBuffer(wrappedDataKey);
+    clearBuffer(ciphertext);
   }
 
   return Object.freeze({
@@ -1163,7 +1231,7 @@ function decodeBase64Url(value: string, expectedBytes?: number): Buffer {
     decoded.toString("base64url") !== value ||
     (expectedBytes !== undefined && decoded.byteLength !== expectedBytes)
   ) {
-    decoded.fill(0);
+    clearBuffer(decoded);
     throw new CredentialStoreError("invalid_record");
   }
   return decoded;

--- a/services/agent-gateway/encrypted-connection-store.ts
+++ b/services/agent-gateway/encrypted-connection-store.ts
@@ -32,6 +32,13 @@ const RECORD_REVISION_PATTERN = new RegExp(`^revision_v1_${UUID_V4_PATTERN}$`);
 const KEY_VERSION_PATTERN = /^encryption-v1-[0-9a-f]{8}$/;
 const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
 
+const TYPED_ARRAY_PROTOTYPE = Object.getPrototypeOf(Uint8Array.prototype);
+const TYPED_ARRAY_BYTE_LENGTH_GETTER = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  "byteLength"
+)?.get;
+const TYPED_ARRAY_FILL = Uint8Array.prototype.fill;
+
 type CredentialProvider = "codex";
 
 type CredentialIdentity = Readonly<{
@@ -817,7 +824,8 @@ function findDecryptionKey(
 
 /** Bounds a Buffer after ownership has entered an unconditional clearing scope. */
 function assertCredentialPayloadBounds(payload: Buffer): void {
-  if (payload.byteLength === 0 || payload.byteLength > MAX_CREDENTIAL_BYTES) {
+  const byteLength = nativeBufferByteLength(payload);
+  if (byteLength === 0 || byteLength > MAX_CREDENTIAL_BYTES) {
     throw new CredentialStoreError("invalid_input");
   }
 }
@@ -827,22 +835,36 @@ function takeRandomBytes(value: unknown, expectedBytes: number): Buffer {
   if (!Buffer.isBuffer(value)) {
     throw new Error("invalid random bytes");
   }
-  if (value.byteLength !== expectedBytes) {
-    clearBuffer(value);
+  const ownedBuffer = value;
+  try {
+    if (nativeBufferByteLength(ownedBuffer) !== expectedBytes) {
+      throw new Error("invalid random bytes");
+    }
+    return ownedBuffer;
+  } catch {
+    clearBuffer(ownedBuffer);
     throw new Error("invalid random bytes");
   }
-  return value;
 }
 
 /** Clears a Buffer through the native method even if an instance shadows it. */
 function clearBuffer(value: Buffer | undefined): void {
-  if (value !== undefined) Buffer.prototype.fill.call(value, 0);
+  if (value !== undefined) Reflect.apply(TYPED_ARRAY_FILL, value, [0]);
+}
+
+/** Reads the intrinsic byte length without invoking an own accessor override. */
+function nativeBufferByteLength(value: Buffer): number {
+  if (TYPED_ARRAY_BYTE_LENGTH_GETTER === undefined) {
+    throw new CredentialStoreError("internal_configuration_invalid");
+  }
+  return Reflect.apply(TYPED_ARRAY_BYTE_LENGTH_GETTER, value, []);
 }
 
 /** Checks an owned random buffer without allocating secret-derived text. */
 function isAllZero(value: Buffer): boolean {
   let combined = 0;
-  for (let index = 0; index < value.length; index += 1) {
+  const byteLength = nativeBufferByteLength(value);
+  for (let index = 0; index < byteLength; index += 1) {
     combined |= value[index];
   }
   return combined === 0;


### PR DESCRIPTION
## Feature

Adds a pure, injected encrypted connection store for opaque Codex credential bundles. No real credential, environment, key service, database, network, provider login, gateway host, or deployment is touched.

## Architecture

```text
credential Buffer -- transfer ownership --> fresh per-record DEK
                                               |
                                      AES-256-GCM payload
                                               |
                                      ciphertext + payload tag
                                               |
current versioned KEK -- wraps DEK only --> wrapped DEK + wrap tag
                                               |
                 clear payload / DEK / random buffers before persistence await
                                               |
                                      encrypted v1 envelope
                                               |
                           atomic create / CAS replace / CAS delete
```

- Fresh 256-bit DEK per credential; the current/previous KEKs only wrap and unwrap DEKs.
- Independent 96-bit CSPRNG nonces and 128-bit tags for payload and key-wrap layers.
- Both canonical AAD layers bind owner, provider, credential id, credential-format version, KEK version, immutable creation operation id, rotation state, and record revision. The wrap layer also binds the exact encrypted payload.
- Current/previous labels with identical key material are rejected without exporting keys.
- Buffer ownership begins before bounds or hostile metadata validation. Captured typed-array length and fill intrinsics bypass hostile own `byteLength`, `length`, and `fill` overrides. Every Buffer path—including invalid input, random-source rejection, collision, adapter failure, and success—is cleared; valid plaintext and generated key/nonce buffers are zeroed synchronously before persistence awaits.
- Same-operation creation retries require both immutable creation identity and exact credential payload equality; rotation uses separate operation lineage and preserves creation retries across re-encryption/restart.
- A rejected or malformed create outcome triggers one strongly-consistent read-after-ambiguous reconciliation. Only the prepared encrypted candidate crosses the await; exact committed state returns idempotent success, collisions are denied, and unavailable reconciliation fails honestly.
- Every caller input, adapter record, and adapter outcome is captured through one exact data-descriptor snapshot. Proxies, accessors, symbols, hidden/extra fields, malformed encodings, and over-bounds values fail closed.
- Atomic create/CAS-replace/CAS-delete prevents stale overwrite and deletion.
- Stable store failures do not reflect adapter details, identifiers, ciphertext, or plaintext.

## Randomness boundary

The default uses Node's CSPRNG. V1 rejects all-zero material, duplicate layer nonces, repeated DEKs, and repeated wrap nonces within a store instance, and caps each instance at 65,536 KEK encryptions. In-memory accounting cannot coordinate independent processes or survive restart, so fleet-wide invocation accounting, persistent topology, and KEK rotation remain blocking human gates before production credentials.

## Validation

- Focused encrypted-store suite — 33/33 passed
- `pnpm test` — 76 files, 1,083 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with 5 pre-existing warnings, 0 errors
- `pnpm format:check` — passed
- `git diff --check` — passed

## Human gates

Production KMS/HSM custody and recovery, fleet-wide nonce/invocation allocation, key-version rotation audit, persistent atomic adapter/database schema, retention/backup deletion policy, gateway host, real Codex login/credential handling, and deployment remain explicitly human-gated follow-up work.
