### PR TITLE
feat(gateway): add versioned operation protocol

### DIFF
--- a/docs/GATEWAY_OPERATION_PROTOCOL.md
+++ b/docs/GATEWAY_OPERATION_PROTOCOL.md
@@ -1,0 +1,63 @@
+# Gateway operation protocol v1
+
+This protocol is the closed server-to-gateway seam for the three Codex operations
+already authorized by internal assertions. It defines transport contracts only;
+it does not enable a provider process, credentials, networking, database writes,
+deployment, or application entrypoint routing.
+
+## Authority model
+
+- Chat and node editing require an owned mindmap intent. The server resolver
+  replaces the requested id with its canonical owned id, and the gateway route
+  validates that exact canonical authority before execution.
+- First-map generation cannot claim ownership of a map that does not exist. It
+  uses the fixed `owner-bootstrap/create-first-mindmap` capability. The resolver
+  must authenticate the owner and default connected Codex connection atomically;
+  neither an owner id nor a synthetic map id crosses in the payload.
+- Provider, connection, owner, gateway origin, route, assertion, model, command,
+  credential home, and environment remain construction-time server authority.
+
+```text
+validated server intent
+        |
+        v
+atomic authority resolver -----> canonical owned map
+        |                         or owner bootstrap capability
+        v
+short-lived signed operation assertion
+        |
+        v
+fixed HTTPS operation route ---> v1 envelope validation
+                                  | operation + resource exact match
+                                  v
+                         server-owned executor registry
+                                  |
+                     +------------+-------------+
+                     |                          |
+                bounded JSON              bounded stream
+                action result             chat response
+```
+
+## Response lifecycle
+
+Action responses use the existing strict JSON success/failure envelope and add
+operation-specific result validation. Chat uses the fixed versioned content type
+`application/vnd.sprig.chat-stream+octet-stream;version=1`. The dispatcher
+validates each closed application event and serializes it as one versioned NDJSON
+frame. The client incrementally decodes frames into application chat events and
+returns a zero-buffer, demand-driven `ReadableStream`; it does not read the
+gateway body before its consumer requests data.
+
+The fixed request deadline remains active for the stream lifetime. Caller abort,
+deadline, consumer cancellation, malformed chunks, length mismatch, or byte/chunk
+overflow cancels and releases the upstream reader. Redirects, response URL drift,
+unexpected status/content type, unbounded header values, and late response bodies
+fail closed. Signed operations are sent once and never retried.
+
+## Human-gated follow-ups
+
+Production composition still requires separate review of the persistent gateway
+host, key custody and rotation, durable replay/rate stores, encrypted credential
+home adapter, Convex deployment, beta cohort, and real Codex login. Application
+entrypoints must pass their validated operation inputs and use these action/chat
+APIs in a later reviewed slice.

--- a/docs/GATEWAY_OPERATION_PROTOCOL.md
+++ b/docs/GATEWAY_OPERATION_PROTOCOL.md
@@ -54,6 +54,14 @@ overflow cancels and releases the upstream reader. Redirects, response URL drift
 unexpected status/content type, unbounded header values, and late response bodies
 fail closed. Signed operations are sent once and never retried.
 
+The gateway retains the provider's derived abort signal, timer, request listener,
+and iterator through stream completion. Cancellation races every lazy `next()`
+and closes the upstream iterator exactly once behind a finite cleanup bound;
+provider `next()` and `return()` failures are normalized without reflecting their
+messages. Client framing retains immutable fragments in a queue, scans every byte
+once, and copies bytes only when a complete line is decoded, including when UTF-8
+code points cross transport chunks.
+
 ## Human-gated follow-ups
 
 Production composition still requires separate review of the persistent gateway

--- a/lib/gateway/ndjson-frame-buffer.test.ts
+++ b/lib/gateway/ndjson-frame-buffer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { BoundedNdjsonFrameBuffer } from "./ndjson-frame-buffer.ts";
+
+describe("bounded NDJSON frame buffer", () => {
+  it("performs amortized-linear work across thousands of fragments", () => {
+    const fragmentCount = 4_096;
+    const buffer = new BoundedNdjsonFrameBuffer(fragmentCount + 16);
+    for (let index = 0; index < fragmentCount; index += 1) {
+      buffer.push(new Uint8Array([97]));
+      expect(buffer.takeLine()).toBeNull();
+    }
+    buffer.push(new Uint8Array([10]));
+
+    expect(buffer.takeLine()).toHaveLength(fragmentCount);
+    expect(buffer.metrics()).toEqual({
+      bytesCopied: fragmentCount,
+      bytesPushed: fragmentCount + 1,
+      bytesScanned: fragmentCount + 1,
+    });
+  });
+
+  it("retains trailing bytes and extracts coalesced lines in order", () => {
+    const buffer = new BoundedNdjsonFrameBuffer(32);
+    buffer.push(new TextEncoder().encode("one\ntwo\ntrail"));
+
+    expect(new TextDecoder().decode(buffer.takeLine() ?? undefined)).toBe(
+      "one"
+    );
+    expect(new TextDecoder().decode(buffer.takeLine() ?? undefined)).toBe(
+      "two"
+    );
+    expect(buffer.takeLine()).toBeNull();
+    expect(buffer.pendingByteLength).toBe(5);
+  });
+});

--- a/lib/gateway/ndjson-frame-buffer.ts
+++ b/lib/gateway/ndjson-frame-buffer.ts
@@ -1,0 +1,121 @@
+type FrameBufferMetrics = Readonly<{
+  bytesCopied: number;
+  bytesPushed: number;
+  bytesScanned: number;
+}>;
+
+type Fragment = {
+  bytes: Uint8Array;
+  start: number;
+};
+
+/**
+ * Incrementally finds NDJSON lines without repeatedly joining fragmented input.
+ * Each byte is scanned once and copied at most once into its completed line.
+ */
+class BoundedNdjsonFrameBuffer {
+  private fragments: Fragment[] = [];
+  private headIndex = 0;
+  private scanIndex = 0;
+  private scanOffset = 0;
+  private currentLineBytes = 0;
+  private pendingBytes = 0;
+  private bytesCopied = 0;
+  private bytesPushed = 0;
+  private bytesScanned = 0;
+
+  constructor(private readonly maxLineBytes: number) {
+    if (!Number.isSafeInteger(maxLineBytes) || maxLineBytes < 1) {
+      throw new RangeError("Invalid NDJSON line bound");
+    }
+  }
+
+  /** Retains one immutable transport fragment without copying its bytes. */
+  push(bytes: Uint8Array): void {
+    if (!(bytes instanceof Uint8Array) || bytes.byteLength === 0) {
+      throw new TypeError("Invalid NDJSON fragment");
+    }
+    this.fragments.push({ bytes, start: 0 });
+    this.pendingBytes += bytes.byteLength;
+    this.bytesPushed += bytes.byteLength;
+  }
+
+  /** Returns the next complete line, excluding its newline, or null. */
+  takeLine(): Uint8Array | null {
+    while (this.scanIndex < this.fragments.length) {
+      const fragment = this.fragments[this.scanIndex];
+      const newline = fragment.bytes.indexOf(10, this.scanOffset);
+      if (newline < 0) {
+        const scanned = fragment.bytes.byteLength - this.scanOffset;
+        this.bytesScanned += scanned;
+        this.currentLineBytes += scanned;
+        if (this.currentLineBytes > this.maxLineBytes) {
+          throw new RangeError("NDJSON line exceeds bound");
+        }
+        this.scanIndex += 1;
+        this.scanOffset =
+          this.scanIndex < this.fragments.length
+            ? this.fragments[this.scanIndex].start
+            : 0;
+        continue;
+      }
+
+      const finalSegmentBytes = newline - this.scanOffset;
+      const lineBytes = this.currentLineBytes + finalSegmentBytes;
+      this.bytesScanned += finalSegmentBytes + 1;
+      if (lineBytes > this.maxLineBytes) {
+        throw new RangeError("NDJSON line exceeds bound");
+      }
+
+      const line = new Uint8Array(lineBytes);
+      let destinationOffset = 0;
+      for (let index = this.headIndex; index <= this.scanIndex; index += 1) {
+        const current = this.fragments[index];
+        const end =
+          index === this.scanIndex ? newline : current.bytes.byteLength;
+        const slice = current.bytes.subarray(current.start, end);
+        line.set(slice, destinationOffset);
+        destinationOffset += slice.byteLength;
+      }
+      this.bytesCopied += lineBytes;
+      this.pendingBytes -= lineBytes + 1;
+
+      fragment.start = newline + 1;
+      this.headIndex = this.scanIndex;
+      if (fragment.start === fragment.bytes.byteLength) this.headIndex += 1;
+      this.currentLineBytes = 0;
+      this.compactConsumedFragments();
+      this.scanIndex = this.headIndex;
+      this.scanOffset =
+        this.scanIndex < this.fragments.length
+          ? this.fragments[this.scanIndex].start
+          : 0;
+      return line;
+    }
+    return null;
+  }
+
+  /** Reports unframed bytes so EOF can reject truncated/trailing content. */
+  get pendingByteLength(): number {
+    return this.pendingBytes;
+  }
+
+  /** Exposes deterministic work counters for adversarial complexity tests. */
+  metrics(): FrameBufferMetrics {
+    return Object.freeze({
+      bytesCopied: this.bytesCopied,
+      bytesPushed: this.bytesPushed,
+      bytesScanned: this.bytesScanned,
+    });
+  }
+
+  /** Periodically drops consumed descriptors without shifting per fragment. */
+  private compactConsumedFragments(): void {
+    if (this.headIndex < 64) return;
+    this.fragments = this.fragments.slice(this.headIndex);
+    this.scanIndex -= this.headIndex;
+    this.headIndex = 0;
+  }
+}
+
+export { BoundedNdjsonFrameBuffer, type FrameBufferMetrics };

--- a/lib/gateway/server-client.test.ts
+++ b/lib/gateway/server-client.test.ts
@@ -982,6 +982,78 @@ describe("gateway server client", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects declared-length overrun before emitting any chat event", async () => {
+    const encoded = serializeGatewayChatStreamFrame({ type: "start" });
+    const cancel = vi.fn();
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({
+        "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+        "content-length": "1",
+      }),
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn<() => Promise<ReadableStreamReadResult<Uint8Array>>>()
+            .mockResolvedValueOnce({ done: false, value: encoded }),
+          cancel,
+          releaseLock: vi.fn(),
+        }),
+        cancel,
+      },
+    });
+    const stream = await client(current).streamChat(chatRequest());
+
+    await expect(stream.getReader().read()).rejects.toMatchObject({
+      code: "gateway_response_invalid",
+      message: "Gateway client request failed",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes a UTF-8 chat frame split across individual bytes", async () => {
+    const event = {
+      type: "text-delta",
+      id: "text-utf8",
+      delta: "mind map 🧠 漢字",
+    } as const;
+    const encoded = serializeGatewayChatStreamFrame(event);
+    const byteResults = Array.from(encoded, (byte) => ({
+      done: false as const,
+      value: new Uint8Array([byte]),
+    }));
+    const read = vi
+      .fn<() => Promise<ReadableStreamReadResult<Uint8Array>>>()
+      .mockResolvedValueOnce(byteResults[0]);
+    for (const result of byteResults.slice(1))
+      read.mockResolvedValueOnce(result);
+    read.mockResolvedValueOnce({ done: true, value: undefined });
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({
+        "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+      }),
+      body: {
+        getReader: () => ({ read, cancel: vi.fn(), releaseLock: vi.fn() }),
+        cancel: vi.fn(),
+      },
+    });
+    const stream = await client(current, {
+      maxResponseChunks: encoded.byteLength + 1,
+    }).streamChat(chatRequest());
+    const reader = stream.getReader();
+
+    await expect(reader.read()).resolves.toEqual({ done: false, value: event });
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
   it("keeps caller abort active after returning a chat stream", async () => {
     const cancel = vi.fn();
     const current = fixture({

--- a/lib/gateway/server-client.test.ts
+++ b/lib/gateway/server-client.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+  serializeGatewayChatStreamFrame,
+} from "../../services/agent-gateway/operation-protocol.ts";
+import {
   createFetchGatewayTransport,
   createGatewayServerClient,
   type GatewayAssertionSigner,
   type GatewayAuthorityResolver,
+  type GatewayChatClientRequest,
   type GatewayClientError,
   type GatewayClientRequest,
   type GatewayResponseBody,
@@ -19,6 +24,24 @@ vi.mock("server-only", () => ({}));
 const ORIGIN = "https://gateway.example.test";
 const RESPONSE_URL = `${ORIGIN}/internal/v1/operations/chat`;
 const SECRET = "secret-canary-never-reflect";
+
+/** Creates one closed chat request with an owned mindmap intent. */
+function chatRequest(
+  overrides: Partial<GatewayChatClientRequest> = {}
+): GatewayChatClientRequest {
+  return {
+    resource: { type: "mindmap", id: "map-1" },
+    connectionId: "connection-1",
+    operation: "chat",
+    requestId: "request-chat-1",
+    input: {
+      instructions: "Help with this map",
+      conversation: "user: explain the root",
+      toolManifest: "[]",
+    },
+    ...overrides,
+  };
+}
 
 type Fixture = Readonly<{
   authorityResolver: GatewayAuthorityResolver;
@@ -806,6 +829,234 @@ describe("gateway server client", () => {
     );
     expect(current.signerCalls).not.toHaveBeenCalled();
     expect(current.transportCalls).not.toHaveBeenCalled();
+  });
+
+  it("sends and validates a closed first-map action with owner bootstrap authority", async () => {
+    const actionUrl = `${ORIGIN}/internal/v1/operations/mind-map-generation`;
+    const current = fixture(
+      jsonResponse(
+        {
+          ok: true,
+          data: {
+            version: 1,
+            operation: "mind-map-generation",
+            rawOutput: '{"name":"Systems"}',
+            output: {
+              name: "Systems",
+              nodes: [{ title: "Distributed", children: [] }],
+            },
+          },
+        },
+        { url: actionUrl }
+      )
+    );
+    current.authorizeCalls.mockResolvedValueOnce({
+      ownerId: "owner-1",
+      resource: {
+        type: "owner-bootstrap",
+        intent: "create-first-mindmap",
+      },
+      connection: {
+        requestedId: "connection-1",
+        canonicalId: "canonical-connection-1",
+        provider: "codex",
+        status: "connected",
+        isDefault: true,
+      },
+      operation: "mind-map-generation",
+    });
+
+    await expect(
+      client(current).executeAction({
+        resource: {
+          type: "owner-bootstrap",
+          intent: "create-first-mindmap",
+        },
+        connectionId: "connection-1",
+        operation: "mind-map-generation",
+        requestId: "request-create-1",
+        input: { instructions: "Generate a map", prompt: "Systems" },
+      })
+    ).resolves.toMatchObject({ operation: "mind-map-generation" });
+
+    expect(current.authorizeCalls.mock.calls[0]?.[0]).toMatchObject({
+      resource: {
+        type: "owner-bootstrap",
+        intent: "create-first-mindmap",
+      },
+      operation: "mind-map-generation",
+    });
+    const sent = current.transportCalls.mock
+      .calls[0]?.[0] as GatewayTransportRequest;
+    expect(sent.url).toBe(actionUrl);
+    expect(JSON.parse(sent.body)).toEqual({
+      input: {
+        version: 1,
+        operation: "mind-map-generation",
+        resource: {
+          type: "owner-bootstrap",
+          intent: "create-first-mindmap",
+        },
+        input: { instructions: "Generate a map", prompt: "Systems" },
+      },
+    });
+  });
+
+  it("decodes chat events without pre-draining and retains stream lifecycle bounds", async () => {
+    const event = {
+      type: "text-delta",
+      id: "text-1",
+      delta: "chat-data",
+    } as const;
+    const encoded = serializeGatewayChatStreamFrame(event);
+    const read = vi
+      .fn<() => Promise<ReadableStreamReadResult<Uint8Array>>>()
+      .mockResolvedValueOnce({ done: false, value: encoded })
+      .mockResolvedValueOnce({ done: true, value: undefined });
+    const cancel = vi.fn();
+    const releaseLock = vi.fn();
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({
+        "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+        "content-length": String(encoded.byteLength),
+      }),
+      body: { getReader: () => ({ read, cancel, releaseLock }), cancel },
+    });
+
+    const stream = await client(current).streamChat(chatRequest());
+    expect(read).not.toHaveBeenCalled();
+    const reader = stream.getReader();
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: event,
+    });
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(cancel).not.toHaveBeenCalled();
+
+    const sent = current.transportCalls.mock
+      .calls[0]?.[0] as GatewayTransportRequest;
+    expect(JSON.parse(sent.body)).toMatchObject({
+      input: {
+        version: 1,
+        operation: "chat",
+        resource: { type: "owned-mindmap", id: "canonical-map-1" },
+        input: chatRequest().input,
+      },
+    });
+  });
+
+  it("cancels a chat body when its demand-driven chunk bound is exceeded", async () => {
+    const encoded = serializeGatewayChatStreamFrame({ type: "start" });
+    const read = vi
+      .fn<() => Promise<ReadableStreamReadResult<Uint8Array>>>()
+      .mockResolvedValue({ done: false, value: encoded });
+    const cancel = vi.fn();
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({
+        "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+      }),
+      body: {
+        getReader: () => ({ read, cancel, releaseLock: vi.fn() }),
+        cancel,
+      },
+    });
+    const stream = await client(current, { maxResponseChunks: 1 }).streamChat(
+      chatRequest()
+    );
+    const reader = stream.getReader();
+    await expect(reader.read()).resolves.toMatchObject({ done: false });
+    await expect(reader.read()).rejects.toMatchObject({
+      code: "response_too_large",
+      message: "Gateway client request failed",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps caller abort active after returning a chat stream", async () => {
+    const cancel = vi.fn();
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({
+        "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+      }),
+      body: {
+        getReader: () => ({
+          read: () => new Promise(() => undefined),
+          cancel,
+          releaseLock: vi.fn(),
+        }),
+        cancel,
+      },
+    });
+    const controller = new AbortController();
+    const stream = await client(current).streamChat(
+      chatRequest({ signal: controller.signal })
+    );
+    controller.abort(new Error(SECRET));
+
+    await expect(stream.getReader().read()).rejects.toMatchObject({
+      code: "request_aborted",
+      message: "Gateway client request failed",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unbounded streaming response headers and disposes the body", async () => {
+    const cancel = vi.fn();
+    const current = fixture({
+      status: 200,
+      redirected: false,
+      url: RESPONSE_URL,
+      headers: new Headers({
+        "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+        "x-oversized": "x".repeat(1_025),
+      }),
+      body: {
+        getReader: () => ({
+          read: vi.fn(),
+          cancel,
+          releaseLock: vi.fn(),
+        }),
+        cancel,
+      },
+    });
+
+    await expectCode(
+      () => client(current).streamChat(chatRequest()),
+      "gateway_response_invalid"
+    );
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed protocol payloads before authority or signing", async () => {
+    const current = fixture();
+    await expectCode(
+      () =>
+        client(current).streamChat(
+          chatRequest({
+            input: {
+              instructions: "Help",
+              conversation: "x".repeat(32_001),
+              toolManifest: "[]",
+            },
+          })
+        ),
+      "gateway_client_configuration_invalid"
+    );
+    expect(current.authorizeCalls).not.toHaveBeenCalled();
+    expect(current.signerCalls).not.toHaveBeenCalled();
   });
 });
 

--- a/lib/gateway/server-client.ts
+++ b/lib/gateway/server-client.ts
@@ -21,6 +21,7 @@ import {
   parseGatewayActionResult,
   parseGatewayChatStreamFrame,
 } from "../../services/agent-gateway/operation-protocol.ts";
+import { BoundedNdjsonFrameBuffer } from "./ndjson-frame-buffer.ts";
 
 const GATEWAY_BASE_PATH = "/internal/v1";
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -1105,7 +1106,7 @@ async function createBoundedGatewayStream(
 
   let byteCount = 0;
   let chunkCount = 0;
-  let pendingBytes = new Uint8Array();
+  const frameBuffer = new BoundedNdjsonFrameBuffer(maxBytes);
   let upstreamDone = false;
   let terminal = false;
   let reading = false;
@@ -1154,10 +1155,8 @@ async function createBoundedGatewayStream(
         reading = true;
         try {
           while (true) {
-            const newline = pendingBytes.indexOf(10);
-            if (newline >= 0) {
-              const line = pendingBytes.slice(0, newline);
-              pendingBytes = pendingBytes.slice(newline + 1);
+            const line = frameBuffer.takeLine();
+            if (line !== null) {
               if (line.byteLength === 0) {
                 throw clientError("gateway_response_invalid");
               }
@@ -1175,7 +1174,7 @@ async function createBoundedGatewayStream(
 
             if (upstreamDone) {
               if (
-                pendingBytes.byteLength !== 0 ||
+                frameBuffer.pendingByteLength !== 0 ||
                 (declaredLength !== undefined && declaredLength !== byteCount)
               ) {
                 throw clientError("gateway_response_invalid");
@@ -1205,12 +1204,10 @@ async function createBoundedGatewayStream(
             if (chunkCount > maxChunks || byteCount > maxBytes) {
               throw clientError("response_too_large");
             }
-            const combined = new Uint8Array(
-              pendingBytes.byteLength + result.value.byteLength
-            );
-            combined.set(pendingBytes);
-            combined.set(result.value, pendingBytes.byteLength);
-            pendingBytes = combined;
+            if (declaredLength !== undefined && byteCount > declaredLength) {
+              throw clientError("gateway_response_invalid");
+            }
+            frameBuffer.push(result.value);
           }
         } catch (error) {
           close(true);

--- a/lib/gateway/server-client.ts
+++ b/lib/gateway/server-client.ts
@@ -9,6 +9,18 @@ import {
   GATEWAY_OPERATIONS,
   type GatewayOperation,
 } from "../../services/agent-gateway/internal-auth.ts";
+import {
+  createGatewayOperationEnvelope,
+  GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+  type GatewayActionResult,
+  type GatewayChatChunk,
+  type GatewayChatInput,
+  type GatewayMindmapGenerationInput,
+  type GatewayNodeEditingInput,
+  type GatewayResourceAuthority,
+  parseGatewayActionResult,
+  parseGatewayChatStreamFrame,
+} from "../../services/agent-gateway/operation-protocol.ts";
 
 const GATEWAY_BASE_PATH = "/internal/v1";
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -23,6 +35,9 @@ const MAX_RESPONSE_BYTES = 4 * 1_024 * 1_024;
 const MAX_RESPONSE_CHUNKS = 4_096;
 const MAX_CLEANUP_TIMEOUT_MS = 1_000;
 const MAX_IDENTIFIER_LENGTH = 256;
+const MAX_RESPONSE_HEADER_COUNT = 64;
+const MAX_RESPONSE_HEADER_NAME_LENGTH = 128;
+const MAX_RESPONSE_HEADER_VALUE_LENGTH = 1_024;
 
 const OPERATION_PATHS: Readonly<Record<GatewayOperation, string>> =
   Object.freeze({
@@ -88,6 +103,15 @@ type GatewayResourceIntent = Readonly<{
   id: string;
 }>;
 
+type GatewayBootstrapResourceIntent = Readonly<{
+  type: "owner-bootstrap";
+  intent: "create-first-mindmap";
+}>;
+
+type GatewayProtocolResourceIntent =
+  | GatewayResourceIntent
+  | GatewayBootstrapResourceIntent;
+
 type GatewayClientRequest = Readonly<{
   resource: GatewayResourceIntent;
   connectionId: string;
@@ -96,8 +120,39 @@ type GatewayClientRequest = Readonly<{
   signal?: AbortSignal;
 }>;
 
-type AuthorizeGatewayIntentInput = Readonly<{
+type GatewayChatClientRequest = Readonly<{
   resource: GatewayResourceIntent;
+  connectionId: string;
+  operation: "chat";
+  requestId: string;
+  input: GatewayChatInput;
+  signal?: AbortSignal;
+}>;
+
+type GatewayActionClientRequest =
+  | Readonly<{
+      resource: GatewayBootstrapResourceIntent;
+      connectionId: string;
+      operation: "mind-map-generation";
+      requestId: string;
+      input: GatewayMindmapGenerationInput;
+      signal?: AbortSignal;
+    }>
+  | Readonly<{
+      resource: GatewayResourceIntent;
+      connectionId: string;
+      operation: "node-editing";
+      requestId: string;
+      input: GatewayNodeEditingInput;
+      signal?: AbortSignal;
+    }>;
+
+type GatewayProtocolClientRequest =
+  | GatewayChatClientRequest
+  | GatewayActionClientRequest;
+
+type AuthorizeGatewayIntentInput = Readonly<{
+  resource: GatewayProtocolResourceIntent;
   connectionId: string;
   provider: "codex";
   operation: GatewayOperation;
@@ -108,11 +163,16 @@ type AuthorizeGatewayIntentInput = Readonly<{
 // construction-time server resolver can return derived authority.
 type AuthorizedGatewayResolution = Readonly<{
   ownerId: string;
-  resource: Readonly<{
-    type: "mindmap";
-    requestedId: string;
-    canonicalId: string;
-  }>;
+  resource:
+    | Readonly<{
+        type: "mindmap";
+        requestedId: string;
+        canonicalId: string;
+      }>
+    | Readonly<{
+        type: "owner-bootstrap";
+        intent: "create-first-mindmap";
+      }>;
   connection: Readonly<{
     requestedId: string;
     canonicalId: string;
@@ -175,7 +235,7 @@ type GatewayTransportResponse = Readonly<{
   status: number;
   redirected: boolean;
   url: string;
-  headers: Pick<Headers, "get">;
+  headers: Pick<Headers, "get"> & Partial<Pick<Headers, "entries">>;
   body: GatewayResponseBody | null;
 }>;
 
@@ -206,6 +266,12 @@ type GatewayServerClientOptions = Readonly<{
 
 type GatewayServerClient = Readonly<{
   execute(request: GatewayClientRequest): Promise<unknown>;
+  executeAction(
+    request: GatewayActionClientRequest
+  ): Promise<GatewayActionResult>;
+  streamChat(
+    request: GatewayChatClientRequest
+  ): Promise<ReadableStream<GatewayChatChunk>>;
 }>;
 
 /** Stable, secret-free client failure suitable for a server route mapping. */
@@ -328,6 +394,9 @@ function createGatewayServerClient(
           configuration.gatewayOrigin,
           authority.operation
         );
+        if (authority.resource.type !== "mindmap") {
+          throw clientError("authorization_unavailable");
+        }
         const body = JSON.stringify({
           input: {
             resource: {
@@ -388,7 +457,174 @@ function createGatewayServerClient(
         requestController.abort();
       }
     },
+    async executeAction(
+      request: GatewayActionClientRequest
+    ): Promise<GatewayActionResult> {
+      const parsedRequest = readProtocolRequest(request, "action");
+      if (parsedRequest.operation === "chat") {
+        throw clientError("gateway_client_configuration_invalid");
+      }
+      const active = await startProtocolRequest(parsedRequest, configuration);
+      try {
+        const value = await readGatewayResponse(
+          active.response,
+          active.url,
+          configuration.maxResponseBytes,
+          configuration.maxResponseChunks,
+          configuration.cleanupTimeoutMs,
+          active.requestController.signal,
+          parsedRequest.signal,
+          true
+        );
+        try {
+          return parseGatewayActionResult(value, parsedRequest.operation);
+        } catch {
+          throw clientError("gateway_response_invalid");
+        }
+      } finally {
+        active.finish();
+      }
+    },
+    async streamChat(
+      request: GatewayChatClientRequest
+    ): Promise<ReadableStream<GatewayChatChunk>> {
+      const parsedRequest = readProtocolRequest(request, "chat");
+      const active = await startProtocolRequest(parsedRequest, configuration);
+      try {
+        return await createBoundedGatewayStream(
+          active.response,
+          active.url,
+          configuration.maxResponseBytes,
+          configuration.maxResponseChunks,
+          configuration.cleanupTimeoutMs,
+          active.requestController.signal,
+          parsedRequest.signal,
+          active.finish
+        );
+      } catch (error) {
+        active.finish();
+        if (error instanceof GatewayClientError) throw error;
+        throw clientError("gateway_response_invalid");
+      }
+    },
   });
+}
+
+type GatewayClientConfiguration = ReturnType<typeof readConfiguration>;
+type ActiveProtocolRequest = Readonly<{
+  response: GatewayTransportResponse;
+  url: string;
+  requestController: AbortController;
+  finish: () => void;
+}>;
+
+/** Authorizes, signs, and sends one versioned request exactly once. */
+async function startProtocolRequest(
+  parsedRequest: GatewayProtocolClientRequest,
+  configuration: GatewayClientConfiguration
+): Promise<ActiveProtocolRequest> {
+  if (parsedRequest.signal?.aborted) throw clientError("request_aborted");
+
+  const requestController = new AbortController();
+  const handleCallerAbort = (): void => requestController.abort();
+  parsedRequest.signal?.addEventListener("abort", handleCallerAbort, {
+    once: true,
+  });
+  if (parsedRequest.signal?.aborted) handleCallerAbort();
+  const requestTimer = setTimeout(
+    () => requestController.abort(),
+    configuration.requestTimeoutMs
+  );
+  let finished = false;
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+    clearTimeout(requestTimer);
+    parsedRequest.signal?.removeEventListener("abort", handleCallerAbort);
+    requestController.abort();
+  };
+
+  try {
+    const resolution = await runAuthorityStage(
+      (context) =>
+        configuration.authorityResolver.authorize(
+          Object.freeze({
+            resource: parsedRequest.resource,
+            connectionId: parsedRequest.connectionId,
+            provider: "codex",
+            operation: parsedRequest.operation,
+            requireDefault: true,
+          }),
+          context
+        ),
+      configuration.authorizationTimeoutMs,
+      requestController.signal,
+      parsedRequest.signal
+    );
+    const authority = requireAuthorizedResolution(resolution, parsedRequest);
+    const assertion = await runControlPlaneStage(
+      (context) =>
+        configuration.assertionSigner.sign(
+          Object.freeze({
+            issuer: configuration.issuer,
+            audience: configuration.audience,
+            subject: authority.ownerId,
+            connectionId: authority.connection.canonicalId,
+            provider: "codex",
+            operation: authority.operation,
+            requestId: parsedRequest.requestId,
+          }),
+          context
+        ),
+      configuration.signerTimeoutMs,
+      requestController.signal,
+      parsedRequest.signal
+    );
+    requireAssertion(assertion);
+
+    const url = buildOperationUrl(
+      configuration.gatewayOrigin,
+      authority.operation
+    );
+    const canonicalResource = canonicalProtocolAuthority(authority.resource);
+    const envelope = createGatewayOperationEnvelope(
+      authority.operation,
+      canonicalResource,
+      parsedRequest.input
+    );
+    const transportPromise = Promise.resolve().then(() => {
+      if (requestController.signal.aborted) {
+        throw cancellationError(requestController.signal, parsedRequest.signal);
+      }
+      return configuration.transport.send(
+        Object.freeze({
+          url,
+          method: "POST",
+          headers: Object.freeze({
+            authorization: `Bearer ${assertion}`,
+            "content-type": "application/json",
+            "x-request-id": parsedRequest.requestId,
+          }),
+          body: JSON.stringify({ input: envelope }),
+          redirect: "error",
+          signal: requestController.signal,
+        })
+      );
+    });
+    const response = await awaitObserved(
+      transportPromise,
+      requestController.signal,
+      parsedRequest.signal,
+      (lateResponse) => {
+        observeResponseDisposal(lateResponse, configuration.cleanupTimeoutMs);
+      }
+    );
+    return Object.freeze({ response, url, requestController, finish });
+  } catch (error) {
+    finish();
+    if (error instanceof GatewayClientError) throw error;
+    throw cancellationError(requestController.signal, parsedRequest.signal);
+  }
 }
 
 /** Snapshots and validates all construction-time policy. */
@@ -490,6 +726,88 @@ function readRequest(request: GatewayClientRequest): GatewayClientRequest {
   });
 }
 
+/** Validates and snapshots one operation-specific protocol invocation. */
+function readProtocolRequest(
+  request: GatewayProtocolClientRequest,
+  kind: "action" | "chat"
+): GatewayProtocolClientRequest {
+  try {
+    if (
+      typeof request !== "object" ||
+      request === null ||
+      !hasExactKeys(request, [
+        "connectionId",
+        "input",
+        "operation",
+        "requestId",
+        "resource",
+        ...(request.signal === undefined ? [] : ["signal"]),
+      ]) ||
+      !isIdentifier(request.connectionId) ||
+      !isIdentifier(request.requestId) ||
+      (request.signal !== undefined &&
+        !(request.signal instanceof AbortSignal)) ||
+      (kind === "chat"
+        ? request.operation !== "chat"
+        : request.operation !== "mind-map-generation" &&
+          request.operation !== "node-editing")
+    ) {
+      throw clientError("gateway_client_configuration_invalid");
+    }
+
+    const resource = readProtocolResourceIntent(request.resource);
+    // Creating the closed envelope here validates every payload field before
+    // authority lookup, while the canonical resource is substituted later.
+    const validationResource: GatewayResourceAuthority =
+      resource.type === "mindmap"
+        ? { type: "owned-mindmap", id: resource.id }
+        : { ...resource };
+    const validated = createGatewayOperationEnvelope(
+      request.operation,
+      validationResource,
+      request.input
+    );
+    return Object.freeze({
+      resource: Object.freeze({ ...resource }),
+      connectionId: request.connectionId,
+      operation: request.operation,
+      requestId: request.requestId,
+      input: deepFreezeJson(validated.input),
+      signal: request.signal,
+    }) as GatewayProtocolClientRequest;
+  } catch (error) {
+    if (error instanceof GatewayClientError) throw error;
+    throw clientError("gateway_client_configuration_invalid");
+  }
+}
+
+/** Recursively freezes the already-validated JSON payload snapshot. */
+function deepFreezeJson<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) {
+    return value;
+  }
+  for (const child of Object.values(value)) deepFreezeJson(child);
+  return Object.freeze(value);
+}
+
+/** Accepts either an owned-map lookup or the exact first-map bootstrap intent. */
+function readProtocolResourceIntent(
+  resource: GatewayProtocolResourceIntent
+): GatewayProtocolResourceIntent {
+  if (
+    typeof resource !== "object" ||
+    resource === null ||
+    (resource.type === "mindmap"
+      ? !hasExactKeys(resource, ["id", "type"]) || !isIdentifier(resource.id)
+      : resource.type !== "owner-bootstrap" ||
+        !hasExactKeys(resource, ["intent", "type"]) ||
+        resource.intent !== "create-first-mindmap")
+  ) {
+    throw clientError("gateway_client_configuration_invalid");
+  }
+  return resource;
+}
+
 /** Executes an authority or signer dependency behind its request deadline. */
 async function runControlPlaneStage<T>(
   operation: (context: ControlPlaneOperationContext) => T | PromiseLike<T>,
@@ -553,15 +871,13 @@ async function runAuthorityStage<T>(
 /** Validates and snapshots authority returned only by the server dependency. */
 function requireAuthorizedResolution(
   resolution: AuthorizedGatewayResolution | null,
-  request: GatewayClientRequest
+  request: GatewayClientRequest | GatewayProtocolClientRequest
 ): AuthorizedGatewayResolution {
   try {
     if (
       resolution === null ||
       !isIdentifier(resolution.ownerId) ||
-      resolution.resource.type !== "mindmap" ||
-      resolution.resource.requestedId !== request.resource.id ||
-      !isIdentifier(resolution.resource.canonicalId) ||
+      !authorityResourceMatches(resolution.resource, request.resource) ||
       resolution.connection.requestedId !== request.connectionId ||
       !isIdentifier(resolution.connection.canonicalId) ||
       resolution.connection.provider !== "codex" ||
@@ -581,6 +897,37 @@ function requireAuthorizedResolution(
   } catch {
     throw clientError("authorization_unavailable");
   }
+}
+
+/** Matches the resolver's canonical authority to the exact caller intent. */
+function authorityResourceMatches(
+  authority: AuthorizedGatewayResolution["resource"],
+  intent: GatewayProtocolResourceIntent
+): boolean {
+  if (authority.type === "mindmap") {
+    return (
+      intent.type === "mindmap" &&
+      authority.requestedId === intent.id &&
+      isIdentifier(authority.canonicalId)
+    );
+  }
+  return (
+    intent.type === "owner-bootstrap" &&
+    authority.intent === "create-first-mindmap" &&
+    intent.intent === authority.intent
+  );
+}
+
+/** Converts resolver output into the authority carried by the v1 envelope. */
+function canonicalProtocolAuthority(
+  resource: AuthorizedGatewayResolution["resource"]
+): GatewayResourceAuthority {
+  return resource.type === "mindmap"
+    ? Object.freeze({ type: "owned-mindmap", id: resource.canonicalId })
+    : Object.freeze({
+        type: "owner-bootstrap",
+        intent: "create-first-mindmap",
+      });
 }
 
 /** Requires a bounded opaque assertion without parsing or reflecting it. */
@@ -613,11 +960,17 @@ async function readGatewayResponse(
   maxChunks: number,
   cleanupTimeoutMs: number,
   requestSignal: AbortSignal,
-  callerSignal?: AbortSignal
+  callerSignal?: AbortSignal,
+  requireHeaderEnumeration = false
 ): Promise<unknown> {
   const body = readResponseBody(response);
+  let declaredLength: number | undefined;
   let metadataValid = false;
+  let metadataError: GatewayClientError | undefined;
   try {
+    assertResponseHeaderBounds(response, requireHeaderEnumeration);
+    const contentType = readBoundedResponseHeader(response, "content-type");
+    declaredLength = readResponseContentLength(response, maxBytes);
     metadataValid =
       typeof response === "object" &&
       response !== null &&
@@ -625,11 +978,16 @@ async function readGatewayResponse(
       response.redirected === false &&
       response.url === expectedUrl &&
       typeof response.headers?.get === "function" &&
-      isJsonContentType(response.headers.get("content-type")) &&
+      isJsonContentType(contentType) &&
       body !== null &&
       typeof body.getReader === "function";
-  } catch {
+  } catch (error) {
     // All transport metadata ambiguity shares one response failure below.
+    if (error instanceof GatewayClientError) metadataError = error;
+  }
+  if (metadataError !== undefined) {
+    await disposeResponseBody(body, cleanupTimeoutMs);
+    throw metadataError;
   }
   if (!metadataValid || body === null) {
     await disposeResponseBody(body, cleanupTimeoutMs);
@@ -645,6 +1003,12 @@ async function readGatewayResponse(
       requestSignal,
       callerSignal
     );
+    if (
+      declaredLength !== undefined &&
+      declaredLength !== encodedBody.byteLength
+    ) {
+      throw clientError("gateway_response_invalid");
+    }
   } catch (error) {
     await disposeResponseBody(body, cleanupTimeoutMs);
     if (error instanceof GatewayClientError) throw error;
@@ -674,6 +1038,256 @@ async function readGatewayResponse(
     throw clientError("gateway_response_invalid");
   }
   throw clientError(failure.data.error.code);
+}
+
+/**
+ * Validates a chat response and returns a demand-driven bounded event stream.
+ * The request deadline and caller abort remain active until close or cancel.
+ */
+async function createBoundedGatewayStream(
+  response: GatewayTransportResponse,
+  expectedUrl: string,
+  maxBytes: number,
+  maxChunks: number,
+  cleanupTimeoutMs: number,
+  requestSignal: AbortSignal,
+  callerSignal: AbortSignal | undefined,
+  finishRequest: () => void
+): Promise<ReadableStream<GatewayChatChunk>> {
+  if (response.status !== 200) {
+    await readGatewayResponse(
+      response,
+      expectedUrl,
+      maxBytes,
+      maxChunks,
+      cleanupTimeoutMs,
+      requestSignal,
+      callerSignal,
+      true
+    );
+    throw clientError("gateway_response_invalid");
+  }
+
+  const body = readResponseBody(response);
+  let declaredLength: number | undefined;
+  let metadataValid = false;
+  let metadataError: GatewayClientError | undefined;
+  try {
+    assertResponseHeaderBounds(response, true);
+    const contentType = readBoundedResponseHeader(response, "content-type");
+    declaredLength = readResponseContentLength(response, maxBytes);
+    metadataValid =
+      response.redirected === false &&
+      response.url === expectedUrl &&
+      contentType === GATEWAY_CHAT_STREAM_CONTENT_TYPE &&
+      body !== null &&
+      typeof body.getReader === "function";
+  } catch (error) {
+    // All hostile or ambiguous metadata shares one stable response failure.
+    if (error instanceof GatewayClientError) metadataError = error;
+  }
+  if (metadataError !== undefined) {
+    await disposeResponseBody(body, cleanupTimeoutMs);
+    throw metadataError;
+  }
+  if (!metadataValid || body === null) {
+    await disposeResponseBody(body, cleanupTimeoutMs);
+    throw clientError("gateway_response_invalid");
+  }
+
+  let reader: GatewayResponseBodyReader;
+  try {
+    reader = body.getReader();
+  } catch {
+    await disposeResponseBody(body, cleanupTimeoutMs);
+    throw clientError("gateway_response_invalid");
+  }
+
+  let byteCount = 0;
+  let chunkCount = 0;
+  let pendingBytes = new Uint8Array();
+  let upstreamDone = false;
+  let terminal = false;
+  let reading = false;
+
+  /** Releases request and reader ownership once, observing hostile cleanup. */
+  const close = (cancelReader: boolean): void => {
+    if (terminal) return;
+    terminal = true;
+    requestSignal.removeEventListener("abort", handleAbort);
+    if (cancelReader) {
+      try {
+        void Promise.resolve(reader.cancel()).catch(() => undefined);
+      } catch {
+        // A non-conforming reader cannot replace the stable stream outcome.
+      }
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // Reader cleanup is best-effort after the protocol outcome is fixed.
+    }
+    finishRequest();
+  };
+  let streamController:
+    | ReadableStreamDefaultController<GatewayChatChunk>
+    | undefined;
+  const handleAbort = (): void => {
+    const error = cancellationError(requestSignal, callerSignal);
+    close(true);
+    try {
+      streamController?.error(error);
+    } catch {
+      // A concurrent consumer cancellation may already own stream termination.
+    }
+  };
+
+  return new ReadableStream<GatewayChatChunk>(
+    {
+      start(controller) {
+        streamController = controller;
+        requestSignal.addEventListener("abort", handleAbort, { once: true });
+        if (requestSignal.aborted) handleAbort();
+      },
+      async pull(controller) {
+        if (terminal || reading) return;
+        reading = true;
+        try {
+          while (true) {
+            const newline = pendingBytes.indexOf(10);
+            if (newline >= 0) {
+              const line = pendingBytes.slice(0, newline);
+              pendingBytes = pendingBytes.slice(newline + 1);
+              if (line.byteLength === 0) {
+                throw clientError("gateway_response_invalid");
+              }
+              let value: unknown;
+              try {
+                value = JSON.parse(
+                  new TextDecoder("utf-8", { fatal: true }).decode(line)
+                );
+                controller.enqueue(parseGatewayChatStreamFrame(value));
+              } catch {
+                throw clientError("gateway_response_invalid");
+              }
+              return;
+            }
+
+            if (upstreamDone) {
+              if (
+                pendingBytes.byteLength !== 0 ||
+                (declaredLength !== undefined && declaredLength !== byteCount)
+              ) {
+                throw clientError("gateway_response_invalid");
+              }
+              close(false);
+              controller.close();
+              return;
+            }
+
+            const result = await awaitObserved(
+              reader.read(),
+              requestSignal,
+              callerSignal
+            );
+            if (result.done) {
+              upstreamDone = true;
+              continue;
+            }
+            if (
+              !(result.value instanceof Uint8Array) ||
+              result.value.byteLength === 0
+            ) {
+              throw clientError("gateway_response_invalid");
+            }
+            chunkCount += 1;
+            byteCount += result.value.byteLength;
+            if (chunkCount > maxChunks || byteCount > maxBytes) {
+              throw clientError("response_too_large");
+            }
+            const combined = new Uint8Array(
+              pendingBytes.byteLength + result.value.byteLength
+            );
+            combined.set(pendingBytes);
+            combined.set(result.value, pendingBytes.byteLength);
+            pendingBytes = combined;
+          }
+        } catch (error) {
+          close(true);
+          controller.error(
+            error instanceof GatewayClientError
+              ? error
+              : clientError("gateway_response_invalid")
+          );
+        } finally {
+          reading = false;
+        }
+      },
+      cancel() {
+        close(true);
+      },
+    },
+    // Zero buffering guarantees the server client never pre-drains chat data.
+    { highWaterMark: 0 }
+  );
+}
+
+/** Reads one bounded scalar response header without reflecting its contents. */
+function readBoundedResponseHeader(
+  response: GatewayTransportResponse,
+  name: string
+): string | null {
+  const value = response.headers.get(name);
+  if (value !== null && value.length > MAX_RESPONSE_HEADER_VALUE_LENGTH) {
+    throw clientError("gateway_response_invalid");
+  }
+  return value;
+}
+
+/** Bounds every enumerable response header for versioned protocol calls. */
+function assertResponseHeaderBounds(
+  response: GatewayTransportResponse,
+  requireEnumeration: boolean
+): void {
+  const entries = response.headers?.entries;
+  if (typeof entries !== "function") {
+    if (requireEnumeration) throw clientError("gateway_response_invalid");
+    return;
+  }
+  let count = 0;
+  const iterator = entries.call(response.headers);
+  while (true) {
+    const next = iterator.next();
+    if (next.done) break;
+    const [name, value] = next.value;
+    count += 1;
+    if (
+      count > MAX_RESPONSE_HEADER_COUNT ||
+      name.length === 0 ||
+      name.length > MAX_RESPONSE_HEADER_NAME_LENGTH ||
+      value.length > MAX_RESPONSE_HEADER_VALUE_LENGTH
+    ) {
+      throw clientError("gateway_response_invalid");
+    }
+  }
+}
+
+/** Validates an optional exact content length before reading any body bytes. */
+function readResponseContentLength(
+  response: GatewayTransportResponse,
+  maxBytes: number
+): number | undefined {
+  const value = readBoundedResponseHeader(response, "content-length");
+  if (value === null) return undefined;
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw clientError("gateway_response_invalid");
+  }
+  const length = Number(value);
+  if (!Number.isSafeInteger(length)) {
+    throw clientError("gateway_response_invalid");
+  }
+  if (length > maxBytes) throw clientError("response_too_large");
+  return length;
 }
 
 /** Reads a response stream with hard byte/chunk limits and observed cancellation. */
@@ -998,11 +1612,16 @@ export {
   createFetchGatewayTransport,
   createGatewayServerClient,
   type FetchImplementation,
+  type GatewayActionClientRequest,
   type GatewayAssertionSigner,
   type GatewayAuthorityResolver,
+  type GatewayBootstrapResourceIntent,
+  type GatewayChatClientRequest,
   GatewayClientError,
   type GatewayClientErrorCode,
   type GatewayClientRequest,
+  type GatewayProtocolClientRequest,
+  type GatewayProtocolResourceIntent,
   type GatewayRemoteErrorCode,
   type GatewayResourceIntent,
   type GatewayResponseBody,

--- a/services/agent-gateway/dispatcher.test.ts
+++ b/services/agent-gateway/dispatcher.test.ts
@@ -77,10 +77,9 @@ type Fixture = ReturnType<typeof createFixture>;
 function createFixture(
   options: Partial<{
     execute: CodexOperationDefinition["execute"];
+    operation: GatewayOperation;
     parseInput: CodexOperationDefinition["parseInput"];
-    parseOutput: NonNullable<CodexOperationDefinition["parseOutput"]>;
     protocolVersion: typeof GATEWAY_OPERATION_PROTOCOL_VERSION;
-    responseKind: "json" | "stream";
     timeoutMs: number;
     maxBodyBytes: number;
     maxBodyChunks: number;
@@ -93,6 +92,7 @@ function createFixture(
     replayDefense: ReplayDefense;
   }> = {}
 ) {
+  const operation = options.operation ?? "chat";
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");
   const clock = new TestClock();
   const signingKey: SigningKey = {
@@ -108,7 +108,7 @@ function createFixture(
     subject: "owner_a",
     connectionId: "connection_a",
     provider: "codex",
-    operation: "chat",
+    operation,
     requestId: "request_1",
   };
   const rateBudget = new TestRateBudget(options.rateConsume);
@@ -117,9 +117,8 @@ function createFixture(
     (async (input: unknown) => ({ echoed: input, source: "server-registry" }));
   const registry = new CodexOperationRegistry([
     {
-      operation: "chat",
+      operation,
       protocolVersion: options.protocolVersion,
-      responseKind: options.responseKind,
       parseInput:
         options.parseInput ??
         ((input) => {
@@ -128,24 +127,30 @@ function createFixture(
           }
           return input;
         }),
-      parseOutput: options.parseOutput,
       execute,
     },
   ]);
   const route: GatewayRoute = {
     method: "POST" as const,
-    path: "/internal/v1/codex/chat" as const,
-    operation: "chat" as const,
+    path: `/internal/v1/codex/${operation}` as const,
+    operation,
     ...(options.protocolVersion === undefined
       ? {}
       : {
           resourceAuthority: {
-            type: "owned-mindmap" as const,
-            id: "canonical-map-1",
+            ...(operation === "mind-map-generation"
+              ? {
+                  type: "owner-bootstrap" as const,
+                  intent: "create-first-mindmap" as const,
+                }
+              : {
+                  type: "owned-mindmap" as const,
+                  id: "canonical-map-1",
+                }),
           },
         }),
     rateBudget: {
-      endpoint: "codex.chat",
+      endpoint: `codex.${operation}`,
       ownerLimit: 4,
       globalLimit: 40,
       windowSeconds: 60,
@@ -258,7 +263,7 @@ function createRequest(
   const token = options.token ?? issueToken(fixture);
   return {
     method: options.method ?? "POST",
-    path: options.path ?? "/internal/v1/codex/chat",
+    path: options.path ?? `/internal/v1/codex/${fixture.expected.operation}`,
     headers: options.headers ?? {
       authorization: `Bearer ${token}`,
       "content-type": options.contentType ?? "application/json",
@@ -274,6 +279,30 @@ function createRequest(
 /** Converts text chunks into a transport-neutral async byte stream. */
 async function* chunks(...values: string[]): AsyncIterable<Uint8Array> {
   for (const value of values) yield Buffer.from(value);
+}
+
+/** Creates one valid versioned chat request for stream lifecycle tests. */
+function createProtocolChatRequest(
+  fixture: Fixture,
+  signal?: AbortSignal
+): GatewayRequestEnvelope {
+  return createRequest(fixture, {
+    body: chunks(
+      JSON.stringify({
+        input: {
+          version: 1,
+          operation: "chat",
+          resource: { type: "owned-mindmap", id: "canonical-map-1" },
+          input: {
+            instructions: "Help",
+            conversation: "user: hello",
+            toolManifest: "[]",
+          },
+        },
+      })
+    ),
+    signal,
+  });
 }
 
 /** Creates a body whose first read stalls until dispatcher cancellation. */
@@ -385,7 +414,6 @@ describe("gateway dispatcher", () => {
     const execute = vi.fn(async () => output);
     const fixture = createFixture({
       protocolVersion: 1,
-      responseKind: "stream",
       maxBodyBytes: 4_096,
       execute,
       parseInput: (input) => input,
@@ -459,14 +487,12 @@ describe("gateway dispatcher", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  it("maps invalid operation output to a stable gateway failure", async () => {
+  it("rejects a chat-to-action response swap with a stable gateway failure", async () => {
     const fixture = createFixture({
       protocolVersion: 1,
       maxBodyBytes: 4_096,
       parseInput: (input) => input,
-      parseOutput: () => {
-        throw new Error(SECRET_CANARY);
-      },
+      execute: async () => ({ secret: SECRET_CANARY }),
     });
     const response = await fixture.dispatch(
       createRequest(fixture, {
@@ -488,6 +514,228 @@ describe("gateway dispatcher", () => {
     );
 
     expect(responseCode(response)).toBe("operation_failed");
+  });
+
+  it("derives mandatory v1 response contracts from each operation", () => {
+    const registry = new CodexOperationRegistry([
+      {
+        operation: "chat",
+        protocolVersion: 1,
+        parseInput: (input) => input,
+        execute: async () => (async function* () {})(),
+        responseKind: "json",
+      } as CodexOperationDefinition,
+      {
+        operation: "mind-map-generation",
+        protocolVersion: 1,
+        parseInput: (input) => input,
+        execute: async () => null,
+        responseKind: "stream",
+        parseOutput: (output: unknown) => output,
+      } as CodexOperationDefinition,
+      {
+        operation: "node-editing",
+        protocolVersion: 1,
+        parseInput: (input) => input,
+        execute: async () => null,
+      },
+    ]);
+
+    expect(registry.get("chat")?.responseKind).toBe("stream");
+    expect(registry.get("chat")?.parseOutput).toBeUndefined();
+    expect(registry.get("mind-map-generation")?.responseKind).toBe("json");
+    expect(() =>
+      registry.get("mind-map-generation")?.parseOutput?.({ arbitrary: true })
+    ).toThrow();
+    expect(() =>
+      registry.get("node-editing")?.parseOutput?.({
+        version: 1,
+        operation: "mind-map-generation",
+        rawOutput: "wrong operation",
+        output: { name: "Map", nodes: [{ title: "Node", children: [] }] },
+      })
+    ).toThrow();
+  });
+
+  it("always validates action output and rejects an action-to-stream swap", async () => {
+    const bootstrapEnvelope = {
+      version: 1,
+      operation: "mind-map-generation",
+      resource: {
+        type: "owner-bootstrap",
+        intent: "create-first-mindmap",
+      },
+      input: { instructions: "Generate", prompt: "Systems" },
+    };
+    for (const invalidOutput of [
+      { arbitrary: true },
+      (async function* () {
+        yield { type: "start" };
+      })(),
+    ]) {
+      const fixture = createFixture({
+        operation: "mind-map-generation",
+        protocolVersion: 1,
+        maxBodyBytes: 4_096,
+        parseInput: (input) => input,
+        execute: async () => invalidOutput,
+      });
+      const response = await fixture.dispatch(
+        createRequest(fixture, {
+          body: chunks(JSON.stringify({ input: bootstrapEnvelope })),
+        })
+      );
+      expect(responseCode(response)).toBe("operation_failed");
+    }
+
+    const validFixture = createFixture({
+      operation: "mind-map-generation",
+      protocolVersion: 1,
+      maxBodyBytes: 4_096,
+      parseInput: (input) => input,
+      execute: async () => ({
+        version: 1,
+        operation: "mind-map-generation",
+        rawOutput: "raw",
+        output: { name: "Systems", nodes: [{ title: "Root", children: [] }] },
+      }),
+    });
+    const validResponse = await validFixture.dispatch(
+      createRequest(validFixture, {
+        body: chunks(JSON.stringify({ input: bootstrapEnvelope })),
+      })
+    );
+    expect(validResponse).toMatchObject({
+      status: 200,
+      body: { ok: true, data: { operation: "mind-map-generation" } },
+    });
+  });
+
+  it.each(["deadline", "request abort"] as const)(
+    "owns provider iteration through %s and closes it exactly once",
+    async (outcome) => {
+      let providerSignal: AbortSignal | undefined;
+      const returnIterator = vi.fn(async () => ({
+        done: true as const,
+        value: undefined,
+      }));
+      const execute = vi.fn(
+        async (_input: unknown, context: { signal: AbortSignal }) => {
+          providerSignal = context.signal;
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                next: () =>
+                  new Promise<IteratorResult<unknown>>(() => undefined),
+                return: returnIterator,
+              };
+            },
+          };
+        }
+      );
+      const fixture = createFixture({
+        protocolVersion: 1,
+        maxBodyBytes: 4_096,
+        timeoutMs: outcome === "deadline" ? 10 : 1_000,
+        execute,
+        parseInput: (input) => input,
+      });
+      const controller = new AbortController();
+      const response = await fixture.dispatch(
+        createProtocolChatRequest(
+          fixture,
+          outcome === "request abort" ? controller.signal : undefined
+        )
+      );
+      if (!(Symbol.asyncIterator in response.body)) {
+        throw new Error("expected stream");
+      }
+      const iterator = response.body[Symbol.asyncIterator]();
+      const pending = iterator.next();
+      if (outcome === "request abort")
+        controller.abort(new Error(SECRET_CANARY));
+
+      await expect(pending).rejects.toMatchObject({
+        code: outcome === "deadline" ? "request_timeout" : "request_aborted",
+        message: "Gateway request was rejected",
+      });
+      expect(providerSignal?.aborted).toBe(true);
+      await vi.waitFor(() => expect(returnIterator).toHaveBeenCalledTimes(1));
+    }
+  );
+
+  it("maps provider next and return rejection to stable secret-free errors", async () => {
+    const returnIterator = vi.fn(async () => {
+      throw new Error(SECRET_CANARY);
+    });
+    const fixture = createFixture({
+      protocolVersion: 1,
+      maxBodyBytes: 4_096,
+      parseInput: (input) => input,
+      execute: async () => ({
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => {
+              throw new Error(SECRET_CANARY);
+            },
+            return: returnIterator,
+          };
+        },
+      }),
+    });
+    const response = await fixture.dispatch(createProtocolChatRequest(fixture));
+    if (!(Symbol.asyncIterator in response.body)) {
+      throw new Error("expected stream");
+    }
+    const iterator = response.body[Symbol.asyncIterator]();
+
+    const nextError = await iterator.next().then(
+      () => null,
+      (error: unknown) => error
+    );
+    expect(nextError).toMatchObject({
+      code: "operation_failed",
+      message: "Gateway request was rejected",
+    });
+    expect(String(nextError)).not.toContain(SECRET_CANARY);
+    expect(returnIterator).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps an explicit provider return rejection without reflecting it", async () => {
+    const fixture = createFixture({
+      protocolVersion: 1,
+      maxBodyBytes: 4_096,
+      parseInput: (input) => input,
+      execute: async () => ({
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => ({
+              done: false as const,
+              value: { type: "start" },
+            }),
+            return: async () => {
+              throw new Error(SECRET_CANARY);
+            },
+          };
+        },
+      }),
+    });
+    const response = await fixture.dispatch(createProtocolChatRequest(fixture));
+    if (!(Symbol.asyncIterator in response.body)) {
+      throw new Error("expected stream");
+    }
+    const iterator = response.body[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toMatchObject({ done: false });
+
+    const returnError = await iterator.return?.().then(
+      () => null,
+      (error: unknown) => error
+    );
+    expect(returnError).toMatchObject({
+      code: "operation_failed",
+      message: "Gateway request was rejected",
+    });
+    expect(String(returnError)).not.toContain(SECRET_CANARY);
   });
 
   it("snapshots server route, context, and rate policy at creation", async () => {

--- a/services/agent-gateway/dispatcher.test.ts
+++ b/services/agent-gateway/dispatcher.test.ts
@@ -13,6 +13,7 @@ import {
   createGatewayDispatcher,
   type GatewayDispatcher,
   type GatewayRequestEnvelope,
+  type GatewayRoute,
   type RateBudget,
   type RateBudgetAttempt,
   RateBudgetError,
@@ -28,6 +29,10 @@ import {
   type SigningKey,
   type VerificationKeys,
 } from "./internal-auth.ts";
+import {
+  GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+  GATEWAY_OPERATION_PROTOCOL_VERSION,
+} from "./operation-protocol.ts";
 
 const BASE_TIME = 1_800_000_000;
 const SECRET_CANARY = "sk-secret-do-not-reflect";
@@ -73,6 +78,9 @@ function createFixture(
   options: Partial<{
     execute: CodexOperationDefinition["execute"];
     parseInput: CodexOperationDefinition["parseInput"];
+    parseOutput: NonNullable<CodexOperationDefinition["parseOutput"]>;
+    protocolVersion: typeof GATEWAY_OPERATION_PROTOCOL_VERSION;
+    responseKind: "json" | "stream";
     timeoutMs: number;
     maxBodyBytes: number;
     maxBodyChunks: number;
@@ -110,6 +118,8 @@ function createFixture(
   const registry = new CodexOperationRegistry([
     {
       operation: "chat",
+      protocolVersion: options.protocolVersion,
+      responseKind: options.responseKind,
       parseInput:
         options.parseInput ??
         ((input) => {
@@ -118,13 +128,22 @@ function createFixture(
           }
           return input;
         }),
+      parseOutput: options.parseOutput,
       execute,
     },
   ]);
-  const route = {
+  const route: GatewayRoute = {
     method: "POST" as const,
     path: "/internal/v1/codex/chat" as const,
     operation: "chat" as const,
+    ...(options.protocolVersion === undefined
+      ? {}
+      : {
+          resourceAuthority: {
+            type: "owned-mindmap" as const,
+            id: "canonical-map-1",
+          },
+        }),
     rateBudget: {
       endpoint: "codex.chat",
       ownerLimit: 4,
@@ -325,7 +344,9 @@ function createObservedBody(): Readonly<{
 function responseCode(
   response: Awaited<ReturnType<GatewayDispatcher>>
 ): string | undefined {
-  return response.body.ok ? undefined : response.body.error.code;
+  return "ok" in response.body && !response.body.ok
+    ? response.body.error.code
+    : undefined;
 }
 
 describe("gateway dispatcher", () => {
@@ -354,6 +375,119 @@ describe("gateway dispatcher", () => {
         },
       },
     ]);
+  });
+
+  it("binds a versioned chat envelope to route authority and returns a byte stream", async () => {
+    const output = (async function* () {
+      yield { type: "start" };
+      yield { type: "text-delta", id: "text-1", delta: "answer" };
+    })();
+    const execute = vi.fn(async () => output);
+    const fixture = createFixture({
+      protocolVersion: 1,
+      responseKind: "stream",
+      maxBodyBytes: 4_096,
+      execute,
+      parseInput: (input) => input,
+    });
+    const envelope = {
+      version: 1,
+      operation: "chat",
+      resource: { type: "owned-mindmap", id: "canonical-map-1" },
+      input: {
+        instructions: "Help with the map",
+        conversation: "user: hello",
+        toolManifest: "[]",
+      },
+    };
+
+    const response = await fixture.dispatch(
+      createRequest(fixture, {
+        body: chunks(JSON.stringify({ input: envelope })),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers).toEqual({
+      "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+    });
+    expect(Symbol.asyncIterator in response.body).toBe(true);
+    if (!(Symbol.asyncIterator in response.body))
+      throw new Error("expected stream");
+    const frames: string[] = [];
+    for await (const frame of response.body) {
+      frames.push(new TextDecoder().decode(frame));
+    }
+    expect(frames).toEqual([
+      '{"version":1,"event":{"type":"start"}}\n',
+      '{"version":1,"event":{"type":"text-delta","id":"text-1","delta":"answer"}}\n',
+    ]);
+    expect(execute).toHaveBeenCalledWith(
+      envelope.input,
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it("rejects a canonical resource mismatch before operation execution", async () => {
+    const execute = vi.fn();
+    const fixture = createFixture({
+      protocolVersion: 1,
+      maxBodyBytes: 4_096,
+      execute,
+      parseInput: (input) => input,
+    });
+    const response = await fixture.dispatch(
+      createRequest(fixture, {
+        body: chunks(
+          JSON.stringify({
+            input: {
+              version: 1,
+              operation: "chat",
+              resource: { type: "owned-mindmap", id: "other-map" },
+              input: {
+                instructions: "Help",
+                conversation: "user: hello",
+                toolManifest: "[]",
+              },
+            },
+          })
+        ),
+      })
+    );
+
+    expect(responseCode(response)).toBe("invalid_request");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("maps invalid operation output to a stable gateway failure", async () => {
+    const fixture = createFixture({
+      protocolVersion: 1,
+      maxBodyBytes: 4_096,
+      parseInput: (input) => input,
+      parseOutput: () => {
+        throw new Error(SECRET_CANARY);
+      },
+    });
+    const response = await fixture.dispatch(
+      createRequest(fixture, {
+        body: chunks(
+          JSON.stringify({
+            input: {
+              version: 1,
+              operation: "chat",
+              resource: { type: "owned-mindmap", id: "canonical-map-1" },
+              input: {
+                instructions: "Help",
+                conversation: "user: hello",
+                toolManifest: "[]",
+              },
+            },
+          })
+        ),
+      })
+    );
+
+    expect(responseCode(response)).toBe("operation_failed");
   });
 
   it("snapshots server route, context, and rate policy at creation", async () => {

--- a/services/agent-gateway/dispatcher.ts
+++ b/services/agent-gateway/dispatcher.ts
@@ -21,6 +21,7 @@ import {
   GATEWAY_CHAT_STREAM_CONTENT_TYPE,
   GATEWAY_OPERATION_PROTOCOL_VERSION,
   type GatewayResourceAuthority,
+  parseGatewayActionResult,
   parseGatewayOperationEnvelope,
   serializeGatewayChatStreamFrame,
 } from "./operation-protocol.ts";
@@ -128,24 +129,31 @@ type OperationExecutionContext = Readonly<{
 type CodexOperationDefinition = Readonly<{
   operation: GatewayOperation;
   protocolVersion?: typeof GATEWAY_OPERATION_PROTOCOL_VERSION;
-  responseKind?: "json" | "stream";
   parseInput: (input: unknown) => unknown;
-  parseOutput?: (output: unknown) => unknown;
   execute: (
     input: unknown,
     context: OperationExecutionContext
   ) => unknown | Promise<unknown>;
 }>;
 
+type RegisteredCodexOperationDefinition = CodexOperationDefinition &
+  Readonly<{
+    responseKind: "json" | "stream";
+    parseOutput?: (output: unknown) => unknown;
+  }>;
+
 /** Immutable server-owned operation lookup; transport input cannot mutate it. */
 class CodexOperationRegistry {
   private readonly definitions: ReadonlyMap<
     GatewayOperation,
-    CodexOperationDefinition
+    RegisteredCodexOperationDefinition
   >;
 
   constructor(definitions: readonly CodexOperationDefinition[]) {
-    const entries = new Map<GatewayOperation, CodexOperationDefinition>();
+    const entries = new Map<
+      GatewayOperation,
+      RegisteredCodexOperationDefinition
+    >();
     for (const definition of definitions) {
       if (!GATEWAY_OPERATIONS.includes(definition.operation)) {
         throw configurationError();
@@ -159,14 +167,7 @@ class CodexOperationRegistry {
       ) {
         throw configurationError();
       }
-      if (
-        definition.responseKind !== undefined &&
-        definition.responseKind !== "json" &&
-        definition.responseKind !== "stream"
-      ) {
-        throw configurationError();
-      }
-      entries.set(definition.operation, Object.freeze({ ...definition }));
+      entries.set(definition.operation, deriveOperationContract(definition));
     }
     if (entries.size === 0) {
       throw configurationError();
@@ -176,9 +177,36 @@ class CodexOperationRegistry {
   }
 
   /** Resolves only a compile-time gateway operation selected by server policy. */
-  get(operation: GatewayOperation): CodexOperationDefinition | undefined {
+  get(
+    operation: GatewayOperation
+  ): RegisteredCodexOperationDefinition | undefined {
     return this.definitions.get(operation);
   }
+}
+
+/** Derives all response semantics centrally from protocol version and operation. */
+function deriveOperationContract(
+  definition: CodexOperationDefinition
+): RegisteredCodexOperationDefinition {
+  const base = {
+    operation: definition.operation,
+    protocolVersion: definition.protocolVersion,
+    parseInput: definition.parseInput,
+    execute: definition.execute,
+  };
+  if (definition.protocolVersion !== GATEWAY_OPERATION_PROTOCOL_VERSION) {
+    return Object.freeze({ ...base, responseKind: "json" });
+  }
+  if (definition.operation === "chat") {
+    return Object.freeze({ ...base, responseKind: "stream" });
+  }
+  const actionOperation = definition.operation;
+  return Object.freeze({
+    ...base,
+    responseKind: "json",
+    parseOutput: (output: unknown) =>
+      parseGatewayActionResult(output, actionOperation),
+  });
 }
 
 type GatewayRoute = Readonly<{
@@ -349,6 +377,16 @@ function createGatewayDispatcher(
         throw new GatewayRequestError("invalid_request");
       }
 
+      if (definition.responseKind === "stream") {
+        const stream = await executeStreamingWithCancellation(
+          definition,
+          parsedInput,
+          claims,
+          request.signal,
+          executionTimeoutMs
+        );
+        return streamSuccessResponse(stream);
+      }
       const result = await executeWithCancellation(
         definition,
         parsedInput,
@@ -356,9 +394,6 @@ function createGatewayDispatcher(
         request.signal,
         executionTimeoutMs
       );
-      if (definition.responseKind === "stream") {
-        return streamSuccessResponse(result);
-      }
       let data = result;
       try {
         data = definition.parseOutput?.(result) ?? result;
@@ -701,6 +736,216 @@ function rateAttempt(options: GatewayDispatcherOptions): RateBudgetAttempt {
 }
 
 /** Hands execution an abort signal and bounds how long dispatch awaits it. */
+async function executeStreamingWithCancellation(
+  definition: RegisteredCodexOperationDefinition,
+  input: unknown,
+  claims: InternalAssertionClaims,
+  requestSignal: AbortSignal | undefined,
+  timeoutMs: number
+): Promise<AsyncIterable<unknown>> {
+  if (requestSignal?.aborted) {
+    throw new GatewayRequestError("request_aborted");
+  }
+
+  const executionController = new AbortController();
+  let iterator: AsyncIterator<unknown> | undefined;
+  let iteratorClaimed = false;
+  let terminalError: GatewayRequestError | undefined;
+  let completed = false;
+  let cleanupPromise: Promise<boolean> | undefined;
+
+  /** Clears lifetime resources and closes the provider iterator at most once. */
+  const cleanup = (closeIterator: boolean): Promise<boolean> => {
+    if (cleanupPromise !== undefined) return cleanupPromise;
+    clearTimeout(timeout);
+    requestSignal?.removeEventListener("abort", handleRequestAbort);
+    executionController.abort();
+    cleanupPromise =
+      closeIterator && iterator !== undefined
+        ? closeStreamingIterator(iterator)
+        : Promise.resolve(true);
+    return cleanupPromise;
+  };
+  const cancel = (code: "request_aborted" | "request_timeout"): void => {
+    if (completed || terminalError !== undefined) return;
+    terminalError = new GatewayRequestError(code);
+    executionController.abort();
+    void cleanup(true);
+  };
+  const handleRequestAbort = (): void => cancel("request_aborted");
+  const timeout = setTimeout(() => cancel("request_timeout"), timeoutMs);
+  requestSignal?.addEventListener("abort", handleRequestAbort, { once: true });
+  if (requestSignal?.aborted) handleRequestAbort();
+
+  const executionPromise = Promise.resolve().then(() => {
+    if (terminalError !== undefined) throw terminalError;
+    return definition.execute(input, {
+      claims,
+      signal: executionController.signal,
+    });
+  });
+  let result: unknown;
+  try {
+    result = await awaitStreamingOperation(
+      executionPromise,
+      executionController.signal,
+      () => terminalError ?? new GatewayRequestError("operation_failed"),
+      (lateResult) => observeLateStreamingResult(lateResult)
+    );
+    if (
+      typeof result !== "object" ||
+      result === null ||
+      typeof (result as AsyncIterable<unknown>)[Symbol.asyncIterator] !==
+        "function"
+    ) {
+      throw new GatewayRequestError("operation_failed");
+    }
+    iterator = (result as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+    if (typeof iterator?.next !== "function") {
+      throw new GatewayRequestError("operation_failed");
+    }
+  } catch (error) {
+    await cleanup(true);
+    throw error instanceof GatewayRequestError
+      ? error
+      : new GatewayRequestError("operation_failed");
+  }
+
+  const ownedIterator = iterator;
+  return Object.freeze({
+    [Symbol.asyncIterator](): AsyncIterator<unknown> {
+      if (iteratorClaimed) {
+        throw new GatewayRequestError("operation_failed");
+      }
+      iteratorClaimed = true;
+      return {
+        async next(): Promise<IteratorResult<unknown>> {
+          if (terminalError !== undefined) throw terminalError;
+          if (completed) return { done: true, value: undefined };
+          try {
+            const next = await awaitStreamingOperation(
+              Promise.resolve().then(() => ownedIterator.next()),
+              executionController.signal,
+              () => terminalError ?? new GatewayRequestError("operation_failed")
+            );
+            if (typeof next !== "object" || next === null) {
+              throw new GatewayRequestError("operation_failed");
+            }
+            if (next.done) {
+              completed = true;
+              await cleanup(false);
+            }
+            return next;
+          } catch (error) {
+            completed = true;
+            await cleanup(true);
+            throw error instanceof GatewayRequestError
+              ? error
+              : new GatewayRequestError("operation_failed");
+          }
+        },
+        async return(): Promise<IteratorResult<unknown>> {
+          if (completed) return { done: true, value: undefined };
+          completed = true;
+          const cleaned = await cleanup(true);
+          if (!cleaned && terminalError === undefined) {
+            throw new GatewayRequestError("operation_failed");
+          }
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  });
+}
+
+/** Races one provider handoff/iteration step while observing late settlement. */
+function awaitStreamingOperation<T>(
+  promise: PromiseLike<T>,
+  signal: AbortSignal,
+  cancellationError: () => GatewayRequestError,
+  onLateFulfilled?: (value: T) => void
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", handleAbort);
+      callback();
+    };
+    const handleAbort = (): void => finish(() => reject(cancellationError()));
+    signal.addEventListener("abort", handleAbort, { once: true });
+    if (signal.aborted) handleAbort();
+
+    Promise.resolve(promise).then(
+      (value) => {
+        if (settled) {
+          try {
+            onLateFulfilled?.(value);
+          } catch {
+            // Late cleanup hooks never replace the authoritative cancellation.
+          }
+          return;
+        }
+        finish(() => resolve(value));
+      },
+      () => finish(() => reject(new GatewayRequestError("operation_failed")))
+    );
+  });
+}
+
+/** Closes a provider iterator behind a finite bound and hides cleanup secrets. */
+async function closeStreamingIterator(
+  iterator: AsyncIterator<unknown>
+): Promise<boolean> {
+  let returnMethod: AsyncIterator<unknown>["return"];
+  try {
+    returnMethod = iterator.return;
+  } catch {
+    return false;
+  }
+  if (typeof returnMethod !== "function") return true;
+  let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
+  let succeeded = false;
+  const cleanup = Promise.resolve()
+    .then(() => returnMethod.call(iterator))
+    .then(
+      () => {
+        succeeded = true;
+      },
+      () => undefined
+    );
+  await Promise.race([
+    cleanup,
+    new Promise<void>((resolve) => {
+      cleanupTimer = setTimeout(resolve, BODY_CLEANUP_GRACE_MS);
+    }),
+  ]);
+  if (cleanupTimer !== undefined) clearTimeout(cleanupTimer);
+  return succeeded;
+}
+
+/** Observes and closes an iterable returned after cancellation won handoff. */
+function observeLateStreamingResult(value: unknown): void {
+  void Promise.resolve()
+    .then(async () => {
+      if (
+        typeof value !== "object" ||
+        value === null ||
+        typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] !==
+          "function"
+      ) {
+        return;
+      }
+      const iterator = (value as AsyncIterable<unknown>)[
+        Symbol.asyncIterator
+      ]();
+      await closeStreamingIterator(iterator);
+    })
+    .catch(() => undefined);
+}
+
+/** Hands buffered execution an abort signal and bounds how long dispatch awaits it. */
 async function executeWithCancellation(
   definition: CodexOperationDefinition,
   input: unknown,

--- a/services/agent-gateway/dispatcher.ts
+++ b/services/agent-gateway/dispatcher.ts
@@ -17,6 +17,13 @@ import {
   type VerificationKeys,
   verifyAuthenticatedInternalAssertion,
 } from "./internal-auth.ts";
+import {
+  GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+  GATEWAY_OPERATION_PROTOCOL_VERSION,
+  type GatewayResourceAuthority,
+  parseGatewayOperationEnvelope,
+  serializeGatewayChatStreamFrame,
+} from "./operation-protocol.ts";
 
 const DEFAULT_MAX_BODY_BYTES = 64 * 1_024;
 const DEFAULT_MAX_BODY_CHUNKS = 256;
@@ -65,11 +72,19 @@ type GatewaySuccessBody = Readonly<{
   data: unknown;
 }>;
 
-type GatewayResponse = Readonly<{
+type GatewayJsonResponse = Readonly<{
   status: number;
   headers: Readonly<Record<string, string>>;
   body: GatewayErrorBody | GatewaySuccessBody;
 }>;
+
+type GatewayStreamResponse = Readonly<{
+  status: 200;
+  headers: Readonly<Record<string, string>>;
+  body: AsyncIterable<Uint8Array>;
+}>;
+
+type GatewayResponse = GatewayJsonResponse | GatewayStreamResponse;
 
 type RateBudgetPolicy = Readonly<{
   endpoint: string;
@@ -112,7 +127,10 @@ type OperationExecutionContext = Readonly<{
 
 type CodexOperationDefinition = Readonly<{
   operation: GatewayOperation;
+  protocolVersion?: typeof GATEWAY_OPERATION_PROTOCOL_VERSION;
+  responseKind?: "json" | "stream";
   parseInput: (input: unknown) => unknown;
+  parseOutput?: (output: unknown) => unknown;
   execute: (
     input: unknown,
     context: OperationExecutionContext
@@ -135,6 +153,19 @@ class CodexOperationRegistry {
       if (entries.has(definition.operation)) {
         throw configurationError();
       }
+      if (
+        definition.protocolVersion !== undefined &&
+        definition.protocolVersion !== GATEWAY_OPERATION_PROTOCOL_VERSION
+      ) {
+        throw configurationError();
+      }
+      if (
+        definition.responseKind !== undefined &&
+        definition.responseKind !== "json" &&
+        definition.responseKind !== "stream"
+      ) {
+        throw configurationError();
+      }
       entries.set(definition.operation, Object.freeze({ ...definition }));
     }
     if (entries.size === 0) {
@@ -154,6 +185,7 @@ type GatewayRoute = Readonly<{
   method: "POST";
   path: `/${string}`;
   operation: GatewayOperation;
+  resourceAuthority?: GatewayResourceAuthority;
   rateBudget: RateBudgetPolicy;
 }>;
 
@@ -294,7 +326,6 @@ function createGatewayDispatcher(
         bodyReadTimeoutMs,
         request.signal
       );
-      const operationInput = readOperationInput(body);
       const definition = configuredOptions.operationRegistry.get(
         configuredOptions.route.operation
       );
@@ -304,18 +335,36 @@ function createGatewayDispatcher(
 
       let parsedInput: unknown;
       try {
-        parsedInput = definition.parseInput(operationInput);
+        const operationInput = readOperationInput(body);
+        const input =
+          definition.protocolVersion === GATEWAY_OPERATION_PROTOCOL_VERSION
+            ? parseGatewayOperationEnvelope(
+                operationInput,
+                configuredOptions.route.operation,
+                requireRouteResourceAuthority(configuredOptions.route)
+              ).input
+            : operationInput;
+        parsedInput = definition.parseInput(input);
       } catch {
         throw new GatewayRequestError("invalid_request");
       }
 
-      const data = await executeWithCancellation(
+      const result = await executeWithCancellation(
         definition,
         parsedInput,
         claims,
         request.signal,
         executionTimeoutMs
       );
+      if (definition.responseKind === "stream") {
+        return streamSuccessResponse(result);
+      }
+      let data = result;
+      try {
+        data = definition.parseOutput?.(result) ?? result;
+      } catch {
+        throw new GatewayRequestError("operation_failed");
+      }
       return successResponse(data);
     } catch (error) {
       if (error instanceof GatewayRequestError) {
@@ -335,6 +384,10 @@ function snapshotDispatcherOptions(
     expected: Object.freeze({ ...options.expected }),
     route: Object.freeze({
       ...options.route,
+      resourceAuthority:
+        options.route.resourceAuthority === undefined
+          ? undefined
+          : Object.freeze({ ...options.route.resourceAuthority }),
       rateBudget: Object.freeze({ ...options.route.rateBudget }),
     }),
     verificationKeys: Object.freeze({ ...options.verificationKeys }),
@@ -383,6 +436,22 @@ function assertDispatcherConfiguration(
   ) {
     throw configurationError();
   }
+
+  const definition = options.operationRegistry.get(options.route.operation);
+  if (
+    definition?.protocolVersion === GATEWAY_OPERATION_PROTOCOL_VERSION &&
+    options.route.resourceAuthority === undefined
+  ) {
+    throw configurationError();
+  }
+}
+
+/** Requires the server-owned authority paired with a versioned operation route. */
+function requireRouteResourceAuthority(
+  route: GatewayRoute
+): GatewayResourceAuthority {
+  if (route.resourceAuthority === undefined) throw configurationError();
+  return route.resourceAuthority;
 }
 
 /** Reads exactly one canonical Bearer credential without accepting duplicates. */
@@ -693,7 +762,7 @@ async function executeWithCancellation(
 }
 
 /** Maps one stable code to a fixed status without reflecting exception text. */
-function errorResponse(code: GatewayErrorCode): GatewayResponse {
+function errorResponse(code: GatewayErrorCode): GatewayJsonResponse {
   const statusByCode: Readonly<Record<GatewayErrorCode, number>> = {
     gateway_configuration_unavailable: 503,
     invalid_request: 400,
@@ -717,12 +786,42 @@ function errorResponse(code: GatewayErrorCode): GatewayResponse {
 }
 
 /** Creates the single successful response shape used by the transport adapter. */
-function successResponse(data: unknown): GatewayResponse {
+function successResponse(data: unknown): GatewayJsonResponse {
   return {
     status: 200,
     headers: { "content-type": "application/json" },
     body: { ok: true, data },
   };
+}
+
+/** Returns a streaming success only for a genuine event async iterable. */
+function streamSuccessResponse(data: unknown): GatewayStreamResponse {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    typeof (data as AsyncIterable<Uint8Array>)[Symbol.asyncIterator] !==
+      "function"
+  ) {
+    throw new GatewayRequestError("operation_failed");
+  }
+  return {
+    status: 200,
+    headers: { "content-type": GATEWAY_CHAT_STREAM_CONTENT_TYPE },
+    body: serializeGatewayChatStream(data as AsyncIterable<unknown>),
+  };
+}
+
+/** Serializes only validated chat events into the versioned NDJSON wire form. */
+async function* serializeGatewayChatStream(
+  events: AsyncIterable<unknown>
+): AsyncIterable<Uint8Array> {
+  for await (const event of events) {
+    try {
+      yield serializeGatewayChatStreamFrame(event);
+    } catch {
+      throw new GatewayRequestError("operation_failed");
+    }
+  }
 }
 
 /** Produces a stable startup error without embedding policy values. */
@@ -750,10 +849,12 @@ export {
   type GatewayErrorBody,
   type GatewayErrorCode,
   type GatewayHeaderValue,
+  type GatewayJsonResponse,
   type GatewayRequestEnvelope,
   GatewayRequestError,
   type GatewayResponse,
   type GatewayRoute,
+  type GatewayStreamResponse,
   type GatewaySuccessBody,
   MAX_BODY_BYTES,
   MAX_BODY_CHUNKS,

--- a/services/agent-gateway/operation-protocol.test.ts
+++ b/services/agent-gateway/operation-protocol.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createGatewayOperationEnvelope,
+  parseGatewayActionResult,
+  parseGatewayChatStreamFrame,
+  parseGatewayOperationEnvelope,
+  serializeGatewayChatStreamFrame,
+} from "./operation-protocol.ts";
+
+const ownedResource = { type: "owned-mindmap", id: "map-1" } as const;
+const bootstrapResource = {
+  type: "owner-bootstrap",
+  intent: "create-first-mindmap",
+} as const;
+
+/** Creates one valid generated node at an explicit recursive depth. */
+function generatedNode(depth = 1): {
+  title: string;
+  children: ReturnType<typeof generatedNode>[];
+} {
+  return {
+    title: `node-${depth}`,
+    children: depth > 1 ? [generatedNode(depth - 1)] : [],
+  };
+}
+
+describe("gateway operation protocol", () => {
+  it("accepts all three closed versioned operation envelopes", () => {
+    expect(
+      createGatewayOperationEnvelope("chat", ownedResource, {
+        instructions: "Help with this map",
+        conversation: "user: explain the root",
+        toolManifest: "[]",
+      })
+    ).toMatchObject({ version: 1, operation: "chat" });
+    expect(
+      createGatewayOperationEnvelope("mind-map-generation", bootstrapResource, {
+        instructions: "Generate a map",
+        prompt: "Distributed systems",
+      })
+    ).toMatchObject({ version: 1, operation: "mind-map-generation" });
+    expect(
+      createGatewayOperationEnvelope("node-editing", ownedResource, {
+        instructions: "Extend a branch",
+        prompt: "Add examples",
+        activeNodeId: "node-1",
+        currentBranch: [
+          {
+            nodeId: "node-1",
+            title: "Root",
+            description: null,
+            link: null,
+          },
+        ],
+      })
+    ).toMatchObject({ version: 1, operation: "node-editing" });
+  });
+
+  it("binds operation and complete canonical resource authority exactly", () => {
+    const envelope = createGatewayOperationEnvelope("chat", ownedResource, {
+      instructions: "Help",
+      conversation: "user: hello",
+      toolManifest: "[]",
+    });
+    expect(() =>
+      parseGatewayOperationEnvelope(envelope, "node-editing", ownedResource)
+    ).toThrow();
+    expect(() =>
+      parseGatewayOperationEnvelope(envelope, "chat", {
+        type: "owned-mindmap",
+        id: "map-2",
+      })
+    ).toThrow();
+    expect(() =>
+      parseGatewayOperationEnvelope(envelope, "chat", bootstrapResource)
+    ).toThrow();
+  });
+
+  it("rejects extra fields, oversized text, and ambiguous first-map authority", () => {
+    expect(() =>
+      createGatewayOperationEnvelope("chat", ownedResource, {
+        instructions: "x",
+        conversation: "x".repeat(32_001),
+        toolManifest: "[]",
+      })
+    ).toThrow();
+    expect(() =>
+      parseGatewayOperationEnvelope(
+        {
+          version: 1,
+          operation: "mind-map-generation",
+          resource: { ...bootstrapResource, ownerId: "forged-owner" },
+          input: { instructions: "Generate", prompt: "Topic" },
+        },
+        "mind-map-generation",
+        bootstrapResource
+      )
+    ).toThrow();
+  });
+
+  it("requires node-edit authority to include the active branch node exactly once", () => {
+    expect(() =>
+      createGatewayOperationEnvelope("node-editing", ownedResource, {
+        instructions: "Extend",
+        prompt: "Examples",
+        activeNodeId: "missing",
+        currentBranch: [
+          {
+            nodeId: "node-1",
+            title: "Root",
+            description: null,
+            link: null,
+          },
+        ],
+      })
+    ).toThrow();
+  });
+
+  it("validates fixed action results and enforces total depth", () => {
+    expect(
+      parseGatewayActionResult(
+        {
+          version: 1,
+          operation: "mind-map-generation",
+          rawOutput: "raw",
+          output: { name: "Map", nodes: [generatedNode()] },
+        },
+        "mind-map-generation"
+      )
+    ).toMatchObject({ operation: "mind-map-generation" });
+    expect(() =>
+      parseGatewayActionResult(
+        {
+          version: 1,
+          operation: "node-editing",
+          rawOutput: "raw",
+          output: { nodes: [generatedNode(11)] },
+        },
+        "node-editing"
+      )
+    ).toThrow();
+  });
+
+  it("round-trips only closed versioned chat events", () => {
+    const event = {
+      type: "tool-output-available",
+      toolCallId: "tool-1",
+      output: { operationId: "operation-1" },
+      dynamic: true,
+    } as const;
+    const encoded = serializeGatewayChatStreamFrame(event);
+    expect(
+      parseGatewayChatStreamFrame(
+        JSON.parse(new TextDecoder().decode(encoded).trim())
+      )
+    ).toEqual(event);
+    expect(() =>
+      parseGatewayChatStreamFrame({
+        version: 1,
+        event: { type: "shell-output", secret: "canary" },
+      })
+    ).toThrow();
+  });
+});

--- a/services/agent-gateway/operation-protocol.ts
+++ b/services/agent-gateway/operation-protocol.ts
@@ -1,0 +1,357 @@
+import { z } from "zod";
+
+import type { GatewayOperation } from "./internal-auth.ts";
+
+const GATEWAY_OPERATION_PROTOCOL_VERSION = 1;
+const GATEWAY_CHAT_STREAM_CONTENT_TYPE =
+  "application/vnd.sprig.chat-stream+octet-stream;version=1";
+const MAX_IDENTIFIER_LENGTH = 256;
+const MAX_INSTRUCTIONS_LENGTH = 8_192;
+const MAX_PROMPT_LENGTH = 16_384;
+const MAX_CONVERSATION_LENGTH = 32_000;
+const MAX_TOOL_MANIFEST_LENGTH = 12_000;
+const MAX_RAW_OUTPUT_LENGTH = 256_000;
+const MAX_NODE_TEXT_LENGTH = 512;
+const MAX_TREE_DEPTH = 10;
+const MAX_TREE_NODES = 256;
+
+const identifierSchema = z
+  .string()
+  .min(1)
+  .max(MAX_IDENTIFIER_LENGTH)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/);
+const boundedTextSchema = (maximum: number) => z.string().min(1).max(maximum);
+
+const ownedMindmapResourceSchema = z
+  .object({ type: z.literal("owned-mindmap"), id: identifierSchema })
+  .strict();
+const ownerBootstrapResourceSchema = z
+  .object({
+    type: z.literal("owner-bootstrap"),
+    intent: z.literal("create-first-mindmap"),
+  })
+  .strict();
+
+const chatInputSchema = z
+  .object({
+    instructions: boundedTextSchema(MAX_INSTRUCTIONS_LENGTH),
+    conversation: boundedTextSchema(MAX_CONVERSATION_LENGTH),
+    toolManifest: z.string().max(MAX_TOOL_MANIFEST_LENGTH),
+  })
+  .strict();
+const mindmapGenerationInputSchema = z
+  .object({
+    instructions: boundedTextSchema(MAX_INSTRUCTIONS_LENGTH),
+    prompt: boundedTextSchema(MAX_PROMPT_LENGTH),
+  })
+  .strict();
+
+const branchNodeSchema = z
+  .object({
+    nodeId: identifierSchema,
+    title: boundedTextSchema(MAX_NODE_TEXT_LENGTH),
+    description: z.string().max(MAX_NODE_TEXT_LENGTH).nullable(),
+    link: z.string().max(MAX_NODE_TEXT_LENGTH).nullable(),
+    childrenNodes: z.array(identifierSchema).max(32).optional(),
+  })
+  .strict();
+const nodeEditingInputSchema = z
+  .object({
+    instructions: boundedTextSchema(MAX_INSTRUCTIONS_LENGTH),
+    prompt: boundedTextSchema(MAX_PROMPT_LENGTH),
+    activeNodeId: identifierSchema,
+    currentBranch: z.array(branchNodeSchema).min(1).max(16),
+  })
+  .strict()
+  .superRefine(({ activeNodeId, currentBranch }, context) => {
+    if (!currentBranch.some((node) => node.nodeId === activeNodeId)) {
+      context.addIssue({
+        code: "custom",
+        message: "active node must belong to the supplied branch",
+      });
+    }
+    if (
+      new Set(currentBranch.map((node) => node.nodeId)).size !==
+      currentBranch.length
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "branch node ids must be unique",
+      });
+    }
+  });
+
+type GeneratedTreeNode = Readonly<{
+  title: string;
+  description?: string;
+  link?: string;
+  children: readonly GeneratedTreeNode[];
+}>;
+
+const generatedTreeNodeSchema: z.ZodType<GeneratedTreeNode> = z.lazy(() =>
+  z
+    .object({
+      title: boundedTextSchema(MAX_NODE_TEXT_LENGTH),
+      description: z.string().max(MAX_NODE_TEXT_LENGTH).optional(),
+      link: z.string().max(MAX_NODE_TEXT_LENGTH).optional(),
+      children: z.array(generatedTreeNodeSchema).max(3),
+    })
+    .strict()
+);
+
+const generatedMindmapOutputSchema = z
+  .object({
+    name: boundedTextSchema(MAX_NODE_TEXT_LENGTH),
+    nodes: z.array(generatedTreeNodeSchema).min(1).max(6),
+  })
+  .strict();
+const generatedNodeSuggestionsOutputSchema = z
+  .object({ nodes: z.array(generatedTreeNodeSchema).min(1).max(3) })
+  .strict();
+
+const mindmapGenerationResultSchema = z
+  .object({
+    version: z.literal(GATEWAY_OPERATION_PROTOCOL_VERSION),
+    operation: z.literal("mind-map-generation"),
+    rawOutput: z.string().max(MAX_RAW_OUTPUT_LENGTH),
+    output: generatedMindmapOutputSchema,
+  })
+  .strict();
+const nodeEditingResultSchema = z
+  .object({
+    version: z.literal(GATEWAY_OPERATION_PROTOCOL_VERSION),
+    operation: z.literal("node-editing"),
+    rawOutput: z.string().max(MAX_RAW_OUTPUT_LENGTH),
+    output: generatedNodeSuggestionsOutputSchema,
+  })
+  .strict();
+
+const chatChunkSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("start") }).strict(),
+  z.object({ type: z.literal("start-step") }).strict(),
+  z.object({ type: z.literal("finish-step") }).strict(),
+  z.object({ type: z.literal("text-start"), id: identifierSchema }).strict(),
+  z
+    .object({
+      type: z.literal("text-delta"),
+      id: identifierSchema,
+      delta: z.string().max(MAX_NODE_TEXT_LENGTH * 8),
+    })
+    .strict(),
+  z.object({ type: z.literal("text-end"), id: identifierSchema }).strict(),
+  z
+    .object({
+      type: z.literal("tool-input-available"),
+      toolCallId: identifierSchema,
+      toolName: identifierSchema,
+      input: z.json(),
+      dynamic: z.literal(true),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("tool-output-available"),
+      toolCallId: identifierSchema,
+      output: z.json(),
+      dynamic: z.literal(true),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("finish"),
+      finishReason: z.enum([
+        "stop",
+        "length",
+        "content-filter",
+        "tool-calls",
+        "error",
+        "other",
+        "unknown",
+      ]),
+    })
+    .strict(),
+  z.object({ type: z.literal("abort"), reason: z.string().max(256) }).strict(),
+]);
+const chatStreamFrameSchema = z
+  .object({
+    version: z.literal(GATEWAY_OPERATION_PROTOCOL_VERSION),
+    event: chatChunkSchema,
+  })
+  .strict();
+
+const chatEnvelopeSchema = z
+  .object({
+    version: z.literal(GATEWAY_OPERATION_PROTOCOL_VERSION),
+    operation: z.literal("chat"),
+    resource: ownedMindmapResourceSchema,
+    input: chatInputSchema,
+  })
+  .strict();
+const mindmapGenerationEnvelopeSchema = z
+  .object({
+    version: z.literal(GATEWAY_OPERATION_PROTOCOL_VERSION),
+    operation: z.literal("mind-map-generation"),
+    resource: ownerBootstrapResourceSchema,
+    input: mindmapGenerationInputSchema,
+  })
+  .strict();
+const nodeEditingEnvelopeSchema = z
+  .object({
+    version: z.literal(GATEWAY_OPERATION_PROTOCOL_VERSION),
+    operation: z.literal("node-editing"),
+    resource: ownedMindmapResourceSchema,
+    input: nodeEditingInputSchema,
+  })
+  .strict();
+
+type GatewayOwnedMindmapAuthority = z.infer<typeof ownedMindmapResourceSchema>;
+type GatewayOwnerBootstrapAuthority = z.infer<
+  typeof ownerBootstrapResourceSchema
+>;
+type GatewayResourceAuthority =
+  | GatewayOwnedMindmapAuthority
+  | GatewayOwnerBootstrapAuthority;
+type GatewayChatInput = z.infer<typeof chatInputSchema>;
+type GatewayMindmapGenerationInput = z.infer<
+  typeof mindmapGenerationInputSchema
+>;
+type GatewayNodeEditingInput = z.infer<typeof nodeEditingInputSchema>;
+type GatewayOperationInput =
+  | GatewayChatInput
+  | GatewayMindmapGenerationInput
+  | GatewayNodeEditingInput;
+type GatewayChatEnvelope = z.infer<typeof chatEnvelopeSchema>;
+type GatewayMindmapGenerationEnvelope = z.infer<
+  typeof mindmapGenerationEnvelopeSchema
+>;
+type GatewayNodeEditingEnvelope = z.infer<typeof nodeEditingEnvelopeSchema>;
+type GatewayOperationEnvelope =
+  | GatewayChatEnvelope
+  | GatewayMindmapGenerationEnvelope
+  | GatewayNodeEditingEnvelope;
+type GatewayMindmapGenerationResult = z.infer<
+  typeof mindmapGenerationResultSchema
+>;
+type GatewayNodeEditingResult = z.infer<typeof nodeEditingResultSchema>;
+type GatewayActionResult =
+  | GatewayMindmapGenerationResult
+  | GatewayNodeEditingResult;
+type GatewayChatChunk = z.infer<typeof chatChunkSchema>;
+
+/** Validates one versioned envelope against its signed route and server authority. */
+function parseGatewayOperationEnvelope(
+  value: unknown,
+  operation: GatewayOperation,
+  expectedResource: GatewayResourceAuthority
+): GatewayOperationEnvelope {
+  const schema = schemaForOperation(operation);
+  const envelope = schema.parse(value) as GatewayOperationEnvelope;
+  if (!resourceAuthoritiesEqual(envelope.resource, expectedResource)) {
+    throw new Error("Gateway resource authority mismatch");
+  }
+  return envelope;
+}
+
+/** Validates an action result against the exact operation that produced it. */
+function parseGatewayActionResult(
+  value: unknown,
+  operation: "mind-map-generation" | "node-editing"
+): GatewayActionResult {
+  const result =
+    operation === "mind-map-generation"
+      ? mindmapGenerationResultSchema.parse(value)
+      : nodeEditingResultSchema.parse(value);
+  assertGatewayActionTreeBounds(result);
+  return result;
+}
+
+/** Validates one gateway-produced chat event before transport serialization. */
+function parseGatewayChatChunk(value: unknown): GatewayChatChunk {
+  return chatChunkSchema.parse(value);
+}
+
+/** Parses one complete versioned NDJSON line into an application chat event. */
+function parseGatewayChatStreamFrame(value: unknown): GatewayChatChunk {
+  return chatStreamFrameSchema.parse(value).event;
+}
+
+/** Serializes one validated event as exactly one newline-delimited frame. */
+function serializeGatewayChatStreamFrame(value: unknown): Uint8Array {
+  const event = parseGatewayChatChunk(value);
+  return new TextEncoder().encode(
+    `${JSON.stringify({ version: GATEWAY_OPERATION_PROTOCOL_VERSION, event })}\n`
+  );
+}
+
+/** Rejects pathological generated trees after structural parsing. */
+function assertGatewayActionTreeBounds(result: GatewayActionResult): void {
+  let nodes = 0;
+  const visit = (node: GeneratedTreeNode, depth: number): void => {
+    nodes += 1;
+    if (depth > MAX_TREE_DEPTH || nodes > MAX_TREE_NODES) {
+      throw new Error("Gateway action tree exceeds protocol bounds");
+    }
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const node of result.output.nodes) visit(node, 1);
+}
+
+/** Creates the only envelope variants accepted by the gateway protocol. */
+function createGatewayOperationEnvelope(
+  operation: GatewayOperation,
+  resource: GatewayResourceAuthority,
+  input: GatewayOperationInput
+): GatewayOperationEnvelope {
+  return parseGatewayOperationEnvelope(
+    { version: GATEWAY_OPERATION_PROTOCOL_VERSION, operation, resource, input },
+    operation,
+    resource
+  );
+}
+
+/** Selects one closed schema without allowing a caller-provided schema. */
+function schemaForOperation(operation: GatewayOperation): z.ZodType {
+  if (operation === "chat") return chatEnvelopeSchema;
+  if (operation === "mind-map-generation") {
+    return mindmapGenerationEnvelopeSchema;
+  }
+  return nodeEditingEnvelopeSchema;
+}
+
+/** Compares the complete closed authority variants without coercion. */
+function resourceAuthoritiesEqual(
+  left: GatewayResourceAuthority,
+  right: GatewayResourceAuthority
+): boolean {
+  if (left.type !== right.type) return false;
+  return left.type === "owned-mindmap"
+    ? right.type === "owned-mindmap" && left.id === right.id
+    : right.type === "owner-bootstrap" && left.intent === right.intent;
+}
+
+export {
+  assertGatewayActionTreeBounds,
+  createGatewayOperationEnvelope,
+  GATEWAY_CHAT_STREAM_CONTENT_TYPE,
+  GATEWAY_OPERATION_PROTOCOL_VERSION,
+  type GatewayActionResult,
+  type GatewayChatChunk,
+  type GatewayChatEnvelope,
+  type GatewayChatInput,
+  type GatewayMindmapGenerationEnvelope,
+  type GatewayMindmapGenerationInput,
+  type GatewayMindmapGenerationResult,
+  type GatewayNodeEditingEnvelope,
+  type GatewayNodeEditingInput,
+  type GatewayNodeEditingResult,
+  type GatewayOperationEnvelope,
+  type GatewayOperationInput,
+  type GatewayOwnedMindmapAuthority,
+  type GatewayOwnerBootstrapAuthority,
+  type GatewayResourceAuthority,
+  parseGatewayActionResult,
+  parseGatewayChatChunk,
+  parseGatewayChatStreamFrame,
+  parseGatewayOperationEnvelope,
+  serializeGatewayChatStreamFrame,
+};


### PR DESCRIPTION
## Feature

Adds the missing operation-specific gateway protocol prerequisite for connection-based Codex routing. Chat, first-map generation, and node editing can now carry their real bounded inputs through the signed gateway seam and receive operation-correct outputs.

## Architecture

- Defines closed versioned Codex-only input envelopes for all three operations.
- Binds chat and node editing to an exact canonical owned-mindmap authority.
- Models first-map generation as an owner-scoped `create-first-mindmap` bootstrap capability, without inventing a map id or carrying an owner id in the payload.
- Extends the immutable executor registry with protocol version, response kind, and output validation.
- Keeps the existing JSON client contract while adding `executeAction` for strictly validated JSON results and `streamChat` for validated application events.
- Serializes chat as versioned NDJSON frames and decodes them incrementally with zero buffering. Redirects, URL drift, status/content-type mismatch, unbounded headers, malformed frames, length mismatch, byte/chunk overflow, abort, and deadline all fail closed and dispose the upstream body.
- Sends each signed operation once; no retries are introduced.

```text
validated operation input
          |
          v
atomic authority resolver
  | owned map -> canonical map id
  | first map -> owner bootstrap capability
          v
signed Codex operation assertion
          |
          v
fixed HTTPS operation path
          |
          v
dispatcher: version + operation + resource validation
          |
     +----+-------------------+
     |                        |
bounded JSON action      closed chat events
     |                        |
strict result schema     versioned NDJSON frames
                              |
                       demand-driven decoder
```

## Validation

- Focused protocol/dispatcher/client suite: 132 passed
- Full suite: 76 files, 1,065 tests passed
- `pnpm typegen`
- `pnpm typecheck`
- `pnpm lint` — 0 errors; five pre-existing warnings outside owned paths
- `pnpm format:check`
- `git diff --check origin/main...HEAD`

No provider process, credential access, real network execution, environment change, database write/deploy, UI change, or entrypoint wiring is included. Production host, key custody, durable stores, credential-home adapter, Convex deployment, beta cohort, and real Codex login remain human-gated follow-ups.
